### PR TITLE
update development ports for explorer and player

### DIFF
--- a/packages/explorer/package.json
+++ b/packages/explorer/package.json
@@ -55,7 +55,7 @@
     "eject": "npx react-scripts eject",
     "postbuild": "cp build/index.html build/404.html",
     "serve": "npx serve -s build",
-    "start": "npx react-scripts start",
+    "start": "PORT=3001 react-scripts start",
     "test": "npx react-scripts test"
   },
   "build": {

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -28,7 +28,7 @@
     "styled-components": "3.2.1"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=3002 react-scripts start",
     "build": "react-scripts build",
     "copy-docs": "echo 'No copy-docs script specified'",
     "eject": "react-scripts eject",


### PR DESCRIPTION
I wanna be able to run them both at once without them bouncing around
between different ports. I went with 3001 and 3002 'cause 3000 is also used for
the stats interface in the test harness. Any objections?