### PR TITLE
Match incoming FPS and aspect ratio

### DIFF
--- a/packages/api/src/controllers/wowza-hydrate.js
+++ b/packages/api/src/controllers/wowza-hydrate.js
@@ -1,6 +1,6 @@
 import { VIDEO_PROFILES } from '@livepeer/sdk'
 
-const PRESETS = Object.values(VIDEO_PROFILES).filter(p => p.framerate === 30)
+const PRESETS = Object.values(VIDEO_PROFILES)
 
 /**
  * Replace a string containing "${SourceStreamName}" with the appropriate stream name
@@ -18,7 +18,11 @@ export default stream => {
   if (!stream.name || !stream.id) {
     throw new Error('missing required fields: id, name')
   }
-  const { transcoderAppConfig, transcoderTemplateAppConfig } = stream.wowza
+  const {
+    transcoderAppConfig,
+    transcoderTemplateAppConfig,
+    sourceInfo,
+  } = stream.wowza
   const templatesInUse = transcoderAppConfig.templatesInUse.split(',')
   let template
   for (let tmpl of templatesInUse) {
@@ -38,6 +42,8 @@ export default stream => {
   const renditions = {}
   let presets = []
   const encodeNameToRenditionName = {}
+  const aspectRatio = sourceInfo.width / sourceInfo.height
+  const fps = sourceInfo.fps
   for (const encode of enabledEncodes) {
     let { width, height, name, streamName, videoCodec } = encode
     let renditionName = replaceStreamName(streamName, stream.name)
@@ -51,10 +57,9 @@ export default stream => {
       continue
     }
 
-    const SIXTEEN_BY_NINE = 16 / 9
-    const NINE_BY_SIXTEEN = 9 / 16
-    if (width === 0) width = height * SIXTEEN_BY_NINE
-    if (height === 0) height = width * NINE_BY_SIXTEEN
+    if (width === 0) width = height * aspectRatio
+    if (height === 0) height = (width * 1) / aspectRatio
+    // TODO: do we need to validate whether or not the incoming height/width fit the aspect ratio?
 
     const wowzaSize = width * height
     let diff = Infinity
@@ -65,7 +70,10 @@ export default stream => {
         .map(x => parseInt(x))
       const livepeerSize = livepeerWidth * livepeerHeight
       const thisDiff = Math.abs(livepeerSize - wowzaSize)
-      if (thisDiff < diff) {
+      if (thisDiff < diff && fps == preset.framerate) {
+        // TODO : need to account for when framerate isn't found in VIDEO_PRESETS.
+        // - However, if we'll implement long-term solution soon after this, like enabling full transcoder
+        //   configurability throughout the network, perhaps don't have to, since only Camcast is using this.
         foundPreset = preset.name
         diff = thisDiff
       }

--- a/packages/api/src/controllers/wowza-hydrate.test-data.json
+++ b/packages/api/src/controllers/wowza-hydrate.test-data.json
@@ -1144,6 +1144,11 @@
             }
           ]
         }
+      },
+      "sourceInfo": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 30
       }
     }
   },
@@ -2732,6 +2737,11 @@
             }
           ]
         }
+      },
+      "sourceInfo": {
+        "width": 1920,
+        "height": 1080,
+        "fps": 30
       }
     },
     "presets": [

--- a/packages/api/src/controllers/wowza-hydrate.test-data.json
+++ b/packages/api/src/controllers/wowza-hydrate.test-data.json
@@ -2741,7 +2741,7 @@
       "sourceInfo": {
         "width": 1920,
         "height": 1080,
-        "fps": 30
+        "fps": 25
       }
     },
     "presets": [

--- a/packages/api/src/controllers/wowza-hydrate.test.js
+++ b/packages/api/src/controllers/wowza-hydrate.test.js
@@ -47,6 +47,60 @@ describe('wowzaHydrate', () => {
     })
   })
 
+  it('should correctly determine renditions and presets 15fps', () => {
+    stream.name = 'transrate'
+    stream.wowza.sourceInfo.fps = 15
+    const newStream = wowzaHydrate({ ...stream })
+    expect(newStream.presets).toEqual(['P360p25fps16x9', 'P144p25fps16x9'])
+    expect(newStream.renditions).toEqual({
+      transrate_source:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/source.m3u8',
+      transrate_360p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P360p25fps16x9.m3u8',
+      transrate_160p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P144p25fps16x9.m3u8',
+    })
+  })
+
+  it('should correctly determine renditions and presets 30fps', () => {
+    stream.name = 'transrate'
+    stream.wowza.sourceInfo.fps = 45
+    const newStream = wowzaHydrate({ ...stream })
+    expect(newStream.presets).toEqual(['P360p30fps16x9', 'P144p30fps16x9'])
+    expect(newStream.renditions).toEqual({
+      transrate_source:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/source.m3u8',
+      transrate_360p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P360p30fps16x9.m3u8',
+      transrate_160p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P144p30fps16x9.m3u8',
+    })
+  })
+
+  it('should correctly determine renditions and presets 30fps', () => {
+    stream.name = 'width_height_test'
+    stream.wowza.sourceInfo.fps = 50
+    const newStream = wowzaHydrate({ ...stream })
+    expect(newStream.presets).toEqual([
+      'P720p60fps16x9',
+      'P360p30fps16x9',
+      'P240p30fps16x9',
+      'P144p30fps16x9',
+    ])
+    expect(newStream.renditions).toEqual({
+      width_height_test_source:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/source.m3u8',
+      width_height_test_720p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P720p60fps16x9.m3u8',
+      width_height_test_360p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P360p30fps16x9.m3u8',
+      width_height_test_240p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P240p30fps16x9.m3u8',
+      width_height_test_160p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P144p30fps16x9.m3u8',
+    })
+  })
+
   it('should correctly substitute heights widths to correct value', () => {
     stream.wowza.sourceInfo.fps = 30
     stream.name = 'width_height_test'

--- a/packages/api/src/controllers/wowza-hydrate.test.js
+++ b/packages/api/src/controllers/wowza-hydrate.test.js
@@ -5,7 +5,7 @@ streamWithoutTransrate.wowza.transcoderAppConfig.templatesInUse =
   '${SourceStreamName}.xml'
 
 describe('wowzaHydrate', () => {
-  it('should correctly determine renditions and presets', () => {
+  it('should correctly determine renditions and presets 30fps', () => {
     const newStream = wowzaHydrate({ ...stream })
     expect(newStream.presets).toEqual(['P360p30fps16x9', 'P240p30fps4x3'])
     expect(newStream.renditions).toEqual({
@@ -32,7 +32,23 @@ describe('wowzaHydrate', () => {
     })
   })
 
+  it('should correctly determine renditions and presets 25fps', () => {
+    stream.name = 'transrate'
+    stream.wowza.sourceInfo.fps = 25
+    const newStream = wowzaHydrate({ ...stream })
+    expect(newStream.presets).toEqual(['P360p25fps16x9', 'P144p25fps16x9'])
+    expect(newStream.renditions).toEqual({
+      transrate_source:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/source.m3u8',
+      transrate_360p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P360p25fps16x9.m3u8',
+      transrate_160p:
+        '/stream/de7818e7-610a-4057-8f6f-b785dc1e6f88/P144p25fps16x9.m3u8',
+    })
+  })
+
   it('should correctly substitute heights widths to correct value', () => {
+    stream.wowza.sourceInfo.fps = 30
     stream.name = 'width_height_test'
     const newStream = wowzaHydrate({ ...stream })
     expect(newStream.presets).toEqual([

--- a/packages/api/src/controllers/wowza-hydrate.test.js
+++ b/packages/api/src/controllers/wowza-hydrate.test.js
@@ -1,8 +1,21 @@
 import wowzaHydrate from './wowza-hydrate'
 const { stream, camcastStream } = require('./wowza-hydrate.test-data.json')
-const streamWithoutTransrate = JSON.parse(JSON.stringify(stream))
-streamWithoutTransrate.wowza.transcoderAppConfig.templatesInUse =
+const streamWithoutTransrateTemplate = JSON.parse(JSON.stringify(stream))
+streamWithoutTransrateTemplate.wowza.transcoderAppConfig.templatesInUse =
   '${SourceStreamName}.xml'
+
+const streamWidthHeightTest50 = JSON.parse(JSON.stringify(stream))
+streamWidthHeightTest50.name = 'width_height_test'
+streamWidthHeightTest50.wowza.sourceInfo.fps = 50
+
+const streamTransrate = JSON.parse(JSON.stringify(stream))
+streamTransrate.name = 'transrate'
+const streamTransrate25 = JSON.parse(JSON.stringify(streamTransrate))
+streamTransrate25.wowza.sourceInfo.fps = 25
+const streamTransrate15 = JSON.parse(JSON.stringify(streamTransrate))
+streamTransrate15.wowza.sourceInfo.fps = 15
+const streamTransrate45 = JSON.parse(JSON.stringify(streamTransrate))
+streamTransrate45.wowza.sourceInfo.fps = 45
 
 describe('wowzaHydrate', () => {
   it('should correctly determine renditions and presets 30fps', () => {
@@ -19,8 +32,7 @@ describe('wowzaHydrate', () => {
   })
 
   it('should correctly determine renditions and presets with different stream name', () => {
-    stream.name = 'transrate'
-    const newStream = wowzaHydrate({ ...stream })
+    const newStream = wowzaHydrate({ ...streamTransrate })
     expect(newStream.presets).toEqual(['P360p30fps16x9', 'P144p30fps16x9'])
     expect(newStream.renditions).toEqual({
       transrate_source:
@@ -33,9 +45,7 @@ describe('wowzaHydrate', () => {
   })
 
   it('should correctly determine renditions and presets 25fps', () => {
-    stream.name = 'transrate'
-    stream.wowza.sourceInfo.fps = 25
-    const newStream = wowzaHydrate({ ...stream })
+    const newStream = wowzaHydrate({ ...streamTransrate25 })
     expect(newStream.presets).toEqual(['P360p25fps16x9', 'P144p25fps16x9'])
     expect(newStream.renditions).toEqual({
       transrate_source:
@@ -48,9 +58,7 @@ describe('wowzaHydrate', () => {
   })
 
   it('should correctly determine renditions and presets 15fps', () => {
-    stream.name = 'transrate'
-    stream.wowza.sourceInfo.fps = 15
-    const newStream = wowzaHydrate({ ...stream })
+    const newStream = wowzaHydrate({ ...streamTransrate15 })
     expect(newStream.presets).toEqual(['P360p25fps16x9', 'P144p25fps16x9'])
     expect(newStream.renditions).toEqual({
       transrate_source:
@@ -63,9 +71,7 @@ describe('wowzaHydrate', () => {
   })
 
   it('should correctly determine renditions and presets 30fps', () => {
-    stream.name = 'transrate'
-    stream.wowza.sourceInfo.fps = 45
-    const newStream = wowzaHydrate({ ...stream })
+    const newStream = wowzaHydrate({ ...streamTransrate45 })
     expect(newStream.presets).toEqual(['P360p30fps16x9', 'P144p30fps16x9'])
     expect(newStream.renditions).toEqual({
       transrate_source:
@@ -78,9 +84,7 @@ describe('wowzaHydrate', () => {
   })
 
   it('should correctly determine renditions and presets 30fps', () => {
-    stream.name = 'width_height_test'
-    stream.wowza.sourceInfo.fps = 50
-    const newStream = wowzaHydrate({ ...stream })
+    const newStream = wowzaHydrate({ ...streamWidthHeightTest50 })
     expect(newStream.presets).toEqual([
       'P720p60fps16x9',
       'P360p30fps16x9',
@@ -127,9 +131,9 @@ describe('wowzaHydrate', () => {
 
   it('should fail if stream name does not equal any template name', () => {
     let message
-    streamWithoutTransrate.name = 'fake_name'
+    streamWithoutTransrateTemplate.name = 'fake_name'
     try {
-      const newStream = wowzaHydrate({ ...streamWithoutTransrate })
+      const newStream = wowzaHydrate({ ...streamWithoutTransrateTemplate })
     } catch (e) {
       message = e.message
     }
@@ -162,10 +166,10 @@ describe('wowzaHydrate', () => {
   it('should handle duplicate stream cases', () => {
     const newStream = wowzaHydrate({ ...camcastStream })
     expect(newStream.presets).toEqual([
-      'P720p30fps16x9',
-      'P360p30fps16x9',
+      'P720p25fps16x9',
+      'P360p25fps16x9',
       'P360p30fps4x3',
-      'P144p30fps16x9',
+      'P144p25fps16x9',
     ])
   })
 })

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -16,6 +16,7 @@ components:
         - kind
         - name
         - presets
+        - renditions
       additionalProperties: false
       properties:
         id:
@@ -46,6 +47,7 @@ components:
             - transcoderAppConfig
             - transcoderTemplateAppConfig
             - streamNameGroups
+            - sourceInfo
           additionalProperties: false
           properties:
             transcoderAppConfig:
@@ -54,10 +56,13 @@ components:
               type: object
             streamNameGroups:
               type: array
+            sourceInfo:
+              type: object
         renditions:
           type: object
           additionalProperties:
             type: string
+        
 
     error:
       required:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -58,11 +58,22 @@ components:
               type: array
             sourceInfo:
               type: object
+              required:
+                - width
+                - height
+                - fps
+              additionalProperties: false
+              properties:
+                width:
+                  type: integer
+                height:
+                  type: integer
+                fps:
+                  type: integer
         renditions:
           type: object
           additionalProperties:
             type: string
-        
 
     error:
       required:

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -66,10 +66,13 @@ components:
               properties:
                 width:
                   type: integer
+                  minValue: 1
                 height:
                   type: integer
+                  minValue: 1
                 fps:
                   type: integer
+                  minVallue: 1
         renditions:
           type: object
           additionalProperties:

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -35,6 +35,13 @@ export const VIDEO_PROFILES = {
     framerate: 30,
     resolution: '1280x720',
   },
+  P720p25fps16x9: {
+    hash: 'e4a64019',
+    name: 'P720p25fps16x9',
+    bitrate: '4000k',
+    framerate: 25,
+    resolution: '1280x720',
+  },
   P720p30fps4x3: {
     hash: '79332fe7',
     name: 'P720p30fps4x3',
@@ -49,11 +56,25 @@ export const VIDEO_PROFILES = {
     framerate: 30,
     resolution: '1024x576',
   },
+  P576p25fps16x9: {
+    hash: '8b1843d6',
+    name: 'P576p25fps16x9',
+    bitrate: '1500k',
+    framerate: 25,
+    resolution: '1024x576',
+  },
   P360p30fps16x9: {
     hash: '93c717e7',
     name: 'P360p30fps16x9',
     bitrate: '1200k',
     framerate: 30,
+    resolution: '640x360',
+  },
+  P360p25fps16x9: {
+    hash: '7cd40fc7',
+    name: 'P360p25fps16x9',
+    bitrate: '1200k',
+    framerate: 25,
     resolution: '640x360',
   },
   P360p30fps4x3: {
@@ -70,6 +91,13 @@ export const VIDEO_PROFILES = {
     framerate: 30,
     resolution: '426x240',
   },
+  P240p25fps16x9: {
+    hash: '1301a7d0',
+    name: 'P240p25fps16x9',
+    bitrate: '600k',
+    framerate: 25,
+    resolution: '426x240',
+  },
   P240p30fps4x3: {
     hash: 'd435c53a',
     name: 'P240p30fps4x3',
@@ -82,6 +110,13 @@ export const VIDEO_PROFILES = {
     name: 'P144p30fps16x9',
     bitrate: '400k',
     framerate: 30,
+    resolution: '256x144',
+  },
+  P144p25fps16x9: {
+    hash: '03f01d1f',
+    name: 'P144p25fps16x9',
+    bitrate: '400k',
+    framerate: 25,
     resolution: '256x144',
   },
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
- We need to be able to match incoming stream fps to an existing profile in `VIDEO_PROFILES` in `packages/sdk/src/index.js`
- We should be able to derive aspect ratio from incoming stream height and width.

**Specific updates (required)**
- As a temporary solution, add 25fps profiles to `VIDEO_PROFILES`, mirroring profiles that exist in `go-livepeer`: https://github.com/livepeer/go-livepeer/pull/1148 (see comments in link for more long-term solutions).
- Add `sourceInfo` object to the request body coming from livepeer-wowza, to be accessed as such:  `req.body.wowza.sourceInfo`, with the following fields:
```json
"sourceInfo": {
   "width": 1920,
   "height": 1920,
   "fps": 25
}
```
- In addition to using height / width, also use incoming `sourceInfo.fps` to select correct present.
- When `width` or `height` in `transcoderTemplateAppConfig` template comes back as zero, use aspect ratio to fill in correct missing number.


**How did you test each of these updates (required)**
Test file

**Does this pull request close any open issues?**
https://github.com/livepeer/livepeerjs/issues/497

**Checklist:**
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
