### PR TITLE
allow user to bail from transfer prompt loop

### DIFF
--- a/packages/explorer/src/utils.js
+++ b/packages/explorer/src/utils.js
@@ -126,6 +126,7 @@ export function promptForArgs(
   const args = []
   for (const prompt of prompts) {
     const val = window.prompt(prompt.ask)
+    if (!val) break
     args.push(prompt.format ? prompt.format(val) : val)
   }
   return args


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
In the explorer, the user is unable to bail from the transfer prompts when they click cancel.  This pull request enables the cancel button to allow the user to bail from the prompt loop.

Steps to reproduce the bug:

Click transfer:
![image](https://user-images.githubusercontent.com/2081699/53688861-861bf780-3d18-11e9-93bc-6189ebe9968e.png)

In the prompt, click Cancel:
![image](https://user-images.githubusercontent.com/2081699/53688869-97fd9a80-3d18-11e9-957b-e0b30c5c2085.png)

You'll then have to click cancel on the next prompt until you can click OK in the final prompt:
![image](https://user-images.githubusercontent.com/2081699/53688877-b2377880-3d18-11e9-8280-9cddbca62ee5.png)


This pull request fixes that issue by breaking the user from the prompt loop upon clicking Cancel.

**Specific updates (required)**
- Checks if the user has clicked `Cancel` in their transfer prompt (this returns null).
-  If the value of the user's response is null (they clicked Cancel) break from the prompt loop. 

**How did you test each of these updates (required)**
After making my change to the promptForArgs function, I clicked the Transfer button in the explorer and checked if I could bail from the prompt loop from clicking cancel.  I then checked if I could enter values and continue to each prompt in the loop.

Sidenote:  There seems to be a separate issue on the live site where the transfer prompt adds zeros to my value.

I wrote 1 LPT as the value to transfer (I have zero LPT unbonded) and this was what the final prompt said:

![image](https://user-images.githubusercontent.com/2081699/53688951-b3b57080-3d19-11e9-976f-7a5ee28f00d9.png)


**Checklist:**
- [X] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
