### PR TITLE
fix(explorer): use thegraph hosted subgraph

### DIFF
--- a/packages/explorer/.env.development
+++ b/packages/explorer/.env.development
@@ -3,8 +3,7 @@ REACT_APP_MAINNET_CONTROLLER_ADDRESS=0xf96d54e490317c557a967abfa5d6e33006be69b3
 REACT_APP_RINKEBY_CONTROLLER_ADDRESS=0x37dC71366Ec655093b9930bc816E16e6b587F968
 
 # If you're running the graph node locally set REACT_APP_LIVEPEER_SUBGRAPH to http://localhost:8000/subgraphs/name/livepeer/graphql.
-# Otherwise, you can set it to the public Livepeer subgraph at https://thegraph.livepeer.org/subgraphs/name/livepeer/graphql.
-REACT_APP_LIVEPEER_SUBGRAPH=
+REACT_APP_LIVEPEER_SUBGRAPH=https://api.thegraph.com/subgraphs/name/graphprotocol/livepeer
 
 ## Miner depends of these vars
 REACT_APP_LAMBDA_API=

--- a/packages/explorer/.env.production
+++ b/packages/explorer/.env.production
@@ -2,9 +2,7 @@ REACT_APP_HTTP_PROVIDER=
 REACT_APP_GA_TRACKING_ID=UA-111259858-1
 REACT_APP_MAINNET_CONTROLLER_ADDRESS=0xf96d54e490317c557a967abfa5d6e33006be69b3
 REACT_APP_RINKEBY_CONTROLLER_ADDRESS=0x37dC71366Ec655093b9930bc816E16e6b587F968
-# This is set in CircleCI
-# Uncomment and set this in the event you want to build and deploy manually
-# REACT_APP_LIVEPEER_SUBGRAPH=
+REACT_APP_LIVEPEER_SUBGRAPH=https://api.thegraph.com/subgraphs/name/graphprotocol/livepeer
 
 ## Miner depends of these vars
 REACT_APP_LAMBDA_API=


### PR DESCRIPTION
There doesn't seem to be much of a reason to set this in CircleCI — it's
not a secret or anything. Let's just put the default here instead.

I deleted the variable from CircleCI.

Works around #364