### PR TITLE
Upping default gas on bond action to 450000

### DIFF
--- a/packages/graphql-sdk/src/resolvers/Mutation.js
+++ b/packages/graphql-sdk/src/resolvers/Mutation.js
@@ -47,7 +47,7 @@ export async function bond(
 ): Promise<TxReceipt> {
   const { to, amount } = args
   return await ctx.livepeer.rpc.bondApprovedTokenAmount(to, amount, {
-    gas: 350000,
+    gas: 450000,
   })
 }
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
Changes the default gas submitted along with the bond() transaction to be 450000. Most bond txns were just using ~200K gas so the 350k suggestion felt safe, but this txn must have claimed a bunch of rounds and used over 400K gas, so I'm upping the suggestion: https://etherscan.io/tx/0x199c78c085ee416f37c65fd2f46a0cb229c1393f46143816d3cb5019d181da79

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Changed 350000 to 450000
- 
- 

**How did you test each of these updates (required)**
Just let the pre-commit hooks run. No additional testing.


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
