### PR TITLE
Update state requirements for withdrawal

### DIFF
--- a/packages/explorer/src/views/Account/index.js
+++ b/packages/explorer/src/views/Account/index.js
@@ -52,7 +52,6 @@ const AccountView: React.ComponentType<AccountViewProps> = ({
   const { delegateAddress, status } = me.data.delegator
   const isBonded = status === 'Bonded'
   const isBonding = status === 'Pending'
-  const isUnbonded = status === 'Unbonded'
   const isMyDelegate = accountAddress === delegateAddress
   const canRebond = isMyDelegate && (isBonded || isBonding)
   const canBond = !!userAddress

--- a/packages/explorer/src/views/AccountDelegating/enhance.js
+++ b/packages/explorer/src/views/AccountDelegating/enhance.js
@@ -107,14 +107,21 @@ const mapMutationHandlers = withHandlers({
   withdrawStake: ({ currentRound, delegator, toasts }) => async () => {
     try {
       const isRoundInitialized = currentRound.data.initialized
-      const { status } = delegator.data
-      if (status !== 'Unbonded') {
+      const { status, withdrawAmount } = delegator.data
+      if (status === 'Unbonding') {
         return toasts.push({
           id: 'withdraw-stake',
           type: 'warn',
           title: 'Cannot withdraw stake',
-          body:
-            'First, you must unbond from your delegate and wait through the unbonding period.',
+          body: 'First, you must wait through the unbonding period.',
+        })
+      }
+      if (withdrawAmount === '0') {
+        return toasts.push({
+          id: 'withdraw-stake',
+          type: 'warn',
+          title: 'Cannot withdraw stake',
+          body: 'You have nothing to withdraw',
         })
       }
       if (!isRoundInitialized) {

--- a/packages/explorer/src/views/AccountDelegating/index.js
+++ b/packages/explorer/src/views/AccountDelegating/index.js
@@ -70,13 +70,12 @@ const AccountDelegating: React.ComponentType<AccountDelegatingProps> = ({
   const earnedFees = hasUnclaimedRounds ? MathBN.sub(pendingFees, fees) : '0'
   const hasFees = fees !== '0'
   const isUnbonding = status === 'Unbonding'
-  const isUnbonded = status === 'Unbonded'
   const isBonding = status === 'Pending'
   const isBonded = status === 'Bonded'
   const roundsUntilUnbonded = isUnbonding
     ? MathBN.sub(withdrawRound, lastInitializedRound)
     : ''
-  const canWithdraw = isUnbonded && withdrawAmount !== '0'
+  const canWithdraw = !isUnbonding && withdrawAmount !== '0'
   return (
     <Wrapper>
       {/*<InlineHint flag="account-delegating">

--- a/packages/explorer/src/views/Transcoders/index.js
+++ b/packages/explorer/src/views/Transcoders/index.js
@@ -45,10 +45,8 @@ const TranscodersView: React.ComponentType<TranscodersViewProps> = ({
     tokenBalance,
   } = me.data
   const totalStake = MathBN.max(bondedAmount, pendingStake)
-  const isBonding = status === 'Pending'
   const isBonded = status === 'Bonded'
   const isUnbonding = status === 'Unbonding'
-  const isUnbonded = status === 'Unbonded'
   const isTranscoder = me.data.transcoder.status === 'Registered'
   const searchParams = new URLSearchParams(history.location.search)
   const TOUR_ENABLED = !!searchParams.get('tour')
@@ -184,7 +182,6 @@ const TranscodersView: React.ComponentType<TranscodersViewProps> = ({
           const myId = me.data.id // delegator id
           const { id } = props // transcoder id
           const isMyDelegate = id === delegateAddress
-          const canRebond = isMyDelegate && (isBonded || isBonding)
           const canBond =
             myId && (!isTranscoder || (isTranscoder && id === myId))
           const canUnbond = myId && isBonded && isMyDelegate

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -2085,10 +2085,10 @@ export async function createLivepeerSDK(
         nextUnbondingLockId,
       } = await rpc.getDelegator(tx.from)
 
-      if (status !== DELEGATOR_STATUS.Unbonded && withdrawAmount !== '0') {
-        throw new Error(
-          'Delegator is not in the unbonded state with a withdraw amount',
-        )
+      if (status === DELEGATOR_STATUS.Unbonding) {
+        throw new Error('Delegator must wait through unbonding period')
+      } else if (withdrawAmount === '0') {
+        throw new Error('Delegator does not have anything to withdraw')
       } else {
         let unbondingLockId = toBN(nextUnbondingLockId)
         if (unbondingLockId.cmp(new BN(0)) > 0) {


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Update state requirements for withdrawal.

This PR is in response to a bug reported by users where they unbonded, waited through the unbonding period, but also bonded more tokens. Then after the unbonding period completes, the user should be able to withdraw the unbonded tokens, but is unable to do so because at the moment there is a requirement at SDK/UI level that the user has to be unbonded in order withdraw. Since the user bonded more tokens it would not be in the unbonded state after the unbonding period completes which blocks the withdrawal.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- **explorer**: Instead of requiring the user to be in the unbonded state to withdraw, require the user to not be in the unbonding state to withdraw. This should cover the scenario described above.
- **sdk**: Update error message handling for `withdrawStake()`

Note: There is no longer an explicit unbonding state in the protocol. In the SDK/UI, the unbonding state is maintained however - a delegator is considered as being in the unbonding state here if its unbonding lock with the ID `nextUnbondingLockId - 1` has a non-zero withdraw round and the current round is less than that value.

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested locally.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
