### PR TITLE
Adding proper handling to incoming width/height 0 from wowza templates

### DIFF
--- a/packages/api/src/controllers/wowza-hydrate.js
+++ b/packages/api/src/controllers/wowza-hydrate.js
@@ -39,7 +39,7 @@ export default stream => {
   const presets = []
   const encodeNameToRenditionName = {}
   for (const encode of enabledEncodes) {
-    const { width, height, name, streamName, videoCodec } = encode
+    let { width, height, name, streamName, videoCodec } = encode
     let renditionName = replaceStreamName(streamName, stream.name)
     // These can be of the form mp4:name, let's ignore the first bit if present
     if (renditionName.includes(':')) {
@@ -50,6 +50,12 @@ export default stream => {
       renditions[renditionName] = `/stream/${stream.id}/source.m3u8`
       continue
     }
+
+    const SIXTEEN_BY_NINE = 16 / 9
+    const NINE_BY_SIXTEEN = 9 / 16
+    if (width === 0) width = height * SIXTEEN_BY_NINE
+    if (height === 0) height = width * NINE_BY_SIXTEEN
+
     const wowzaSize = width * height
     let diff = Infinity
     let foundPreset = null

--- a/packages/api/src/controllers/wowza-hydrate.test-data.json
+++ b/packages/api/src/controllers/wowza-hydrate.test-data.json
@@ -32,7 +32,7 @@
       "profileDir": "${com.wowza.wms.context.VHostConfigHome}/transcoder/profiles",
       "templateDir": "${com.wowza.wms.context.VHostConfigHome}/transcoder/templates",
       "licensesInUse": 0,
-      "templatesInUse": "${SourceStreamName}.xml, transrate.xml",
+      "templatesInUse": "${SourceStreamName}.xml,transrate.xml",
       "createTemplateDir": false,
       "liveStreamTranscoder": "transcoder"
     },

--- a/packages/api/src/controllers/wowza-hydrate.test-data.json
+++ b/packages/api/src/controllers/wowza-hydrate.test-data.json
@@ -32,7 +32,7 @@
       "profileDir": "${com.wowza.wms.context.VHostConfigHome}/transcoder/profiles",
       "templateDir": "${com.wowza.wms.context.VHostConfigHome}/transcoder/templates",
       "licensesInUse": 0,
-      "templatesInUse": "${SourceStreamName}.xml,transrate.xml",
+      "templatesInUse": "${SourceStreamName}.xml, transrate.xml",
       "createTemplateDir": false,
       "liveStreamTranscoder": "transcoder"
     },
@@ -684,6 +684,261 @@
         ],
         "deinterlace": false,
         "description": "Default transrate.xml file",
