### PR TITLE
fix: rounding error in formatBalance

### DIFF
--- a/packages/explorer/src/utils.js
+++ b/packages/explorer/src/utils.js
@@ -90,12 +90,11 @@ export function formatBalance(
   decimals = decimals ? decimals : unitMap[unit].length
   return !x
     ? '0'
-    : parseFloat(
-        Big(x)
-          .div(unitMap[unit])
-          .toFixed(decimals)
-          .replace(/([0-9]+(\.[0-9]+[1-9])?)(\.?0+$)/, '$1'),
-      ).toString()
+    : Big(x)
+        .div(unitMap[unit])
+        .toFixed(decimals)
+        // Remove trailing zeroes
+        .replace(/([0-9]+(\.[0-9]+[1-9])?)(\.?0+$)/, '$1')
 }
 
 export function formatRoundsToDate(round: number): string {

--- a/packages/explorer/src/utils.test.js
+++ b/packages/explorer/src/utils.test.js
@@ -1,0 +1,16 @@
+import { formatBalance } from './utils'
+
+describe('formatBalance', () => {
+  it('should handle numbers with <= 18 decimals', () => {
+    const cases = [
+      ['19555555555555555555', '19.555555555555555555'],
+      ['19555550000000000000', '19.55555'],
+      ['13000000000000000000', '13'],
+      ['00000000000000000000000001', '0.000000000000000001'],
+      ['999999999999999999', '0.999999999999999999'],
+    ]
+    for (const [input, expected] of cases) {
+      expect(formatBalance(input)).toEqual(expected)
+    }
+  })
+})


### PR DESCRIPTION
The `parseFloat` was truncating data beyond 53 bits. This removes it and
data appears to be rendering correctly again. Added tests for that too.

I'm hoping this was the root cause of #338, #336, and #334.

<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
Removes a `parseFloat` that was truncating balance display.

**Specific updates (required)**
- That.

**How did you test each of these updates (required)**
Added tests for various high-precision float cases. Looked at a lot of balances in the UI. They look okay.

**Does this pull request close any open issues?**
I hope #338, #336, and #334.

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
