### PR TITLE
Fix / Remove getDelegatorStake function

### DIFF
--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -68,7 +68,6 @@ The following section details the rpc API's function signatures and typedefs.
     -   [getFaucetInfo](#getfaucetinfo)
     -   [getBroadcaster](#getbroadcaster)
     -   [getDelegatorStatus](#getdelegatorstatus)
-    -   [getDelegatorStake](#getdelegatorstake)
     -   [getDelegator](#getdelegator)
     -   [getTranscoderIsActive](#gettranscoderisactive)
     -   [getTranscoderStatus](#gettranscoderstatus)
@@ -358,23 +357,6 @@ The delegator status of the given address
 ```javascript
 await rpc.getDelegatorStatus('0xf00...')
 // => 'Pending' | 'Bonded' | 'Unbonding' | 'Unbonded'
-```
-
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
-
-#### getDelegatorStake
-
-The delegator's stake
-
-**Parameters**
-
--   `addr` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** user's ETH address
-
-**Examples**
-
-```javascript
-await rpc.getDelegatorStake('0xf00...')
-// => string
 ```
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -91,7 +91,6 @@ The following section details the rpc API's function signatures and typedefs.
   - [getInflationChange](#getinflationchange)
   - [getBroadcaster](#getbroadcaster)
   - [getDelegatorStatus](#getdelegatorstatus)
-  - [getDelegatorStake](#getdelegatorstake)
   - [getDelegator](#getdelegator)
   - [getTranscoderIsActive](#gettranscoderisactive)
   - [getTranscoderStatus](#gettranscoderstatus)
@@ -545,23 +544,6 @@ The delegator status of the given address
 ```javascript
 await rpc.getDelegatorStatus('0xf00...')
 // => 'Pending' | 'Bonded' | 'Unbonded'
-```
-
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>**
-
-#### getDelegatorStake
-
-The delegator's stake
-
-**Parameters**
-
-- `addr` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** user's ETH address
-
-**Examples**
-
-```javascript
-await rpc.getDelegatorStake('0xf00...')
-// => string
 ```
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>**
@@ -1070,11 +1052,7 @@ method.
 **Examples**
 
 ```javascript
-await rpc.estimateGas(
- 'BondingManager',
- 'bond',
- [10, '0x00.....']
-)
+await rpc.estimateGas('BondingManager', 'bond', [10, '0x00.....'])
 // => 33454
 ```
 

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -175,8 +175,8 @@ export const utils = {
               [k]: Array.isArray(v)
                 ? v.map(_v => (BN.isBN(_v) ? toString(_v) : _v))
                 : BN.isBN(v)
-                  ? toString(v)
-                  : v,
+                ? toString(v)
+                : v,
             }
           },
           {},
@@ -250,11 +250,10 @@ export const utils = {
   serializeTranscodingProfiles: names => {
     return [
       ...new Set( // dedupe profiles
-        names.map(
-          x =>
-            VIDEO_PROFILES[x]
-              ? VIDEO_PROFILES[x].hash
-              : VIDEO_PROFILES.P240p30fps4x3.hash,
+        names.map(x =>
+          VIDEO_PROFILES[x]
+            ? VIDEO_PROFILES[x].hash
+            : VIDEO_PROFILES.P240p30fps4x3.hash,
         ),
       ),
     ].join('')
@@ -383,18 +382,18 @@ export async function initRPC({
     'object' === typeof provider && provider
       ? provider
       : usePrivateKeys
-        ? // Use provider-signer to locally sign transactions
-          new SignerProvider(provider, {
-            signTransaction: (rawTx, cb) => {
-              const tx = new EthereumTx(rawTx)
-              tx.sign(privateKeys[from])
-              cb(null, '0x' + tx.serialize().toString('hex'))
-            },
-            accounts: cb => cb(null, accounts),
-            timeout: 10 * 1000,
-          })
-        : // Use default signer
-          new Eth.HttpProvider(provider || DEFAULTS.provider)
+      ? // Use provider-signer to locally sign transactions
+        new SignerProvider(provider, {
+          signTransaction: (rawTx, cb) => {
+            const tx = new EthereumTx(rawTx)
+            tx.sign(privateKeys[from])
+            cb(null, '0x' + tx.serialize().toString('hex'))
+          },
+          accounts: cb => cb(null, accounts),
+          timeout: 10 * 1000,
+        })
+      : // Use default signer
+        new Eth.HttpProvider(provider || DEFAULTS.provider)
   const eth = new Eth(ethjsProvider)
   const ens = new ENS({
     provider: eth.currentProvider,
@@ -491,12 +490,14 @@ export async function initContracts(
   // Create a list of events in each contract
   const events = Object.entries(abis)
     .map(([contract, abi]) => {
-      return abi.filter(x => x.type === 'event').map(abi => ({
-        abi,
-        contract,
-        event: contracts[contract][abi.name],
-        name: abi.name,
-      }))
+      return abi
+        .filter(x => x.type === 'event')
+        .map(abi => ({
+          abi,
+          contract,
+          event: contracts[contract][abi.name],
+          name: abi.name,
+        }))
     })
     .reduce(
       (a, b) =>
@@ -1056,25 +1057,6 @@ export async function createLivepeerSDK(
         ),
       )
       return DELEGATOR_STATUS[status]
-    },
-
-    /**
-     * The delegator's stake
-     * @memberof livepeer~rpc
-     * @param  {string} addr - user's ETH address
-     * @return {Promise<string>}
-     *
-     * @example
-     *
-     * await rpc.getDelegatorStake('0xf00...')
-     * // => string
-     */
-    async getDelegatorStake(addr: string): Promise<string> {
-      return headToString(
-        await BondingManager.delegatorStake(
-          await resolveAddress(rpc.getENSAddress, addr),
-        ),
-      )
     },
 
     /**


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Remove getDelegatorStake function from SDK. The function is exposed through the rpc and doesn't exist. 

**Specific updates (required)**
- Remove function from the file docs/sdk/README.md
- Remove function from the file packages/sdk/README.md
- Remove function from the file packages/sdk/src/index.js
- Apply lint and fix some existing problems

**How did you test each of these updates (required)**
- Install the package locally using `npm link`
- Integrate the SDK in some example and expose the functions of the rpc
- The function getDelegatorStake should not exist
- In the readme file of the SDK, the function getDelegatorStake should not exist

**Does this pull request close any open issues?**
None

**Screenshots (optional):**
The error:
![screenshot_20190103_144520](https://user-images.githubusercontent.com/1144028/50653696-2946cf80-0f69-11e9-8f18-4ffa0793f6df.png)
The rpc functions exposed:
![screenshot_20190103_142547](https://user-images.githubusercontent.com/1144028/50653709-34016480-0f69-11e9-8703-20cd9e5fedf9.png)
Without the function getDelegatorStake:
![screenshot_20190103_143449](https://user-images.githubusercontent.com/1144028/50653707-31067400-0f69-11e9-8a7f-423035cd780e.png)


**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
