### PR TITLE
Fix hardcoded MerkleMine proof size for transaction data in explorer

### DIFF
--- a/packages/explorer/src/views/Mining/enhance.js
+++ b/packages/explorer/src/views/Mining/enhance.js
@@ -6,6 +6,21 @@ import {
   connectToasts,
 } from '../../enhancers'
 
+const encodeProofSize = proof => {
+  // Assume hex encoded proof
+  const proofSize = proof.length / 2
+
+  let res = proofSize.toString('16')
+  let len = res.length
+
+  while (len < 64) {
+    res = '0' + res
+    len++
+  }
+
+  return res
+}
+
 const mapMutationHandlers = withHandlers({
   generateToken: ({ sendTransaction, toasts }) => async ({
     address,
@@ -18,7 +33,7 @@ const mapMutationHandlers = withHandlers({
         data:
           `0x2c84bfa6000000000000000000000000${address.substr(2)}` +
           '0000000000000000000000000000000000000000000000000000000000000040' +
-          '00000000000000000000000000000000000000000000000000000000000002c0' +
+          encodeProofSize(proof) +
           proof,
       }
       console.log('submitting transaction', options)


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Properly construct the ABI encoded Merkle proof size for the transaction data used to generate tokens.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Instead of using a hard coded Merkle proof size (currently 704 bytes), construct the ABI encoded Merkle proof size based on the provided hex encoded proof by taking the proof size and left padding with zeros until we have 32 bytes

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I ran the explorer locally and hardcoded the variable `defaultAddress` here https://github.com/livepeer/livepeerjs/blob/f3094301de6e1cf0f203c8affa0731b06ad8a605/packages/explorer/src/views/Mining/index.js#L24 to 0xd3bbe001d3044e78b068244aae95bafe75744233 which has an associated proof of size 640 which is different from the currently hardcoded 704. I logged the transaction data created when clicking "Claim Token" while using this default address to observe that the proof size was properly encoded in the transaction data.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
