### PR TITLE
[Ready] player /channel/local mode

### DIFF
--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -53,3 +53,9 @@ Need a new variable? Create a PR or [file an issue](https://github.com/livepeer/
 add `?source=<STREAM_ROOT_URL>/stream` to the player url
 
 **Example**: `https://media.livepeer.org/embed/0x0ddb225031ccb58ff42866f82d907f7766899014?source=http://localhost:8935/stream`
+
+## Local Mode
+
+pull the local `current` stream. the local livepeer node has to have `-currentManifest` flag on.
+
+go to `http://localhost:3000/channels/local` . this sets the source to `http://localhost:8935/stream/current.m3u8`

--- a/packages/player/src/views/Channel/index.js
+++ b/packages/player/src/views/Channel/index.js
@@ -155,33 +155,28 @@ class Channel extends Component {
   }
 
   getRootUrl(location, address) {
-    if (location.search && location.search.length > 0) {
-      let queryObject = parseQs(location.search)
-      if (queryObject && queryObject.source) {
-        console.log('using source qs', location)
-        return queryObject.source
-      }
+    let queryObject = parseQs(location.search)
+    if (queryObject && queryObject.source) {
+      console.log('using source qs', location)
+      return queryObject.source
     } else {
       let rootUrl = null
-      if (address === process.env.REACT_APP_LIVEPEER_TV_ADDRESS.toLowerCase()) {
-        rootUrl = process.env.REACT_APP_LIVEPEER_TV_STREAM_ROOT_URL
-      } else if (
-        address ===
-        process.env.REACT_APP_CRYPTO_LIVEPEER_TV_ADDRESS.toLowerCase()
-      ) {
-        rootUrl = process.env.REACT_APP_CRYPTO_LIVEPEER_TV_STREAM_ROOT_URL
-      } else if (
-        address === process.env.REACT_APP_INGEST2_ADDRESS.toLowerCase()
-      ) {
-        rootUrl = process.env.REACT_APP_INGEST2_STREAM_ROOT_URL
-      } else if (address === 'local') {
-        console.info('LOCAL ', address)
-        rootUrl = 'http://localhost:8935/stream'
-      } else {
-        rootUrl = process.env.REACT_APP_STREAM_ROOT_URL
+      switch (address) {
+        case process.env.REACT_APP_LIVEPEER_TV_ADDRESS.toLowerCase():
+          rootUrl = process.env.REACT_APP_LIVEPEER_TV_STREAM_ROOT_URL
+          break
+        case process.env.REACT_APP_CRYPTO_LIVEPEER_TV_ADDRESS.toLowerCase():
+          rootUrl = process.env.REACT_APP_CRYPTO_LIVEPEER_TV_STREAM_ROOT_URL
+          break
+        case process.env.REACT_APP_INGEST2_ADDRESS.toLowerCase():
+          rootUrl = process.env.REACT_APP_INGEST2_STREAM_ROOT_URL
+          break
+        case 'local':
+          rootUrl = 'http://localhost:8935/stream'
+        default:
+          rootUrl = process.env.REACT_APP_STREAM_ROOT_URL
+          return rootUrl
       }
-
-      return rootUrl
     }
   }
 
@@ -211,47 +206,6 @@ class Channel extends Component {
         url: `${rootUrl}/${manifestId}.m3u8`,
       })
     }
-
-    // if (location.search) {
-    //   let queryObject = parseQs(location.search)
-    //   if (queryObject && queryObject.source) {
-    //     console.log('using source qs', location)
-    //     return this.setState({
-    //       live: true,
-    //       url: `${queryObject.source}/${manifestId}.m3u8`,
-    //     })
-    //   }
-    // }
-    //
-    // if (address === process.env.REACT_APP_LIVEPEER_TV_ADDRESS.toLowerCase()) {
-    //   this.setState({
-    //     live: true,
-    //     url: `${
-    //       process.env.REACT_APP_LIVEPEER_TV_STREAM_ROOT_URL
-    //     }/${manifestId}.m3u8`,
-    //   })
-    // } else if (
-    //   address === process.env.REACT_APP_CRYPTO_LIVEPEER_TV_ADDRESS.toLowerCase()
-    // ) {
-    //   this.setState({
-    //     live: true,
-    //     url: `${
-    //       process.env.REACT_APP_CRYPTO_LIVEPEER_TV_STREAM_ROOT_URL
-    //     }/${manifestId}.m3u8`,
-    //   })
-    // } else if (
-    //   address === process.env.REACT_APP_INGEST2_ADDRESS.toLowerCase()
-    // ) {
-    //   this.setState({
-    //     live: true,
-    //     url: `${
-    //       process.env.REACT_APP_INGEST2_STREAM_ROOT_URL
-    //     }/${manifestId}.m3u8`,
-    //   })
-    // } else {
-    //   let url = `${process.env.REACT_APP_STREAM_ROOT_URL}/${manifestId}.m3u8`
-    //   this.setState({ url })
-    // }
   }
 
   render() {

--- a/packages/player/src/views/Channel/index.js
+++ b/packages/player/src/views/Channel/index.js
@@ -173,10 +173,12 @@ class Channel extends Component {
           break
         case 'local':
           rootUrl = 'http://localhost:8935/stream'
+          break
         default:
           rootUrl = process.env.REACT_APP_STREAM_ROOT_URL
-          return rootUrl
       }
+
+      return rootUrl
     }
   }
 
@@ -194,12 +196,13 @@ class Channel extends Component {
       })
     } else {
       const [latestJob] = data.broadcaster.jobs
-      const manifestId = latestJob.streamId.substr(0, 68 + 64)
 
       if (!latestJob) {
         if (nextProps.loading === false) this.setState({ live: false })
         return
       }
+
+      const manifestId = latestJob.streamId.substr(0, 68 + 64)
 
       return this.setState({
         live: true,

--- a/packages/player/src/views/Channel/index.js
+++ b/packages/player/src/views/Channel/index.js
@@ -154,7 +154,7 @@ class Channel extends Component {
     this.setState({ tipAmount: e.target.value })
   }
 
-  getRootUrl(location, address) {
+  getRootUrl = (location, address) => {
     let queryObject = parseQs(location.search)
     if (queryObject && queryObject.source) {
       console.log('using source qs', location)


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
this checks for special `/local` instead of a broadcaster address to grab the local broadcasting. this works along with `current.m3u8` and allows devs to test their broadcast without needing a blockchain lookup

**Specific updates (required)**
- checks for route `/channel/local`
- override blockchain lookup if it's running in local mode.

**How did you test each of these updates (required)**
It works just like the production player, but will check the local broadcast if instructed. so this shouldn't break anything.

**Does this pull request close any open issues?**
No, but it was a feature request.

**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
