### PR TITLE
feat: use GraphQL for round initialization and estimate gas

### DIFF
--- a/packages/explorer/src/enhancers/index.js
+++ b/packages/explorer/src/enhancers/index.js
@@ -171,6 +171,17 @@ export const connectRebondFromUnbondedMutation = graphql(
   },
 )
 
+export const connectInitializeRoundMutation = graphql(
+  gql`
+    mutation initializeRound {
+      initializeRound
+    }
+  `,
+  {
+    name: 'initializeRound',
+  },
+)
+
 const CoinbaseQuery = gql`
   query CoinbaseQuery {
     coinbase

--- a/packages/explorer/src/views/ProtocolStatus/enhance.js
+++ b/packages/explorer/src/views/ProtocolStatus/enhance.js
@@ -4,10 +4,11 @@ import {
   connectCurrentBlockQuery,
   connectCurrentRoundQuery,
   connectToasts,
+  connectInitializeRoundMutation,
 } from '../../enhancers'
 
 const mapMutationHandlers = withHandlers({
-  initializeRound: ({ toasts }) => async () => {
+  initializeRound: ({ toasts, initializeRound }) => async () => {
     try {
       toasts.push({
         id: 'initialize-round',
@@ -15,7 +16,7 @@ const mapMutationHandlers = withHandlers({
         body: 'The current round is being initialized.',
       })
       // TODO: move into graphql schema as mutation
-      await window.livepeer.rpc.initializeRound({ gas: 3200000 })
+      await initializeRound()
       toasts.push({
         id: 'initialize-round',
         type: 'success',
@@ -42,5 +43,6 @@ export default compose(
   connectCurrentBlockQuery,
   connectCurrentRoundQuery,
   connectToasts,
+  connectInitializeRoundMutation,
   mapMutationHandlers,
 )

--- a/packages/explorer/src/views/ProtocolStatus/enhance.js
+++ b/packages/explorer/src/views/ProtocolStatus/enhance.js
@@ -15,7 +15,6 @@ const mapMutationHandlers = withHandlers({
         title: 'Initializing round...',
         body: 'The current round is being initialized.',
       })
-      // TODO: move into graphql schema as mutation
       await initializeRound()
       toasts.push({
         id: 'initialize-round',

--- a/packages/graphql-sdk/schema.json
+++ b/packages/graphql-sdk/schema.json
@@ -2458,6 +2458,18 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "initializeRound",
+              "description": "Submits a round initialization transaction",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/packages/graphql-sdk/src/resolvers/Mutation.js
+++ b/packages/graphql-sdk/src/resolvers/Mutation.js
@@ -215,3 +215,23 @@ export async function rebondFromUnbonded(
     gas: gas,
   })
 }
+
+/**
+ * Submits a round initialization transaction
+ * @param {MutationObj} obj
+ * @return {Promise<TxReceipt>}
+ */
+export async function initializeRound(
+  obj: MutationObj,
+  args,
+  ctx: GQLContext,
+): Promise<TxReceipt> {
+  const gas = await ctx.livepeer.rpc.estimateGas(
+    'RoundsManager',
+    'initializeRound',
+    [],
+  )
+  return await ctx.livepeer.rpc.initializeRound({
+    gas,
+  })
+}

--- a/packages/graphql-sdk/src/types/Mutation.js
+++ b/packages/graphql-sdk/src/types/Mutation.js
@@ -24,6 +24,9 @@ type Mutation {
   "Rebond tokens for an unbonding lock to a delegate while a delegator is in the Unbonded state "
   rebondFromUnbonded(delegate: String!, unbondingLockId: Int!): JSON
 
+  "Submits a round initialization transaction"
+  initializeRound: JSON
+
 }`
 
 export default () => [Mutation]

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1995,7 +1995,6 @@ export async function createLivepeerSDK(
           await config.eth.estimateGas({
             to: config.contracts[contractName].address,
             from: config.defaultTx.from,
-            gas: config.defaultTx.gas,
             value: tx.value,
             data: encodedData,
           }),


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
Moves the round initialization logic into a GraphQL mutation

**Specific updates (required)**
- Introduce a new GraphQL mutation, initializeRound
- Use it in the explorer
- I had to remove one line in `estimateGas`, which was capping the amount of gas that was used to estimate the amount of gas necessary. Defeated the purpose. [It appears to be an optimal property for the estimateGas call](https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethestimategas).

**How did you test each of these updates (required)**
Initialized rounds in Rinkeby.

**Does this pull request close any open issues?**
Fixes #339 

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
