### PR TITLE
Some proposed changes to Livepeer Explorer landing

### DIFF
--- a/packages/explorer/src/views/Landing/index.js
+++ b/packages/explorer/src/views/Landing/index.js
@@ -22,19 +22,15 @@ const Landing = ({ history, ...props }) => (
         <h3 style={{ letterSpacing: 8 }}>Protocol Explorer</h3>
         <br />
         <br />
-        <Video src="/static/media/landing.mp4" />
-        <br />
-        <br />
         <div style={{ display: 'flex' }}>
           <InfoBox>
             <h2>
               <Icon use="explore" />&nbsp;
-              {`Explore Protocol Activity`}
+              {`Explore Your Account`}
             </h2>
             <p>
-              The account view shows the recent Livepeer smart contract
-              transactions for any Ethereum address. It also gives you deep
-              insight into important protocol metrics.
+              Check your balance of Livepeer Tokens (LPT),
+              and learn what you can do with them.
             </p>
             <br />
             <form
@@ -50,7 +46,7 @@ const Landing = ({ history, ...props }) => (
                 name="address"
                 type="search"
                 pattern="^0x[a-fA-F0-9]{40}$"
-                placeholder="Enter an ETH account address"
+                placeholder="Enter your ETH account address"
                 onKeyDown={e => {
                   if (e.keyCode !== 13 || !e.target.value) return
                   document.getElementById('account-search-button').click()
@@ -66,11 +62,11 @@ const Landing = ({ history, ...props }) => (
           <InfoBox>
             <h2>
               <Icon use="how_to_vote" />&nbsp;
-              {`Play the Delegation Game`}
+              {`BOND your LPT to a Node`}
             </h2>
             <p>
-              Bond to delegates to earn newly minted token and fees from
-              transcoder activity, growing your total ownership in the network.
+              Bond to a Transcoder Node in the network to support
+              them, and also earn a share of their rewards and fees.
             </p>
             <br />
             <p style={{ textAlign: 'right', margin: 0 }}>
@@ -78,10 +74,10 @@ const Landing = ({ history, ...props }) => (
                 big
                 type="submit"
                 onClick={() => {
-                  history.push('/token')
+                  history.push('/transcoders')
                 }}
               >
-                Get Token
+                SEE OPTIONS
               </CTAButton>
             </p>
           </InfoBox>


### PR DESCRIPTION
Removed the video tutorial, edit some copy, changed some routing.

<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**

It makes some changes to explorer.livepeer.org landing page, to help new explorers in Livepeer to begin to engage with the protocol more easily.

Specifically, it promotes the section where a user can enter any Ethereum address (including their own), to begin to explore livepeer's protocol.

It also rewords some copy, to make it more accessible to a wider audience - the 2.6 million who have no idea about bonding and inflationary reward yet - but they will soon, maybe!

**Specific updates (required)**

- Remove the video (for now, pending a new video to be put in it's place to help new entrants joined the community)

- Rebrand "Explorer Protocol Activity" to "Explore Your Account"

   - Adapt the copy to make it friendlier, and easier to engage with. Also, to seek to personalise it somewhat, and make the user feel at the centre of this.

- Rebrand "Play the Delegation Game" to "BOND your LPT to a Node"

   - Someone should totally gamify this, but not us. At least, not yet.
   - For now, I propose to lead them down the garden path, to the specific call-to-action that we want them to take. To BOND.
   - GET TOKEN is finished now. Remove from everywhere, let's tidy this up :)

**How did you test each of these updates (required)**

I tested them in my mind's eye, tweaked some text about, fit @jozanza's pattern. It'll be fine. Can we push them to staging first and then have a look?

**Does this pull request close any open issues?**

No.

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.