+        "implementation": "default",
+        "streamNameGroups": [
+          {
+            "name": "all",
+            "Members": [
+              {
+                "encodeName": "source",
+                "memberName": "source",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              },
+              {
+                "encodeName": "720p",
+                "memberName": "720p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              },
+              {
+                "encodeName": "360p",
+                "memberName": "360p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              },
+              {
+                "encodeName": "240p",
+                "memberName": "240p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              },
+              {
+                "encodeName": "160p",
+                "memberName": "160p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              }
+            ],
+            "streamName": "${SourceStreamName}_all"
+          },
+          {
+            "name": "mobile",
+            "Members": [
+              {
+                "encodeName": "240p",
+                "memberName": "240p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              },
+              {
+                "encodeName": "160p",
+                "memberName": "160p",
+                "wowzaAudioOnly": false,
+                "wowzaVideoOnly": false
+              }
+            ],
+            "streamName": "${SourceStreamName}_mobile"
+          }
+        ]
+      },
+      "width_height_test": {
+        "name": "width_height_test",
+        "encodes": [
+          {
+            "name": "source",
+            "gpuid": 0,
+            "width": 0,
+            "enable": true,
+            "height": 0,
+            "Overlays": [],
+            "interval": 0,
+            "audioCodec": "PassThru",
+            "streamName": "mp4:${SourceStreamName}_source",
+            "videoCodec": "PassThru",
+            "audioBitrate": "${SourceAudioBitrate}",
+            "followSource": false,
+            "videoBitrate": "${SourceVideoBitrate}"
+          },
+          {
+            "name": "720p",
+            "gpuid": -1,
+            "width": 0,
+            "enable": true,
+            "height": 720,
+            "fitMode": "fit-height",
+            "profile": "main",
+            "Overlays": [
+              {
+                "x": 4,
+                "y": 4,
+                "align": "left,top",
+                "index": 0,
+                "width": "${ImageWidth}",
+                "enable": false,
+                "height": "${ImageHeight}",
+                "opacity": 100,
+                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                "overlayName": "WowzaLogo",
+                "checkForUpdates": false
+              }
+            ],
+            "interval": 60,
+            "audioCodec": "PassThru",
+            "streamName": "mp4:${SourceStreamName}_720p",
+            "videoCodec": "H.264",
+            "audioBitrate": "${SourceAudioBitrate}",
+            "followSource": true,
+            "videoBitrate": "1300000",
+            "implementation": "default"
+          },
+          {
+            "name": "360p",
+            "gpuid": -1,
+            "width": 640,
+            "enable": true,
+            "height": 0,
+            "fitMode": "fit-height",
+            "profile": "main",
+            "Overlays": [
+              {
+                "x": 4,
+                "y": 4,
+                "align": "left,top",
+                "index": 0,
+                "width": "${ImageWidth}",
+                "enable": false,
+                "height": "${ImageHeight}",
+                "opacity": 100,
+                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                "overlayName": "WowzaLogo",
+                "checkForUpdates": false
+              }
+            ],
+            "interval": 60,
+            "audioCodec": "PassThru",
+            "streamName": "mp4:${SourceStreamName}_360p",
+            "videoCodec": "H.264",
+            "audioBitrate": "${SourceAudioBitrate}",
+            "followSource": true,
+            "videoBitrate": "850000",
+            "implementation": "default"
+          },
+          {
+            "name": "240p",
+            "gpuid": -1,
+            "width": 0,
+            "enable": true,
+            "height": 240,
+            "fitMode": "fit-height",
+            "profile": "baseline",
+            "Overlays": [
+              {
+                "x": 4,
+                "y": 4,
+                "align": "left,top",
+                "index": 0,
+                "width": "${ImageWidth}",
+                "enable": false,
+                "height": "${ImageHeight}",
+                "opacity": 100,
+                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                "overlayName": "WowzaLogo",
+                "checkForUpdates": false
+              }
+            ],
+            "interval": 60,
+            "audioCodec": "PassThru",
+            "streamName": "mp4:${SourceStreamName}_240p",
+            "videoCodec": "H.264",
+            "audioBitrate": "${SourceAudioBitrate}",
+            "followSource": true,
+            "videoBitrate": "350000",
+            "implementation": "default"
+          },
+          {
+            "name": "160p",
+            "gpuid": -1,
+            "width": 284,
+            "enable": true,
+            "height": 0,
+            "fitMode": "fit-height",
+            "profile": "baseline",
+            "Overlays": [
+              {
+                "x": 4,
+                "y": 4,
+                "align": "left,top",
+                "index": 0,
+                "width": "${ImageWidth}",
+                "enable": false,
+                "height": "${ImageHeight}",
+                "opacity": 100,
+                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                "overlayName": "WowzaLogo",
+                "checkForUpdates": false
+              }
+            ],
+            "interval": 60,
+            "audioCodec": "PassThru",
+            "streamName": "mp4:${SourceStreamName}_160p",
+            "videoCodec": "H.264",
+            "audioBitrate": "${SourceAudioBitrate}",
+            "followSource": true,
+            "videoBitrate": "200000",
+            "implementation": "default"
+          },
+          {
+            "name": "h263",
+            "gpuid": -1,
+            "width": 176,
+            "enable": false,
+            "height": 144,
+            "fitMode": "letterbox",
+            "profile": "baseline",
+            "Overlays": [
+              {
+                "x": 4,
+                "y": 4,
+                "align": "left,top",
+                "index": 0,
+                "width": "${ImageWidth}",
+                "enable": false,
+                "height": "${ImageHeight}",
+                "opacity": 100,
+                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                "overlayName": "WowzaLogo",
+                "checkForUpdates": false
+              }
+            ],
+            "interval": 60,
+            "audioCodec": "PassThru",
+            "streamName": "mp4:${SourceStreamName}_h263",
+            "videoCodec": "H.263",
+            "audioBitrate": "${SourceAudioBitrate}",
+            "followSource": false,
+            "videoBitrate": "150000",
+            "implementation": "default"
+          }
+        ],
+        "version": "1541749568000",
+        "overlays": [
+          {
+            "x": 4,
+            "y": 4,
+            "align": "left,top",
+            "index": 0,
+            "width": "${ImageWidth}",
+            "enable": false,
+            "height": "${ImageHeight}",
+            "opacity": 100,
+            "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+            "overlayName": "WowzaLogo",
+            "checkForUpdates": false
+          }
+        ],
+        "deinterlace": false,
+        "description": "Default width_height_test.xml file",
         "implementation": "default",
         "streamNameGroups": [
           {

--- a/packages/api/src/controllers/wowza-hydrate.test.js
+++ b/packages/api/src/controllers/wowza-hydrate.test.js
@@ -29,6 +29,38 @@ describe('wowzaHydrate', () => {
     })
   })
 
+  it('should correctly substitute heights widths to correct value', () => {
+    stream.name = 'width_height_test'
+    const newStream = wowzaHydrate({ ...stream })
+    expect(newStream.presets).toEqual([
+      'P720p60fps16x9',
+      'P360p30fps16x9',
+      'P240p30fps16x9',
+      'P144p30fps16x9',
+    ])
+    expect(newStream.renditions).toEqual({
+      width_height_test_source:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/source.m3u8',
+      width_height_test_720p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P720p60fps16x9.m3u8',
+      width_height_test_360p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P360p30fps16x9.m3u8',
+      width_height_test_240p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P240p30fps16x9.m3u8',
+      width_height_test_160p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P144p30fps16x9.m3u8',
+    })
+  })
+
+  it('should fail if stream name does not equal any template name', () => {
+    stream.name = 'fake_name'
+    try {
+      const newStream = wowzaHydrate({ ...stream })
+    } catch (e) {
+      expect(e.message).toEqual('no template found from templatesInUse')
+    }
+  })
+
   it('should fail if missing parameters', () => {
     for (const field of ['name', 'id']) {
       const brokenStream = { ...stream }

--- a/packages/api/src/controllers/wowza-hydrate.test.js
+++ b/packages/api/src/controllers/wowza-hydrate.test.js
@@ -1,5 +1,8 @@
 import wowzaHydrate from './wowza-hydrate'
 const stream = require('./wowza-hydrate.test-data.json')
+const streamWithoutTransrate = JSON.parse(JSON.stringify(stream))
+streamWithoutTransrate.wowza.transcoderAppConfig.templatesInUse =
+  '${SourceStreamName}.xml'
 
 describe('wowzaHydrate', () => {
   it('should correctly determine renditions and presets', () => {
@@ -53,12 +56,14 @@ describe('wowzaHydrate', () => {
   })
 
   it('should fail if stream name does not equal any template name', () => {
-    stream.name = 'fake_name'
+    let message
+    streamWithoutTransrate.name = 'fake_name'
     try {
-      const newStream = wowzaHydrate({ ...stream })
+      const newStream = wowzaHydrate({ ...streamWithoutTransrate })
     } catch (e) {
-      expect(e.message).toEqual('no template found from templatesInUse')
+      message = e.message
     }
+    expect(message).toEqual('no template found from templatesInUse')
   })
 
   it('should fail if missing parameters', () => {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Adding a 16/9 or 9/16 multiplier to any height or width coming in as 0 from incoming enabled wowza rendition templates. 

**How did you test each of these updates (required)**
- Added tests to output 4 correct rendition templates for various encodings coming in with heights / widths = 0

**Does this pull request close any open issues?**
https://github.com/livepeer/livepeerjs/issues/472


**Checklist:**
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
