### PR TITLE
fix issue causing missing transcoders

### DIFF
--- a/packages/explorer/src/enhancers/index.js
+++ b/packages/explorer/src/enhancers/index.js
@@ -449,7 +449,7 @@ export const TranscodersQuery = gql`
   }
 
   query TranscodersQuery {
-    transcoders {
+    transcoders(where: { status: "Registered" }) {
       ...TranscoderFragment
     }
   }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes an issue that caused a couple of transcoders to disappear from the transcoders view. 

**Specific updates (required)**
- Applies a filter to the `transcoders` graphql query so that it only fetches all registered transcoders, so that none of the registered transcoders get left off the first page of results.

**How did you test each of these updates (required)**
Tested locally and confirmed I can now see the missing transcoders.

**Does this pull request close any open issues?**
#434 

**Screenshots (optional):**
Missing transcoders are appearing again while testing locally:
![Screen Shot 2019-07-25 at 10 52 54 AM](https://user-images.githubusercontent.com/555740/61884573-76b96880-aeca-11e9-9c2c-0e381f5d30c8.png)

