### PR TITLE
fix blank page issue in mist browser

### DIFF
--- a/packages/explorer/src/components/BasicNavbar.js
+++ b/packages/explorer/src/components/BasicNavbar.js
@@ -24,7 +24,7 @@ const BasicNavbar = ({ onSearch, currentRound, toasts, coinbase, history }) => {
   const myAccountAddress = coinbase.data.coinbase
   const notAuthenticated = !myAccountAddress
   const { host } = window.livepeer.config.eth.currentProvider
-  const networkName = !window.web3
+  const networkName = !window.web3.version
     ? /infura/.test(host)
       ? host.split('.')[0].replace(/(http|https):\/\//, '')
       : 'Custom RPC'

--- a/packages/explorer/src/index.js
+++ b/packages/explorer/src/index.js
@@ -153,7 +153,7 @@ const trackingId = process.env.REACT_APP_GA_TRACKING_ID
       },
     }
     // The address of the deployed Controller contract
-    if (window.web3) {
+    if (window.web3.version) {
       const { version } = window.web3
       const controllers = {
         1: process.env.REACT_APP_MAINNET_CONTROLLER_ADDRESS,


### PR DESCRIPTION

**What does this pull request do? Explain your changes. (required)**

I have edited two js files for resolve the issue of get a blank webpage on mist browser, for example https://explorer.livepeer.org/token or https://explorer.livepeer.org/transcoders.

The issue was caused by native web3 command in mist (window.web3), because Mist does not ship its own version of web3.js in browser anymore since 0.9 version.In the future mist will provide a new ethereum provider i think.

In the code, i have changed from window.web3 to window.web3.version because in this way the control fails and the browser always will use infura. The issue with checking only on window.web3 is that it is exists in native mist browser but provide only an object (CurrentProvider) without attributes like version or version.network and for this reason the browser obtain a blank page because it is breaks when it tries to access to 'network' parament in window.web3.version, window.web3.version is undefined in this case.

**Specific updates (required)**

- The webpage is loaded correctly now on Mist browser.
- With these changes, Mist will use web3 injection provided by infura like other browsers without metamask installed.

**How did you test each of these updates (required)**

I have tested this in the same environment requested in Fix #155 , OS X and Mist 0.11.

**Does this pull request close any open issues?**

Yes, Fix #155 issue.

**Screenshots (optional):**

**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
