### PR TITLE
Check for web3 object before checking property on web3 object

### DIFF
--- a/packages/explorer/src/components/BasicNavbar.js
+++ b/packages/explorer/src/components/BasicNavbar.js
@@ -24,7 +24,12 @@ const BasicNavbar = ({ onSearch, currentRound, toasts, coinbase, history }) => {
   const myAccountAddress = coinbase.data.coinbase
   const notAuthenticated = !myAccountAddress
   const { host } = window.livepeer.config.eth.currentProvider
-  const networkName = !window.web3.version
+  // Test if web3 is injected
+  // For Mist compatability we also check if the web3 object has the `version` property
+  // because at the moment the Mist provided web3 object does not have additional properties like `version`
+  // As a result, if a web3 object with the `version` property is not available, we fallback
+  // to using a default provider which should be the case for Mist
+  const networkName = !(window.web3 && window.web3.version)
     ? /infura/.test(host)
       ? host.split('.')[0].replace(/(http|https):\/\//, '')
       : 'Custom RPC'

--- a/packages/explorer/src/index.js
+++ b/packages/explorer/src/index.js
@@ -153,7 +153,12 @@ const trackingId = process.env.REACT_APP_GA_TRACKING_ID
       },
     }
     // The address of the deployed Controller contract
-    if (window.web3.version) {
+    // Test if web3 is injected
+    // For Mist compatability we also check if the web3 object has the `version` property
+    // because at the moment the Mist provided web3 object does not have additional properties like `version`
+    // As a result, if a web3 object with the `version` property is not available, we fallback
+    // to using a default provider which should be the case when using Mist
+    if (window.web3 && window.web3.version) {
       const { version } = window.web3
       const controllers = {
         1: process.env.REACT_APP_MAINNET_CONTROLLER_ADDRESS,


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Check for injected web3 object in the explorer before checking for property on the web3 object. At the moment, the explorer tries to check for a web3 object with the `version` property. See #164 for more details on the rationale before the current behavior in order to allow the explorer to be used within the Mist browser. The problem with the current implementation is that if a user navigates to the explorer with a non-web3 enabled browser (i.e. Chrome without Metamask), there will be no injected web3 object at all. The explorer will try to check for the `version` property for an undefined object resulting in an error. 

Now, the explorer will first check for the injected web3 object and only check for the `version` property if the web3 object is present.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- **explorer**: Check for injected web3 object before checking property on web3 object

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #185 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
