### PR TITLE
Fall back from graph node to Infura when not on mainnet

### DIFF
--- a/packages/apollo/src/index.js
+++ b/packages/apollo/src/index.js
@@ -133,7 +133,7 @@ export default async function createApolloClient(
 
     // If no subgraph endpoint is provided OR if web3 is available and not
     // on mainnnet, do not use subgraph data
-    if (!url || (IS_WEB3_AVAILABLE && !IS_MAINNET)) {
+    if ((IS_WEB3_AVAILABLE && !IS_MAINNET) || !url) {
       return false
     }
     try {

--- a/packages/apollo/src/index.js
+++ b/packages/apollo/src/index.js
@@ -127,7 +127,13 @@ export default async function createApolloClient(
    * @return {boolean}
    */
   async function isSubgraphAvailable(url: string): boolean {
-    if (!url) {
+    const IS_WEB3_AVAILABLE = window.web3
+    const IS_MAINNET =
+      IS_WEB3_AVAILABLE && `${window.web3.version.network}` === '1'
+
+    // If no subgraph endpoint is provided OR if web3 is available and not
+    // on mainnnet, do not use subgraph data
+    if (!url || (IS_WEB3_AVAILABLE && !IS_MAINNET)) {
       return false
     }
     try {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes an issue on staging where the explorer shows transcoder information from mainnet, even when the user switches Metamask to Rinkeby

**Specific updates (required)**
- Falls back from the graph node to Infura whenever the network detected is _not_ mainnet.

**Does this pull request close any open issues?**
#285 

**Screenshots (optional):**
<img width="1438" alt="screen shot 2018-12-13 at 9 04 52 pm" src="https://user-images.githubusercontent.com/555740/49978927-cd18fe80-ff1a-11e8-8bc1-a4c0990bedf1.png">

**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
