### PR TITLE
Feat: API pagination for the streams endpoint

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -9,7 +9,10 @@ import wowzaHydrate from './wowza-hydrate'
 const app = Router()
 
 app.get('/', async (req, res) => {
-  const output = await req.store.list(`stream/`)
+  let limit = req.query.limit
+  let offset = req.query.offset
+
+  const output = await req.store.list(`stream/`, limit, offset)
   res.status(200)
   res.json(output)
 })

--- a/packages/api/src/store/level-store.js
+++ b/packages/api/src/store/level-store.js
@@ -39,7 +39,7 @@ export default class LevelStore {
       filter = {
         gte: prefix,
         lt: endKey,
-        limit,
+        // limit,
       }
     }
     await this.ready
@@ -53,6 +53,11 @@ export default class LevelStore {
     for await (const val of this.listStream(prefix, limit, offset)) {
       ret.push(val)
     }
+
+    if (limit > 0) {
+      ret = ret.slice(offset, offset + limit)
+    }
+
     return ret
   }
 

--- a/packages/api/src/store/level-store.js
+++ b/packages/api/src/store/level-store.js
@@ -1,5 +1,9 @@
 import level from 'level'
 import fs from 'fs-extra'
+
+// default limit value in level is -1 , ref: https://github.com/Level/level#dbcreatereadstreamoptions
+const DEFAULT_LIMIT = -1
+
 export default class LevelStore {
   constructor({ dbPath }) {
     if (!dbPath) {
@@ -22,7 +26,7 @@ export default class LevelStore {
     return this.db.close()
   }
 
-  async *listStream(prefix = '') {
+  async *listStream(prefix = '', limit = DEFAULT_LIMIT, offset = 0) {
     // I do not know if this is the right way to do this, but...
     // if we want every key that starts with "endpoint/", what we're
     // really asking for is ">= 'endpoint/'" and '< 'endpoint0',
@@ -35,6 +39,7 @@ export default class LevelStore {
       filter = {
         gte: prefix,
         lt: endKey,
+        limit,
       }
     }
     await this.ready
@@ -43,9 +48,9 @@ export default class LevelStore {
     }
   }
 
-  async list(prefix = '') {
+  async list(prefix = '', limit = DEFAULT_LIMIT, offset = 0) {
     const ret = []
-    for await (const val of this.listStream(prefix)) {
+    for await (const val of this.listStream(prefix, limit, offset)) {
       ret.push(val)
     }
     return ret

--- a/packages/api/src/store/postgres-store.js
+++ b/packages/api/src/store/postgres-store.js
@@ -7,6 +7,7 @@ import { parse as parseUrl, format as stringifyUrl } from 'url'
 // Should be configurable, perhaps?
 const TABLE_NAME = 'api'
 const CONNECT_TIMEOUT = 5000
+const DEFAULT_LIMIT = 100
 
 export default class PostgresStore {
   constructor({ postgresUrl }) {
@@ -30,10 +31,10 @@ export default class PostgresStore {
     await this.pool.end()
   }
 
-  async list(prefix = '') {
+  async list(prefix = '', limit = DEFAULT_LIMIT, offset = 0) {
     const res = await this.pool.query(
-      `SELECT data FROM ${TABLE_NAME} WHERE id LIKE $1`,
-      [`${prefix}%`],
+      `SELECT data FROM ${TABLE_NAME} WHERE id LIKE $1 LIMIT $2 OFFSET $3`,
+      [`${prefix}%`, `${limit}`, `${offset}`],
     )
     return res.rows.map(({ data }) => data)
   }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
adds `limit` and `offset` capabilities to the API so it won't list the entire list of streams every time. and it can be used for pagination

**Specific updates (required)**
- updates to `leveldb` to use `limit` 
- updates to the `postgresql` to use `limit` and `offset`
- 

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**
<!-- Fixes # -->

**Screenshots (optional):**
<!-- Drag some screenshots here, if applicable -->

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
