### PR TITLE
Fix missed reward call totals

### DIFF
--- a/packages/explorer/src/components/TranscoderCard/index.js
+++ b/packages/explorer/src/components/TranscoderCard/index.js
@@ -31,6 +31,7 @@ const TranscoderCard: React.ComponentType<TranscoderCardProps> = styled(
   }) => {
     let missedCalls: number = 0
     if (rewards) {
+      console.log('hiii', currentRound.data.id)
       missedCalls = rewards
         // If transcoder is active and has participated in more than 30 rounds,
         // slice the last 31 rounds since we're excluding the current round.
@@ -39,6 +40,7 @@ const TranscoderCard: React.ComponentType<TranscoderCardProps> = styled(
         .filter(
           reward =>
             reward.rewardTokens === null &&
+            reward.round.id >= currentRound.data.id - 30 &&
             reward.round.id !== currentRound.data.id,
         ).length
     }

--- a/packages/explorer/src/components/TranscoderCard/index.js
+++ b/packages/explorer/src/components/TranscoderCard/index.js
@@ -32,10 +32,7 @@ const TranscoderCard: React.ComponentType<TranscoderCardProps> = styled(
     let missedCalls: number = 0
     if (rewards) {
       missedCalls = rewards
-        // If transcoder is active and has participated in more than 30 rounds,
-        // slice the last 31 rounds since we're excluding the current round.
-        // Otherwise, slice the last 30
-        .slice(rewards.length > 30 && active ? -31 : -30)
+        .sort((a, b) => b.round.id - a.round.id)
         .filter(
           reward =>
             reward.rewardTokens === null &&

--- a/packages/explorer/src/components/TranscoderCard/index.js
+++ b/packages/explorer/src/components/TranscoderCard/index.js
@@ -31,7 +31,6 @@ const TranscoderCard: React.ComponentType<TranscoderCardProps> = styled(
   }) => {
     let missedCalls: number = 0
     if (rewards) {
-      console.log('hiii', currentRound.data.id)
       missedCalls = rewards
         // If transcoder is active and has participated in more than 30 rounds,
         // slice the last 31 rounds since we're excluding the current round.


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Replacing the subgraph API endpoint with The Graph's fixed the stability issue we were experiencing with our self-hosted graph node yesterday, but introduced some skewed missed reward call totals due to a slight discrepancy in the data returned by The Graph's hosted subgraph and our own (round numbers were no longer getting returned in ascending order). This fix accounts for that discrepancy and fixes those inaccurate missed reward call totals.

**Specific updates (required)**
- Ensures that only the past 30 rounds are used to calculate a transcoder's total missed reward calls.

**How did you test each of these updates (required)**
Cross-referenced the transcoders' missed reward calls with what I'm seeing in the Livepeer subgraph. 

**Does this pull request close any open issues?**
#364 

**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
