### PR TITLE
fix(api): disable 30fps, round TARGETDURATION header

### DIFF
--- a/packages/api/src/controllers/compose-m3u8.js
+++ b/packages/api/src/controllers/compose-m3u8.js
@@ -121,7 +121,7 @@ export const handleMediaPlaylist = broadcasters => {
     '#EXTM3U',
     '#EXT-X-VERSION:3',
     `#EXT-X-MEDIA-SEQUENCE:${bestRun[0].seq}`,
-    `#EXT-X-TARGETDURATION:${targetDuration}`,
+    `#EXT-X-TARGETDURATION:${Math.ceil(targetDuration)}`,
     ...output,
   ]
 

--- a/packages/api/src/controllers/wowza-hydrate.js
+++ b/packages/api/src/controllers/wowza-hydrate.js
@@ -1,6 +1,6 @@
 import { VIDEO_PROFILES } from '@livepeer/sdk'
 
-const PRESETS = Object.values(VIDEO_PROFILES)
+const PRESETS = Object.values(VIDEO_PROFILES).filter(p => p.framerate === 30)
 
 /**
  * Replace a string containing "${SourceStreamName}" with the appropriate stream name


### PR DESCRIPTION
The second thing is for m3u8 compliance, learned about this requirement from `mediastreamvalidator`. The first thing is to reduce the number of variables and not accidentally upscale 30fps to 60fps video (thanks for this catch, @angyangie!) 