### PR TITLE
Adding `SourceStreamName` transcoding settings handling

### DIFF
--- a/packages/api/src/controllers/wowza-hydrate.js
+++ b/packages/api/src/controllers/wowza-hydrate.js
@@ -21,12 +21,12 @@ export default stream => {
   const { transcoderAppConfig, transcoderTemplateAppConfig } = stream.wowza
   const templatesInUse = transcoderAppConfig.templatesInUse.split(',')
   let template
-  // todo fixme xxx: handle the {SourceStreamName} case
   for (let tmpl of templatesInUse) {
+    let tmplName = replaceStreamName(tmpl, stream.name)
     // these all end in .xml
-    tmpl = tmpl.slice(0, tmpl.length - 4)
-    if (transcoderTemplateAppConfig[tmpl] !== undefined) {
-      template = tmpl
+    tmplName = tmplName.slice(0, tmplName.length - 4)
+    if (transcoderTemplateAppConfig[tmplName] !== undefined) {
+      template = tmplName
       break
     }
   }

--- a/packages/api/src/controllers/wowza-hydrate.test-data.json
+++ b/packages/api/src/controllers/wowza-hydrate.test-data.json
@@ -551,6 +551,197 @@
           }
         ]
       },
+      "test_stream": {
+        "name": "test_stream",
+        "encodes": [
+          {
+            "name": "source",
+            "gpuid": 0,
+            "width": 0,
+            "enable": true,
+            "height": 0,
+            "Overlays": [],
+            "interval": 0,
+            "audioCodec": "PassThru",
+            "streamName": "mp4:${SourceStreamName}_source",
+            "videoCodec": "PassThru",
+            "audioBitrate": "${SourceAudioBitrate}",
+            "followSource": false,
+            "videoBitrate": "${SourceVideoBitrate}"
+          },
+          {
+            "name": "360p",
+            "gpuid": -1,
+            "width": 640,
+            "enable": true,
+            "height": 360,
+            "fitMode": "fit-height",
+            "profile": "main",
+            "Overlays": [
+              {
+                "x": 4,
+                "y": 4,
+                "align": "left,top",
+                "index": 0,
+                "width": "${ImageWidth}",
+                "enable": false,
+                "height": "${ImageHeight}",
+                "opacity": 100,
+                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                "overlayName": "WowzaLogo",
+                "checkForUpdates": false
+              }
+            ],
+            "interval": 60,
+            "audioCodec": "PassThru",
+            "streamName": "mp4:${SourceStreamName}_360p",
+            "videoCodec": "H.264",
+            "audioBitrate": "${SourceAudioBitrate}",
+            "followSource": true,
+            "videoBitrate": "850000",
+            "implementation": "default"
+          },
+          {
+            "name": "240p",
+            "gpuid": -1,
+            "width": 360,
+            "enable": true,
+            "height": 240,
+            "fitMode": "fit-height",
+            "profile": "baseline",
+            "Overlays": [
+              {
+                "x": 4,
+                "y": 4,
+                "align": "left,top",
+                "index": 0,
+                "width": "${ImageWidth}",
+                "enable": false,
+                "height": "${ImageHeight}",
+                "opacity": 100,
+                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                "overlayName": "WowzaLogo",
+                "checkForUpdates": false
+              }
+            ],
+            "interval": 60,
+            "audioCodec": "PassThru",
+            "streamName": "mp4:${SourceStreamName}_240p",
+            "videoCodec": "H.264",
+            "audioBitrate": "${SourceAudioBitrate}",
+            "followSource": true,
+            "videoBitrate": "350000",
+            "implementation": "default"
+          },
+          {
+            "name": "h263",
+            "gpuid": -1,
+            "width": 176,
+            "enable": false,
+            "height": 144,
+            "fitMode": "letterbox",
+            "profile": "baseline",
+            "Overlays": [
+              {
+                "x": 4,
+                "y": 4,
+                "align": "left,top",
+                "index": 0,
+                "width": "${ImageWidth}",
+                "enable": false,
+                "height": "${ImageHeight}",
+                "opacity": 100,
+                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                "overlayName": "WowzaLogo",
+                "checkForUpdates": false
+              }
+            ],
+            "interval": 60,
+            "audioCodec": "PassThru",
+            "streamName": "mp4:${SourceStreamName}_h263",
+            "videoCodec": "H.263",
+            "audioBitrate": "${SourceAudioBitrate}",
+            "followSource": false,
+            "videoBitrate": "150000",
+            "implementation": "default"
+          }
+        ],
+        "version": "1541749568000",
+        "overlays": [
+          {
+            "x": 4,
+            "y": 4,
+            "align": "left,top",
+            "index": 0,
+            "width": "${ImageWidth}",
+            "enable": false,
+            "height": "${ImageHeight}",
+            "opacity": 100,
+            "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+            "overlayName": "WowzaLogo",
+            "checkForUpdates": false
+          }
+        ],
+        "deinterlace": false,
+        "description": "Default transrate.xml file",
+        "implementation": "default",
+        "streamNameGroups": [
+          {
+            "name": "all",
+            "Members": [
+              {
+                "encodeName": "source",
+                "memberName": "source",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              },
+              {
+                "encodeName": "720p",
+                "memberName": "720p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              },
+              {
+                "encodeName": "360p",
+                "memberName": "360p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              },
+              {
+                "encodeName": "240p",
+                "memberName": "240p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              },
+              {
+                "encodeName": "160p",
+                "memberName": "160p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              }
+            ],
+            "streamName": "${SourceStreamName}_all"
+          },
+          {
+            "name": "mobile",
+            "Members": [
+              {
+                "encodeName": "240p",
+                "memberName": "240p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              },
+              {
+                "encodeName": "160p",
+                "memberName": "160p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              }
+            ],
+            "streamName": "${SourceStreamName}_mobile"
+          }
+        ]
+      },
       "transcode-h265-divx": {
         "name": "transcode-h265-divx",
         "encodes": [

--- a/packages/api/src/controllers/wowza-hydrate.test.js
+++ b/packages/api/src/controllers/wowza-hydrate.test.js
@@ -4,13 +4,27 @@ const stream = require('./wowza-hydrate.test-data.json')
 describe('wowzaHydrate', () => {
   it('should correctly determine renditions and presets', () => {
     const newStream = wowzaHydrate({ ...stream })
-    expect(newStream.presets).toEqual(['P360p30fps16x9', 'P144p30fps16x9'])
+    expect(newStream.presets).toEqual(['P360p30fps16x9', 'P240p30fps4x3'])
     expect(newStream.renditions).toEqual({
       test_stream_source:
         '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/source.m3u8',
       test_stream_360p:
         '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P360p30fps16x9.m3u8',
-      test_stream_160p:
+      test_stream_240p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P240p30fps4x3.m3u8',
+    })
+  })
+
+  it('should correctly determine renditions and presets with different stream name', () => {
+    stream.name = 'transrate'
+    const newStream = wowzaHydrate({ ...stream })
+    expect(newStream.presets).toEqual(['P360p30fps16x9', 'P144p30fps16x9'])
+    expect(newStream.renditions).toEqual({
+      transrate_source:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/source.m3u8',
+      transrate_360p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P360p30fps16x9.m3u8',
+      transrate_160p:
         '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P144p30fps16x9.m3u8',
     })
   })


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Adding ability to handle SourceStreamName transcoding settings handling. More details here: https://github.com/livepeer/livepeerjs/issues/471

**Specific updates (required)**

- Use `${SourceStreamName}` to select correct transcoding configurations from Wowza stream coming into livepeerJS api

**How did you test each of these updates (required)**
- Locally: `yarn run dev` + `yarn run go-livepeer` +  streaming from OBS to `rtmp://localhost:3035/live `
- Running api tests: `yarn run test:local`

**Does this pull request close any open issues?**
https://github.com/livepeer/livepeerjs/issues/471

**Checklist:**
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
