### PR TITLE
fix(explorer): use UnbondingForm in Account view

### DIFF
--- a/packages/explorer/src/views/Account/enhance.js
+++ b/packages/explorer/src/views/Account/enhance.js
@@ -133,7 +133,9 @@ const mapMutationHandlers = withHandlers({
     }
     history.push(`#/bond/${id}`)
   },
-  unbond: ({ currentRound, me, protocol, toasts }) => async ({ id }) => {
+  unbond: ({ currentRound, history, me, protocol, toasts }) => async ({
+    id,
+  }) => {
     try {
       const { id: lastInitializedRound } = currentRound.data
       const { status, lastClaimRound } = me.data.delegator
@@ -158,13 +160,7 @@ const mapMutationHandlers = withHandlers({
           body: `You have unclaimed earnings from more than ${maxEarningsClaimsRounds} previous rounds.`,
         })
       }
-      await window.livepeer.rpc.unbond()
-      toasts.push({
-        id: 'unbond',
-        type: 'success',
-        title: 'Unbonding Complete',
-        body: `Successfully unbonded from ${id}`,
-      })
+      history.push(`#/unbond/${id}`)
     } catch (err) {
       if (!/User denied/.test(err.message)) {
         toasts.push({

--- a/packages/graphql-sdk/src/resolvers/Mutation.js
+++ b/packages/graphql-sdk/src/resolvers/Mutation.js
@@ -161,13 +161,9 @@ export async function unbond(
   ctx: GQLContext,
 ): Promise<TxReceipt> {
   const { amount } = args
-  const gas = await ctx.livepeer.rpc.estimateGas('BondingManager', 'unbond', [
-    amount,
-  ])
 
   return await ctx.livepeer.rpc.unbond(amount, {
     ...ctx.livepeer.config.defaultTx,
-    gas: gas,
   })
 }
 

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -175,8 +175,8 @@ export const utils = {
               [k]: Array.isArray(v)
                 ? v.map(_v => (BN.isBN(_v) ? toString(_v) : _v))
                 : BN.isBN(v)
-                  ? toString(v)
-                  : v,
+                ? toString(v)
+                : v,
             }
           },
           {},
@@ -250,11 +250,10 @@ export const utils = {
   serializeTranscodingProfiles: names => {
     return [
       ...new Set( // dedupe profiles
-        names.map(
-          x =>
-            VIDEO_PROFILES[x]
-              ? VIDEO_PROFILES[x].hash
-              : VIDEO_PROFILES.P240p30fps4x3.hash,
+        names.map(x =>
+          VIDEO_PROFILES[x]
+            ? VIDEO_PROFILES[x].hash
+            : VIDEO_PROFILES.P240p30fps4x3.hash,
         ),
       ),
     ].join('')
@@ -383,18 +382,18 @@ export async function initRPC({
     'object' === typeof provider && provider
       ? provider
       : usePrivateKeys
-        ? // Use provider-signer to locally sign transactions
-          new SignerProvider(provider, {
-            signTransaction: (rawTx, cb) => {
-              const tx = new EthereumTx(rawTx)
-              tx.sign(privateKeys[from])
-              cb(null, '0x' + tx.serialize().toString('hex'))
-            },
-            accounts: cb => cb(null, accounts),
-            timeout: 10 * 1000,
-          })
-        : // Use default signer
-          new Eth.HttpProvider(provider || DEFAULTS.provider)
+      ? // Use provider-signer to locally sign transactions
+        new SignerProvider(provider, {
+          signTransaction: (rawTx, cb) => {
+            const tx = new EthereumTx(rawTx)
+            tx.sign(privateKeys[from])
+            cb(null, '0x' + tx.serialize().toString('hex'))
+          },
+          accounts: cb => cb(null, accounts),
+          timeout: 10 * 1000,
+        })
+      : // Use default signer
+        new Eth.HttpProvider(provider || DEFAULTS.provider)
   const eth = new Eth(ethjsProvider)
   const ens = new ENS({
     provider: eth.currentProvider,
@@ -491,12 +490,14 @@ export async function initContracts(
   // Create a list of events in each contract
   const events = Object.entries(abis)
     .map(([contract, abi]) => {
-      return abi.filter(x => x.type === 'event').map(abi => ({
-        abi,
-        contract,
-        event: contracts[contract][abi.name],
-        name: abi.name,
-      }))
+      return abi
+        .filter(x => x.type === 'event')
+        .map(abi => ({
+          abi,
+          contract,
+          event: contracts[contract][abi.name],
+          name: abi.name,
+        }))
     })
     .reduce(
       (a, b) =>
@@ -2041,23 +2042,29 @@ export async function createLivepeerSDK(
           ? bondedAmount
           : pendingStake
       // Only unbond if amount doesn't exceed your current stake
-      if (toBN(totalStake).cmp(toBN(amount)) >= 0) {
-        // Unbond total stake if a zero or negative amount is passed
-        amount = amount <= 0 ? totalStake : amount
-        // Can only unbond successfully when not already "Unbonded"
-        if (status === DELEGATOR_STATUS.Unbonded) {
-          throw new Error('This account is already unbonded.')
-        } else {
-          return await utils.getTxReceipt(
-            await BondingManager.unbond(amount),
-            config.eth,
-          )
-        }
-      } else {
+      if (toBN(totalStake).cmp(toBN(amount)) < 0) {
         throw new Error(
           `Cannot unbond a portion of tokens greater than your total stake of ${totalStake} LPT`,
         )
       }
+
+      // Unbond total stake if a zero or negative amount is passed
+      amount = amount <= 0 ? totalStake : amount
+
+      // Can only unbond successfully when not already "Unbonded"
+      if (status === DELEGATOR_STATUS.Unbonded) {
+        throw new Error('This account is already unbonded.')
+      }
+
+      tx.gas = await rpc.estimateGas('BondingManager', 'unbond', [amount])
+
+      return await utils.getTxReceipt(
+        await BondingManager.unbond(amount, {
+          ...config.defaultTx,
+          ...tx,
+        }),
+        config.eth,
+      )
     },
 
     /**


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
<!-- A clear and concise description of what this pull request does. -->

Resolves the `Cannot read property "toString()" of undefined error` described in [this comment](https://github.com/livepeer/livepeerjs/issues/360#issuecomment-489392439). Currently, we [directly call the unbond SDK method](https://github.com/livepeer/livepeerjs/blob/master/packages/explorer/src/views/Account/enhance.js#L161) when unbonding from the Account view, but there is no value provided for the `amount` parameter. As a result, an error is thrown when we pass [undefined into the contract call](https://github.com/livepeer/livepeerjs/blob/master/packages/sdk/src/index.js#L2052). This PR also changes the Account view so the UnbondingForm is popped up when the unbond button is clicked (which is what happens when a user clicks the unbond button in the Transcoders view).

Resolves issue where if the user leaves the amount field as 0 when unbonding, gas estimation will throw an error despite the UI telling the user that leaving the amount field as 0 will unbond the user's entire bonded amount. Currently, the pre-processing for using the user's entire bonded amount when the user provides an amount of 0 occurs [in the unbond SDK method](https://github.com/livepeer/livepeerjs/blob/master/packages/sdk/src/index.js#L2046). However, gas estimation is executed in the [GraphQL package prior to this pre-processing step](https://github.com/livepeer/livepeerjs/blob/master/packages/graphql-sdk/src/resolvers/Mutation.js#L164). As a result, if the user provides an amount of 0, gas estimation will be executed with an amount of 0 which would result in a transaction that always fails because the contract will revert if the user tries to unbond with an amount of 0.

Longer term we might want to move gas estimation for other transactions into their corresponding SDK methods as well so that gas estimation can always happen after pre-processing that might be necessary for the particular transaction.

**Specific updates (required)**
<!--- List out all significant updates your code introduces -->
- Pop up UnbondingForm when unbonding from Account view by pushing to history
- Move gas estimation to the unbond SDK method after the pre-processing step for the amount field

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

Manual testing

**Does this pull request close any open issues?**
<!-- Fixes # -->

Fixes #360

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
