### PR TITLE
Prevent current round from counting towards a transcoder's missed reward call total

### DIFF
--- a/packages/apollo/src/index.js
+++ b/packages/apollo/src/index.js
@@ -91,7 +91,8 @@ export default async function createApolloClient(
       // Extend Transcoder type with rewards field to match remote schema
       const linkTypeDefs = `
         type Reward {
-          rewardTokens: String
+          rewardTokens: String,
+          round: Round
         }
         extend type Transcoder {
           rewards: [Reward]

--- a/packages/explorer/src/components/TranscoderCard/index.js
+++ b/packages/explorer/src/components/TranscoderCard/index.js
@@ -13,6 +13,7 @@ import type { TranscoderCardProps } from './props'
 const TranscoderCard: React.ComponentType<TranscoderCardProps> = styled(
   ({
     active,
+    currentRound,
     bonded,
     bondedAmount,
     className,
@@ -31,8 +32,15 @@ const TranscoderCard: React.ComponentType<TranscoderCardProps> = styled(
     let missedCalls: number = 0
     if (rewards) {
       missedCalls = rewards
-        .slice(-30)
-        .filter(reward => reward.rewardTokens === null).length
+        // If transcoder is active and has participated in more than 30 rounds,
+        // slice the last 31 rounds since we're excluding the current round.
+        // Otherwise, slice the last 30
+        .slice(rewards.length > 30 && active ? -31 : -30)
+        .filter(
+          reward =>
+            reward.rewardTokens === null &&
+            reward.round.id !== currentRound.data.id,
+        ).length
     }
     return (
       <div className={className}>

--- a/packages/explorer/src/views/Transcoders/enhance.js
+++ b/packages/explorer/src/views/Transcoders/enhance.js
@@ -33,6 +33,9 @@ const MeDelegatorTranscoderQuery = gql`
     pendingPricePerSegment
     rewards {
       rewardTokens
+      round {
+        id
+      }
     }
   }
 
@@ -88,6 +91,9 @@ const TranscodersQuery = gql`
     totalStake
     rewards {
       rewardTokens
+      round {
+        id
+      }
     }
   }
 

--- a/packages/explorer/src/views/Transcoders/index.js
+++ b/packages/explorer/src/views/Transcoders/index.js
@@ -32,6 +32,7 @@ type TranscodersViewProps = {
  */
 const TranscodersView: React.ComponentType<TranscodersViewProps> = ({
   bond,
+  currentRound,
   history,
   match,
   me,
@@ -200,6 +201,7 @@ const TranscodersView: React.ComponentType<TranscodersViewProps> = ({
           return (
             <TranscoderCard
               {...props}
+              currentRound={currentRound}
               numActive={numActive}
               key={id}
               bonded={isMyDelegate}


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes an issue where the current round would count towards a transcoder's missed reward call total. 

**Specific updates (required)**
- Filters out the current round before calculating a transcoder's missed reward call total.
- Checks to see if a transcoder is active and has participated in more than 30 rounds and if so grabs its last 31 participated rounds before filtering out the current round and calculating the missed reward call total.

**How did you test each of these updates (required)**
Ran the explorer locally. Will need an active transcoder to confirm fix.

**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
