### PR TITLE
explorer: Increase default gas limit for initializeRound()

### DIFF
--- a/packages/explorer/src/views/ProtocolStatus/enhance.js
+++ b/packages/explorer/src/views/ProtocolStatus/enhance.js
@@ -15,7 +15,7 @@ const mapMutationHandlers = withHandlers({
         body: 'The current round is being initialized.',
       })
       // TODO: move into graphql schema as mutation
-      await window.livepeer.rpc.initializeRound()
+      await window.livepeer.rpc.initializeRound({ gas: 2800000 })
       toasts.push({
         id: 'initialize-round',
         type: 'success',


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

Increase the default gas limit for the `initializeRound()` transaction.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- **explorer**: Increase the default gas limit for `initializeRound()` from 2100000 to 2800000

**How did you test each of these updates (required)**

I built the explorer and tried to initialize the round which opened up a Metamask popup displaying the gas limit for the transaction.

**Does this pull request close any open issues?**

Fixes #168 

In the future, we can implement #174 to avoid hardcoding gas limits.

**Screenshots (optional):**
<!-- Drag some screenshots here, if applicable -->

![screen shot 2018-08-07 at 1 11 20 pm](https://user-images.githubusercontent.com/5933273/43791837-f5107174-9a44-11e8-81bf-fe07fda1a689.png)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
