### PR TITLE
Fixed #71

### DIFF
--- a/packages/graphql-sdk/src/resolvers/Mutation.js
+++ b/packages/graphql-sdk/src/resolvers/Mutation.js
@@ -24,7 +24,9 @@ export async function approve(
   const { type, amount } = args
   switch (type) {
     case 'bond':
-      return await ctx.livepeer.rpc.approveTokenBondAmount(amount)
+      return await ctx.livepeer.rpc.approveTokenBondAmount(amount, {
+        gas: 60000,
+      })
       break
     default:
       throw new Error(`Approval type "${type}" is not supported.`)
@@ -44,7 +46,9 @@ export async function bond(
   ctx: GQLContext,
 ): Promise<TxReceipt> {
   const { to, amount } = args
-  return await ctx.livepeer.rpc.bondApprovedTokenAmount(to, amount)
+  return await ctx.livepeer.rpc.bondApprovedTokenAmount(to, amount, {
+    gas: 350000,
+  })
 }
 
 /**

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1308,12 +1308,15 @@ export default async function createLivepeerSDK(
 
     async approveTokenBondAmount(
       amount: string,
-      tx = config.eth.defaultTx,
+      tx: TxObject,
     ): Promise<TxReceipt> {
       const token = toBN(amount)
       // @todo - check token balance
       await utils.getTxReceipt(
-        await LivepeerToken.approve(BondingManager.address, token),
+        await LivepeerToken.approve(BondingManager.address, token, {
+          ...config.defaultTx,
+          ...tx,
+        }),
         config.eth,
       )
     },
@@ -1321,12 +1324,12 @@ export default async function createLivepeerSDK(
     async bondApprovedTokenAmount(
       to: string,
       amount: string,
-      tx = config.defaultTx,
+      tx: TxObject,
     ): Promise<TxReceipt> {
       const token = toBN(amount)
       // @todo - check for existing approval / round initialization / token balance
       return await utils.getTxReceipt(
-        await BondingManager.bond(token, to),
+        await BondingManager.bond(token, to, { ...config.defaultTx, ...tx }),
         config.eth,
       )
     },


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Removed default gas limit of 2.1M wei for approve/bond actions. Instead, hard-coded the gas limit of 60000 to the approve txn and 350000 to the bond txn.

**Specific updates (required)**
- Hard-coded the gas limit of 60000 to the approve txn
- Hard-coded the gas limit of 350000 to the bond txn

**How did you test each of these updates (required)**
Confirm in the Metamask popup that the gas limit is set to 60000 for that of approve txn and 350000 for bond txn

**Screenshots**
- Approve txn
<img width="787" alt="screen shot 2018-05-17 at 11 32 01 pm" src="https://user-images.githubusercontent.com/5172086/40195308-caa1aa3e-5a2a-11e8-8702-f97eefd580a5.png">

- Bond txn
<img width="857" alt="screen shot 2018-05-17 at 11 31 11 pm" src="https://user-images.githubusercontent.com/5172086/40195317-cf964e32-5a2a-11e8-87cb-788249120892.png">

**Does this pull request close any open issues?**
Fixes #71 

**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.