### PR TITLE
sdk: Add missing rpc.getTotalBonded() function

### DIFF
--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -791,6 +791,20 @@ export default async function createLivepeerSDK(
     },
 
     /**
+     * Gets the total amount of bonded tokens
+     * @memberof livepeer~rpc
+     * @return {Promise<string}
+     *
+     * @example
+     *
+     * await rpc.getTotalBonded()
+     * // => string
+     */
+    async getTotalBonded(): Promise<string> {
+      return headToString(await BondingManager.getTotalBonded())
+    },
+
+    /**
      * Gets the total supply of token (LTPU) available in the protocol
      * @memberof livepeer~rpc
      * @return {Promise<string>}


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Add the `rpc.getTotalBonded()` function to the SDK which is currently missing and causing these tests to fail https://github.com/livepeer/livepeerjs/blob/master/packages/sdk/src/index.test.js#L89 https://github.com/livepeer/livepeerjs/blob/master/packages/sdk/src/index.test.js#L326

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- **sdk**: Add `rpc.getTotalBonded()` 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I ran the SDK test suite.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
