### PR TITLE
sdk: fix inconsistent return type of getJob()

### DIFF
--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1733,10 +1733,12 @@ export async function createLivepeerSDK(
         x.transcoderAddress === EMPTY_ADDRESS
       ) {
         const { hash } = await rpc.getBlock(x.creationBlock)
-        x.transcoderAddress = await BondingManager.electActiveTranscoder(
-          x.maxPricePerSegment,
-          hash,
-          x.creationRound,
+        x.transcoderAddress = headToString(
+          await BondingManager.electActiveTranscoder(
+            x.maxPricePerSegment,
+            hash,
+            x.creationRound,
+          ),
         )
       }
       return {

--- a/packages/sdk/src/index.test.js
+++ b/packages/sdk/src/index.test.js
@@ -30,7 +30,7 @@ const oneOf = x => yup.mixed().oneOf(x)
 
 let livepeer
 
-test.before(async t => {
+test.beforeEach(async t => {
   // create new sdk instance before each test
   livepeer = await Livepeer()
 })
@@ -334,10 +334,10 @@ test('should return object with correct shape from getJob()', async t => {
     broadcaster: string,
   })
   const res = await livepeer.rpc.getJobs()
-  res.forEach(async x => {
+  for (const x of res) {
     const job = await livepeer.rpc.getJob(x.id)
     schema.validateSync(job)
-  })
+  }
   t.pass()
 })
 
@@ -364,7 +364,7 @@ test('should return number that signifies the estimated amount of gas to be used
       methodArgs: [],
     },
   ]
-  cases.forEach(async x => {
+  for (const x of cases) {
     const res = await livepeer.rpc.estimateGas(
       x.contractName,
       x.methodName,
@@ -372,7 +372,7 @@ test('should return number that signifies the estimated amount of gas to be used
     )
     t.true(number.isValidSync(res))
     t.true(res > 0)
-  })
+  }
   t.pass()
 })
 


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
Fixes #319 and makes the shape of jobs returned by `getJob` consistent

**Specific updates (required)**
* Fixes some async handling in the sdk tests
* Fixes the now-consistent test failure in getJob

**How did you test each of these updates (required)**
To the best of my knowledge, I don't believe this `transcoderAddress` field is yet used anywhere — there are no references outside of the `sdk` and `subgraph` projects.

**Does this pull request close any open issues?**
#319