### PR TITLE
fix(apollo): fix transcoders view when on rinkeby

### DIFF
--- a/packages/apollo/src/index.js
+++ b/packages/apollo/src/index.js
@@ -94,8 +94,27 @@ export default async function createApolloClient(
           rewardTokens: String,
           round: Round
         }
+        enum Transcoder_orderBy {
+          id
+          active
+          ensName
+          status
+          lastRewardRound
+          rewardCut
+          feeShare
+          pricePerSegment
+          pendingRewardCut
+          pendingFeeShare
+          pendingPricePerSegment
+          totalStake
+          rewards
+        }
+        enum OrderDirection {
+          asc
+          desc
+        }
         extend type Transcoder {
-          rewards: [Reward]
+          rewards(orderBy: Transcoder_orderBy, orderDirection: OrderDirection): [Reward]
         }
       `
       return mergeSchemas({


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes an issue that prevents the transcoders view from loading when switching to the Rinkeby network (as reported by Rayj on Discord). This issue was introduced recently when we added `orderBy` & `orderDirection` arguments to the `rewards` query. Since these arguments only exist on the subgraph schema and the explorer doesn't use the subgraph while on rinkeby, we have to make sure to extend the local schema with these same arguments otherwise the query won't resolve. That's what this PR does.

**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
