### PR TITLE
feat(api): add /api/orchestrator/ext/:token

### DIFF
--- a/packages/api/src/controllers/orchestrator.js
+++ b/packages/api/src/controllers/orchestrator.js
@@ -2,10 +2,13 @@ import { Router } from 'express'
 
 const app = Router()
 
-app.get('/', async (req, res, next) => {
+const getOrchestrators = async (req, res, next) => {
   const orchestrators = await req.getOrchestrators(req)
 
   return res.json(orchestrators.map(({ address }) => ({ address })))
-})
+}
+
+app.get('/', getOrchestrators)
+app.get('/ext/:token', getOrchestrators)
 
 export default app


### PR DESCRIPTION
Add an tokenized external orchestrator endpoint that doesn't do anything yet but will eventually be used to authenticate incoming requests for orchestrators.