### PR TITLE
Widen the bonding modal

### DIFF
--- a/packages/explorer/src/components/BasicModal.js
+++ b/packages/explorer/src/components/BasicModal.js
@@ -23,7 +23,7 @@ const BasicModal = ({ title, children, onOpen, onClose }) => {
             display: 'block',
             margin: 'auto',
             padding: 24,
-            width: 440,
+            width: 600,
           }}
           onClick={e => e.stopPropagation()}
         >

--- a/packages/explorer/src/components/BondForm/index.js
+++ b/packages/explorer/src/components/BondForm/index.js
@@ -7,7 +7,7 @@ import { withProp } from '../../enhancers'
 import { formatBalance, toBaseUnit, MathBN } from '../../utils'
 import InlineAccount from '../InlineAccount'
 import InlineHint from '../InlineHint'
-import Button from '../Button'
+import Button, { EditButton } from '../Button'
 import { H1 } from '../HTags'
 import type { BondFormProps } from './props'
 
@@ -139,9 +139,9 @@ const BondForm: React.StatelessFunctionalComponent<BondFormProps> = ({
           <p>Your Transfer Allowance</p>
           <p style={{ fontWeight: 400, marginBottom: 0 }}>
             {formatBalance(allowance)} LPT&nbsp;
-            <Button onClick={onUpdateAllowance} style={{ marginTop: 0 }}>
+            <EditButton onClick={onUpdateAllowance} style={{ marginTop: 0 }}>
               Edit
-            </Button>
+            </EditButton>
           </p>
         </div>
       </div>

--- a/packages/explorer/src/components/Button.js
+++ b/packages/explorer/src/components/Button.js
@@ -42,4 +42,12 @@ const Button = styled.button`
   }
 `
 
+export const EditButton = styled(Button)`
+  margin-top: 0px;
+  width: 100%;
+  text-align: center;
+  justify-content: center;
+  margin-left: 0;
+`
+
 export default Button

--- a/packages/explorer/src/components/Button.js
+++ b/packages/explorer/src/components/Button.js
@@ -43,11 +43,11 @@ const Button = styled.button`
 `
 
 export const EditButton = styled(Button)`
-  margin-top: 0px;
+  margin-top: 0;
+  margin-left: 0;
   width: 100%;
   text-align: center;
   justify-content: center;
-  margin-left: 0;
 `
 
 export default Button


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Addresses #346 by increasing the bonding modal width to 600px from 440px.
This allows for significantly more digits in the LPT amount to read on one line, including the full 18-decimal.

I've also made a styled EditButton that I subjectively think ties this change together nicely design-wise, but feel free to offer feedback.

**Specific updates (required)**
- Make BasicModal 600px wide (from 440px)
- Make a new EditButton that extends the styles of Button with these styles:
```
  margin-top: 0;
  margin-left: 0;
  width: 100%;
  text-align: center;
  justify-content: center;
```

**How did you test each of these updates (required)**
I forced large LPT amounts with 18-decimal LPT to be visible in the modal and visually tested if it was wider enough to read on one line.

**Does this pull request close any open issues?**
#346 

**Screenshots (optional):**
<!-- Drag some screenshots here, if applicable -->
![image](https://user-images.githubusercontent.com/2081699/53689200-35a79880-3d1e-11e9-8fa6-dcbaff747136.png)


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
