### PR TITLE
Pull CTABanner out of the CTA container

### DIFF
--- a/packages/explorer/src/components/App.js
+++ b/packages/explorer/src/components/App.js
@@ -42,31 +42,30 @@ const App = props => (
     </Switch>
     <BondModals />
     <ClaimEarningsModals />
+    <Switch>
+      <Route
+        path="*"
+        component={() => (
+          <CTABanner flag="view-transcoders">
+            <div>
+              If you are a token holder, you can participate in the network by
+              staking towards a transcoder and earn additional fees and LPT
+              rewards.
+            </div>
+            <div>
+              <Button
+                style={{ margin: 0 }}
+                onClick={() => history.push('/transcoders?tour=true')}
+              >
+                Start Delegating
+              </Button>
+            </div>
+          </CTABanner>
+        )}
+      />
+    </Switch>
     <CTA>
       <ToastNotifications />
-      <Switch>
-        <Route exact path="/transcoders" component={() => null} />
-        <Route
-          path="*"
-          component={() => (
-            <CTABanner flag="view-transcoders">
-              <div>
-                If you are a token holder, you can participate in the network by
-                staking towards a transcoder and earn additional fees and LPT
-                rewards.
-              </div>
-              <div>
-                <Button
-                  style={{ margin: 0 }}
-                  onClick={() => history.push('/transcoders?tour=true')}
-                >
-                  Start Delegating
-                </Button>
-              </div>
-            </CTABanner>
-          )}
-        />
-      </Switch>
     </CTA>
   </div>
 )

--- a/packages/explorer/src/components/CTABanner.js
+++ b/packages/explorer/src/components/CTABanner.js
@@ -30,6 +30,8 @@ const CTABanner = styled(
     }
   },
 )`
+  position: fixed;
+  bottom: 0;
   display: flex;
   width: 100%;
   padding: 16px;


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
It fixes an UI bug where hiding `CTABanner` wouldn't make the fixed positioned wrapper (`CTA`) go away. That transparent wrapper would then be in front of other elements, including the modal referenced in the linked issue.

**Specific updates (required)**
- Make the `CTABanner`'s position fixed
- Pull all `CTABanner` usages out of the `CTA` wrapper
- Removed unused switch case

**How did you test each of these updates (required)**
Used a local instance to test in both `Cipher` and `Toshi` apps.

**Does this pull request close any open issues?**
Fixes #84 