### PR TITLE
fix(Account): Update account page when the Ethereum address is updated

### DIFF
--- a/packages/explorer/src/index.js
+++ b/packages/explorer/src/index.js
@@ -102,9 +102,11 @@ const trackingId = process.env.REACT_APP_GA_TRACKING_ID
       // If user account changes while on /me, this will hard refresh the page
       onAccountChange: (currentAccount: string, nextAccount: string): void => {
         const path = window.location.pathname.toLowerCase()
-        const onMyAccountPage = path === '/me'
-        const accountChanged = nextAccount && currentAccount
-        if (onMyAccountPage && accountChanged) return window.location.reload()
+        const onMyAccountPage = new RegExp(`^/accounts/${currentAccount}`).test(
+          path,
+        )
+        const accountChanged = nextAccount !== currentAccount
+        if (onMyAccountPage && accountChanged) return (window.location = '/me')
       },
     }
     // The address of the deployed Controller contract


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Refresh the account page when the client's Ethereum address updates.

**Specific updates (required)**
- Check when the ethereum address is updated and we're on the account page.
- Redirect to /me when that happens so the contents are updated accordingly.

**How did you test each of these updates (required)**
Ran it locally and tested swapping addresses in Metamask. It correctly triggered a redirection to /me.

**Does this pull request close any open issues?**
Fixes #82 