### PR TITLE
Use pending stake when fully unbonding

### DIFF
--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1870,13 +1870,13 @@ export default async function createLivepeerSDK(
      * // }
      */
     async unbond(tx = config.defaultTx): Promise<TxReceipt> {
-      const { status, bondedAmount } = await rpc.getDelegator(tx.from)
+      const { status, pendingStake } = await rpc.getDelegator(tx.from)
       // Can only unbond successfully when not already "Unbonded"
       if (status === DELEGATOR_STATUS.Unbonded) {
         throw new Error('This account is already unbonded.')
       } else {
         return await utils.getTxReceipt(
-          await BondingManager.unbond(bondedAmount),
+          await BondingManager.unbond(pendingStake),
           config.eth,
         )
       }


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

When fully unbonding, the SDK will use the delegator's pending stake as the parameter for `BondingManager.unbond()`.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- **sdk**: Modify `unbond()` to use the delegator's pending stake instead of bonded amount

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

I tested this change on Rinkeby.

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #204 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
