### PR TITLE
Add transcoder address to job info

### DIFF
--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1627,12 +1627,19 @@ export default async function createLivepeerSDK(
      */
     async getJob(id: string): Promise<Job> {
       const x = await JobsManager.getJob(id)
+      const { hash } = await rpc.getBlock(x.creationBlock)
+      const transcoder = await BondingManager.electActiveTranscoder(
+        x.maxPricePerSegment,
+        hash,
+        x.creationRound,
+      )
       return {
         id: toString(id),
         streamId: x.streamId,
         transcodingOptions: utils.parseTranscodingOptions(x.transcodingOptions),
         transcoder: x.transcoderAddress,
         broadcaster: x.broadcasterAddress,
+        transcoder: transcoder,
       }
     },
 

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1627,15 +1627,15 @@ export default async function createLivepeerSDK(
      */
     async getJob(id: string): Promise<Job> {
       const x = await JobsManager.getJob(id)
-      const { hash } = await rpc.getBlock(x.creationBlock)
       // Computer transcoder's address if none was returned
-      x.transcoderAddress = x.transcoderAddress
-        ? x.transcoderAddress
-        : await BondingManager.electActiveTranscoder(
-            x.maxPricePerSegment,
-            hash,
-            x.creationRound,
-          )
+      if (!x.transcoderAddress) {
+        const { hash } = await rpc.getBlock(x.creationBlock)
+        x.transcoderAddress = await BondingManager.electActiveTranscoder(
+          x.maxPricePerSegment,
+          hash,
+          x.creationRound,
+        )
+      }
       return {
         id: toString(id),
         streamId: x.streamId,

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1628,6 +1628,7 @@ export default async function createLivepeerSDK(
     async getJob(id: string): Promise<Job> {
       const x = await JobsManager.getJob(id)
       const { hash } = await rpc.getBlock(x.creationBlock)
+      // Computer transcoder's address if none was returned
       x.transcoderAddress = x.transcoderAddress
         ? x.transcoderAddress
         : await BondingManager.electActiveTranscoder(

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1628,7 +1628,10 @@ export default async function createLivepeerSDK(
     async getJob(id: string): Promise<Job> {
       const x = await JobsManager.getJob(id)
       // Computer transcoder's address if none was returned
-      if (!x.transcoderAddress) {
+      if (
+        x.transcoderAddress === null ||
+        x.transcoderAddress === EMPTY_ADDRESS
+      ) {
         const { hash } = await rpc.getBlock(x.creationBlock)
         x.transcoderAddress = await BondingManager.electActiveTranscoder(
           x.maxPricePerSegment,

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1623,12 +1623,13 @@ export default async function createLivepeerSDK(
      * //   transcodingOptions: Array<JobProfile>
      * //   transcoder: string,
      * //   broadcaster: string,
+     * //   transcoderAddress: string,
      * // }
      */
     async getJob(id: string): Promise<Job> {
       const x = await JobsManager.getJob(id)
       const { hash } = await rpc.getBlock(x.creationBlock)
-      const transcoder = await BondingManager.electActiveTranscoder(
+      const transcoderAddress = await BondingManager.electActiveTranscoder(
         x.maxPricePerSegment,
         hash,
         x.creationRound,
@@ -1639,7 +1640,7 @@ export default async function createLivepeerSDK(
         transcodingOptions: utils.parseTranscodingOptions(x.transcodingOptions),
         transcoder: x.transcoderAddress,
         broadcaster: x.broadcasterAddress,
-        transcoder: transcoder,
+        transcoderAddress: transcoderAddress,
       }
     },
 

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1623,24 +1623,24 @@ export default async function createLivepeerSDK(
      * //   transcodingOptions: Array<JobProfile>
      * //   transcoder: string,
      * //   broadcaster: string,
-     * //   transcoderAddress: string,
      * // }
      */
     async getJob(id: string): Promise<Job> {
       const x = await JobsManager.getJob(id)
       const { hash } = await rpc.getBlock(x.creationBlock)
-      const transcoderAddress = await BondingManager.electActiveTranscoder(
-        x.maxPricePerSegment,
-        hash,
-        x.creationRound,
-      )
+      x.transcoderAddress = x.transcoderAddress
+        ? x.transcoderAddress
+        : await BondingManager.electActiveTranscoder(
+            x.maxPricePerSegment,
+            hash,
+            x.creationRound,
+          )
       return {
         id: toString(id),
         streamId: x.streamId,
         transcodingOptions: utils.parseTranscodingOptions(x.transcodingOptions),
         transcoder: x.transcoderAddress,
         broadcaster: x.broadcasterAddress,
-        transcoderAddress: transcoderAddress,
       }
     },
 

--- a/packages/sdk/src/index.test.js
+++ b/packages/sdk/src/index.test.js
@@ -302,6 +302,22 @@ test('should return object with correct shape from getCurrentRoundInfo()', async
 
 // Jobs
 
+test('should return object with correct shape from getJob()', async t => {
+  const schema = object({
+    id: string,
+    streamId: string,
+    transcodingOptions: Array,
+    transcoder: string,
+    broadcaster: string,
+  })
+  const res = await livepeer.rpc.getJobs()
+  res.forEach(async x => {
+    const job = await livepeer.rpc.getJob(x.id)
+    schema.validateSync(job)
+  })
+  t.pass()
+})
+
 test('should return object with correct shape from getJobsInfo()', async t => {
   const schema = object({
     total: string,

--- a/packages/sdk/src/index.test.js
+++ b/packages/sdk/src/index.test.js
@@ -306,7 +306,15 @@ test('should return object with correct shape from getJob()', async t => {
   const schema = object({
     id: string,
     streamId: string,
-    transcodingOptions: array,
+    transcodingOptions: array(
+      object({
+        hash: string,
+        name: string,
+        bitrate: string,
+        framerate: number,
+        resolution: string,
+      }),
+    ),
     transcoder: string,
     broadcaster: string,
   })

--- a/packages/sdk/src/index.test.js
+++ b/packages/sdk/src/index.test.js
@@ -306,7 +306,7 @@ test('should return object with correct shape from getJob()', async t => {
   const schema = object({
     id: string,
     streamId: string,
-    transcodingOptions: Array,
+    transcodingOptions: array,
     transcoder: string,
     broadcaster: string,
   })


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->
The SDK function getJob() currently will not return a transcoder address in the result object if the transcoder did not already submit an on-chain claim to store the transcoder address on-chain. This PR calls the contract function [electActiveTranscoder](https://github.com/livepeer/protocol/blob/master/contracts/bonding/BondingManager.sol#L651) in order to compute the assigned transcoder address to be returned with the result object.


**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**
<!-- Fixes # -->
Fixes #190 
**Screenshots (optional):**
<!-- Drag some screenshots here, if applicable -->

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
