### PR TITLE
[READY] livepeer/player: specify stream source in url

### DIFF
--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -11,9 +11,9 @@ A video player for the web. Lets you see what's live streaming on the network. O
 
 ## Table of Contents
 
-* [Installation](#installation)
-* [Developing](#developing)
-* [Building](#building)
+- [Installation](#installation)
+- [Developing](#developing)
+- [Building](#building)
 
 <!-- hide-on-docup-stop -->
 
@@ -47,3 +47,9 @@ Built files will be output to `./dist`
 | `REACT_APP_STREAM_ROOT_URL` |               | The root http url from which broadcaster m3u8 files will be served                                                                                                                                                                                                                                                                                                     |
 
 Need a new variable? Create a PR or [file an issue](https://github.com/livepeer/livepeerjs/issues/new?labels=player) 🍻
+
+### Changing Stream Route on the fly
+
+add `?source=<STREAM_ROOT_URL>/stream` to the player url
+
+**Example**: `https://media.livepeer.org/embed/0x0ddb225031ccb58ff42866f82d907f7766899014?source=http://localhost:8935/stream`

--- a/packages/player/src/views/Channel/index.js
+++ b/packages/player/src/views/Channel/index.js
@@ -172,34 +172,34 @@ class Channel extends Component {
     }
 
     if (address === process.env.REACT_APP_LIVEPEER_TV_ADDRESS.toLowerCase()) {
-      return this.setState({
+      this.setState({
         live: true,
         url: `${
           process.env.REACT_APP_LIVEPEER_TV_STREAM_ROOT_URL
         }/${manifestId}.m3u8`,
       })
-    }
-    if (
+    } else if (
       address === process.env.REACT_APP_CRYPTO_LIVEPEER_TV_ADDRESS.toLowerCase()
     ) {
-      return this.setState({
+      this.setState({
         live: true,
         url: `${
           process.env.REACT_APP_CRYPTO_LIVEPEER_TV_STREAM_ROOT_URL
         }/${manifestId}.m3u8`,
       })
-    }
-    if (address === process.env.REACT_APP_INGEST2_ADDRESS.toLowerCase()) {
-      return this.setState({
+    } else if (
+      address === process.env.REACT_APP_INGEST2_ADDRESS.toLowerCase()
+    ) {
+      this.setState({
         live: true,
         url: `${
           process.env.REACT_APP_INGEST2_STREAM_ROOT_URL
         }/${manifestId}.m3u8`,
       })
+    } else {
+      let url = `${process.env.REACT_APP_STREAM_ROOT_URL}/${manifestId}.m3u8`
+      this.setState({ url })
     }
-
-    let url = `${process.env.REACT_APP_STREAM_ROOT_URL}/${manifestId}.m3u8`
-    this.setState({ url })
   }
 
   render() {

--- a/packages/player/src/views/Channel/index.js
+++ b/packages/player/src/views/Channel/index.js
@@ -21,6 +21,11 @@ import BasicNavbar from '../../components/BasicNavbar'
 import Footer from '../../components/Footer'
 import { actions as routingActions } from '../../services/routing'
 import Modal from 'react-responsive-modal'
+import * as qs from 'query-string'
+
+const parseQs = str => {
+  return qs.parse(str)
+}
 
 const { changeChannel } = routingActions
 
@@ -145,13 +150,27 @@ class Channel extends Component {
 
   async componentWillReceiveProps(nextProps) {
     const { data } = nextProps.account
+    const location = nextProps.location
     const address = data.id.toLowerCase()
     const [latestJob] = data.broadcaster.jobs
+    const manifestId = latestJob.streamId.substr(0, 68 + 64)
+
     if (!latestJob) {
       if (nextProps.loading === false) this.setState({ live: false })
       return
     }
-    const manifestId = latestJob.streamId.substr(0, 68 + 64)
+
+    if (location.search) {
+      let queryObject = parseQs(location.search)
+      if (queryObject && queryObject.source) {
+        console.log('using source qs')
+        return this.setState({
+          live: true,
+          url: `${queryObject.source}/${manifestId}.m3u8`,
+        })
+      }
+    }
+
     if (address === process.env.REACT_APP_LIVEPEER_TV_ADDRESS.toLowerCase()) {
       return this.setState({
         live: true,
@@ -178,12 +197,14 @@ class Channel extends Component {
         }/${manifestId}.m3u8`,
       })
     }
+
     let url = `${process.env.REACT_APP_STREAM_ROOT_URL}/${manifestId}.m3u8`
     this.setState({ url })
   }
 
   render() {
-    const { account, changeChannel } = this.props
+    const { account, changeChannel, location } = this.props
+    console.log('locaation: ', location)
     const { loading } = account
     const {
       id,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
this should allow the user to add `source` query to their player url to specify the stream source. this should close #182 

**Specific updates (required)**

- detect query string and parse it.
- generate a proper m3u8 url using the stream source + manifestId

**How did you test each of these updates (required)**
I ran a local lp node, and used specified an external source (cdn) . it works out of the box.

**Does this pull request close any open issues?**
fixes #182 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
