### PR TITLE
fix(api): remove duplicate presets

### DIFF
--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -134,7 +134,7 @@ describe('controllers/stream', () => {
 
   describe('basic CRUD with apiKey', () => {
     let client
-    let mockStream = require('./wowza-hydrate.test-data.json')
+    let mockStream = require('./wowza-hydrate.test-data.json').stream
     delete mockStream.id
     delete mockStream.kind
     mockStream.presets = ['P360p30fps16x9', 'P144p30fps16x9']

--- a/packages/api/src/controllers/wowza-hydrate.js
+++ b/packages/api/src/controllers/wowza-hydrate.js
@@ -36,7 +36,7 @@ export default stream => {
   const transcoderConfig = transcoderTemplateAppConfig[template]
   const enabledEncodes = transcoderConfig.encodes.filter(e => e.enable)
   const renditions = {}
-  const presets = []
+  let presets = []
   const encodeNameToRenditionName = {}
   for (const encode of enabledEncodes) {
     let { width, height, name, streamName, videoCodec } = encode
@@ -80,6 +80,8 @@ export default stream => {
     renditions[renditionName] = `/stream/${stream.id}/${foundPreset}.m3u8`
     presets.push(foundPreset)
   }
+  // Dedupe presets
+  presets = [...new Set(presets)]
   const enabledEncodeNames = new Set(enabledEncodes.map(encode => encode.name))
   const streamNameGroups = transcoderConfig.streamNameGroups.map(
     streamNameGroup => {

--- a/packages/api/src/controllers/wowza-hydrate.test-data.json
+++ b/packages/api/src/controllers/wowza-hydrate.test-data.json
@@ -1,1148 +1,2755 @@
 {
-  "id": "de7818e7-610a-4057-8f6f-b785dc1e6f88",
-  "kind": "stream",
-  "name": "test_stream",
-  "wowza": {
-    "transcoderAppConfig": {
-      "version": "1564614763000",
-      "licensed": true,
-      "licenses": -1,
-      "available": true,
-      "templates": {
-        "templates": [
-          {
-            "id": "transcode-h265-divx",
-            "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/transcode-h265-divx"
-          },
-          {
-            "id": "audioonly",
-            "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/audioonly"
-          },
-          {
-            "id": "transrate",
-            "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/transrate"
-          },
-          {
-            "id": "transcode",
-            "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/transcode"
-          }
-        ],
-        "vhostName": "_defaultVHost_"
+  "stream": {
+    "id": "de7818e7-610a-4057-8f6f-b785dc1e6f88",
+    "kind": "stream",
+    "name": "test_stream",
+    "wowza": {
+      "transcoderAppConfig": {
+        "version": "1564614763000",
+        "licensed": true,
+        "licenses": -1,
+        "available": true,
+        "templates": {
+          "templates": [
+            {
+              "id": "transcode-h265-divx",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/transcode-h265-divx"
+            },
+            {
+              "id": "audioonly",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/audioonly"
+            },
+            {
+              "id": "transrate",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/transrate"
+            },
+            {
+              "id": "transcode",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/transcode"
+            }
+          ],
+          "vhostName": "_defaultVHost_"
+        },
+        "profileDir": "${com.wowza.wms.context.VHostConfigHome}/transcoder/profiles",
+        "templateDir": "${com.wowza.wms.context.VHostConfigHome}/transcoder/templates",
+        "licensesInUse": 0,
+        "templatesInUse": "${SourceStreamName}.xml,transrate.xml",
+        "createTemplateDir": false,
+        "liveStreamTranscoder": "transcoder"
       },
-      "profileDir": "${com.wowza.wms.context.VHostConfigHome}/transcoder/profiles",
-      "templateDir": "${com.wowza.wms.context.VHostConfigHome}/transcoder/templates",
-      "licensesInUse": 0,
-      "templatesInUse": "${SourceStreamName}.xml,transrate.xml",
-      "createTemplateDir": false,
-      "liveStreamTranscoder": "transcoder"
-    },
-    "transcoderTemplateAppConfig": {
-      "audioonly": {
-        "name": "audioonly",
-        "encodes": [
-          {
-            "name": "aac",
-            "gpuid": 0,
-            "width": 0,
-            "enable": true,
-            "height": 0,
-            "Overlays": [],
-            "interval": 0,
-            "audioCodec": "AAC",
-            "streamName": "mp4:${SourceStreamName}_aac",
-            "videoCodec": "PassThru",
-            "audioBitrate": "48000",
-            "followSource": false,
-            "videoBitrate": "${SourceVideoBitrate}"
-          }
-        ],
-        "version": "1541749568000",
-        "overlays": [],
-        "deinterlace": false,
-        "description": "Default audioonly.xml file",
-        "streamNameGroups": []
-      },
-      "transcode": {
-        "name": "transcode",
-        "encodes": [
-          {
-            "name": "720p",
-            "gpuid": -1,
-            "width": 1280,
-            "enable": false,
-            "height": 720,
-            "fitMode": "fit-height",
-            "profile": "main",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "AAC",
-            "streamName": "mp4:${SourceStreamName}_720p",
-            "videoCodec": "H.264",
-            "audioBitrate": "96000",
-            "followSource": false,
-            "videoBitrate": "1300000",
-            "implementation": "default"
-          },
-          {
-            "name": "360p",
-            "gpuid": -1,
-            "width": 640,
-            "enable": true,
-            "height": 360,
-            "fitMode": "fit-height",
-            "profile": "main",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "AAC",
-            "streamName": "mp4:${SourceStreamName}_360p",
-            "videoCodec": "H.264",
-            "audioBitrate": "96000",
-            "followSource": false,
-            "videoBitrate": "850000",
-            "implementation": "default"
-          },
-          {
-            "name": "240p",
-            "gpuid": -1,
-            "width": 360,
-            "enable": false,
-            "height": 240,
-            "fitMode": "fit-height",
-            "profile": "baseline",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "AAC",
-            "streamName": "mp4:${SourceStreamName}_240p",
-            "videoCodec": "H.264",
-            "audioBitrate": "96000",
-            "followSource": false,
-            "videoBitrate": "350000",
-            "implementation": "default"
-          },
-          {
-            "name": "160p",
-            "gpuid": -1,
-            "width": 284,
-            "enable": true,
-            "height": 160,
-            "fitMode": "fit-height",
-            "profile": "baseline",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "AAC",
-            "streamName": "mp4:${SourceStreamName}_160p",
-            "videoCodec": "H.264",
-            "audioBitrate": "96000",
-            "followSource": false,
-            "videoBitrate": "200000",
-            "implementation": "default"
-          },
-          {
-            "name": "h263",
-            "gpuid": -1,
-            "width": 176,
-            "enable": false,
-            "height": 144,
-            "fitMode": "letterbox",
-            "profile": "baseline",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "AAC",
-            "streamName": "mp4:${SourceStreamName}_h263",
-            "videoCodec": "H.263",
-            "audioBitrate": "64000",
-            "followSource": false,
-            "videoBitrate": "150000",
-            "implementation": "default"
-          }
-        ],
-        "version": "1541749568000",
-        "overlays": [
-          {
-            "x": 4,
-            "y": 4,
-            "align": "left,top",
-            "index": 0,
-            "width": "${ImageWidth}",
-            "enable": false,
-            "height": "${ImageHeight}",
-            "opacity": 100,
-            "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-            "overlayName": "WowzaLogo",
-            "checkForUpdates": false
-          }
-        ],
-        "deinterlace": false,
-        "description": "Default transcode.xml file",
-        "implementation": "default",
-        "streamNameGroups": [
-          {
-            "name": "all",
-            "Members": [
-              {
-                "encodeName": "720p",
-                "memberName": "720p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "360p",
-                "memberName": "360p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "240p",
-                "memberName": "240p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "160p",
-                "memberName": "160p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              }
-            ],
-            "streamName": "${SourceStreamName}_all"
-          },
-          {
-            "name": "mobile",
-            "Members": [
-              {
-                "encodeName": "240p",
-                "memberName": "240p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "160p",
-                "memberName": "160p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              }
-            ],
-            "streamName": "${SourceStreamName}_mobile"
-          }
-        ]
-      },
-      "transrate": {
-        "name": "transrate",
-        "encodes": [
-          {
-            "name": "source",
-            "gpuid": 0,
-            "width": 0,
-            "enable": true,
-            "height": 0,
-            "Overlays": [],
-            "interval": 0,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_source",
-            "videoCodec": "PassThru",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": false,
-            "videoBitrate": "${SourceVideoBitrate}"
-          },
-          {
-            "name": "720p",
-            "gpuid": -1,
-            "width": 1280,
-            "enable": false,
-            "height": 720,
-            "fitMode": "fit-height",
-            "profile": "main",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_720p",
-            "videoCodec": "H.264",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": true,
-            "videoBitrate": "1300000",
-            "implementation": "default"
-          },
-          {
-            "name": "360p",
-            "gpuid": -1,
-            "width": 640,
-            "enable": true,
-            "height": 360,
-            "fitMode": "fit-height",
-            "profile": "main",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_360p",
-            "videoCodec": "H.264",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": true,
-            "videoBitrate": "850000",
-            "implementation": "default"
-          },
-          {
-            "name": "240p",
-            "gpuid": -1,
-            "width": 360,
-            "enable": false,
-            "height": 240,
-            "fitMode": "fit-height",
-            "profile": "baseline",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_240p",
-            "videoCodec": "H.264",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": true,
-            "videoBitrate": "350000",
-            "implementation": "default"
-          },
-          {
-            "name": "160p",
-            "gpuid": -1,
-            "width": 284,
-            "enable": true,
-            "height": 160,
-            "fitMode": "fit-height",
-            "profile": "baseline",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_160p",
-            "videoCodec": "H.264",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": true,
-            "videoBitrate": "200000",
-            "implementation": "default"
-          },
-          {
-            "name": "h263",
-            "gpuid": -1,
-            "width": 176,
-            "enable": false,
-            "height": 144,
-            "fitMode": "letterbox",
-            "profile": "baseline",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_h263",
-            "videoCodec": "H.263",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": false,
-            "videoBitrate": "150000",
-            "implementation": "default"
-          }
-        ],
-        "version": "1541749568000",
-        "overlays": [
-          {
-            "x": 4,
-            "y": 4,
-            "align": "left,top",
-            "index": 0,
-            "width": "${ImageWidth}",
-            "enable": false,
-            "height": "${ImageHeight}",
-            "opacity": 100,
-            "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-            "overlayName": "WowzaLogo",
-            "checkForUpdates": false
-          }
-        ],
-        "deinterlace": false,
-        "description": "Default transrate.xml file",
-        "implementation": "default",
-        "streamNameGroups": [
-          {
-            "name": "all",
-            "Members": [
-              {
-                "encodeName": "source",
-                "memberName": "source",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "720p",
-                "memberName": "720p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "360p",
-                "memberName": "360p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "240p",
-                "memberName": "240p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "160p",
-                "memberName": "160p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              }
-            ],
-            "streamName": "${SourceStreamName}_all"
-          },
-          {
-            "name": "mobile",
-            "Members": [
-              {
-                "encodeName": "240p",
-                "memberName": "240p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "160p",
-                "memberName": "160p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              }
-            ],
-            "streamName": "${SourceStreamName}_mobile"
-          }
-        ]
-      },
-      "test_stream": {
-        "name": "test_stream",
-        "encodes": [
-          {
-            "name": "source",
-            "gpuid": 0,
-            "width": 0,
-            "enable": true,
-            "height": 0,
-            "Overlays": [],
-            "interval": 0,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_source",
-            "videoCodec": "PassThru",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": false,
-            "videoBitrate": "${SourceVideoBitrate}"
-          },
-          {
-            "name": "360p",
-            "gpuid": -1,
-            "width": 640,
-            "enable": true,
-            "height": 360,
-            "fitMode": "fit-height",
-            "profile": "main",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_360p",
-            "videoCodec": "H.264",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": true,
-            "videoBitrate": "850000",
-            "implementation": "default"
-          },
-          {
-            "name": "240p",
-            "gpuid": -1,
-            "width": 360,
-            "enable": true,
-            "height": 240,
-            "fitMode": "fit-height",
-            "profile": "baseline",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_240p",
-            "videoCodec": "H.264",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": true,
-            "videoBitrate": "350000",
-            "implementation": "default"
-          },
-          {
-            "name": "h263",
-            "gpuid": -1,
-            "width": 176,
-            "enable": false,
-            "height": 144,
-            "fitMode": "letterbox",
-            "profile": "baseline",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_h263",
-            "videoCodec": "H.263",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": false,
-            "videoBitrate": "150000",
-            "implementation": "default"
-          }
-        ],
-        "version": "1541749568000",
-        "overlays": [
-          {
-            "x": 4,
-            "y": 4,
-            "align": "left,top",
-            "index": 0,
-            "width": "${ImageWidth}",
-            "enable": false,
-            "height": "${ImageHeight}",
-            "opacity": 100,
-            "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-            "overlayName": "WowzaLogo",
-            "checkForUpdates": false
-          }
-        ],
-        "deinterlace": false,
-        "description": "Default transrate.xml file",
-        "implementation": "default",
-        "streamNameGroups": [
-          {
-            "name": "all",
-            "Members": [
-              {
-                "encodeName": "source",
-                "memberName": "source",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "720p",
-                "memberName": "720p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "360p",
-                "memberName": "360p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "240p",
-                "memberName": "240p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "160p",
-                "memberName": "160p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              }
-            ],
-            "streamName": "${SourceStreamName}_all"
-          },
-          {
-            "name": "mobile",
-            "Members": [
-              {
-                "encodeName": "240p",
-                "memberName": "240p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "160p",
-                "memberName": "160p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              }
-            ],
-            "streamName": "${SourceStreamName}_mobile"
-          }
-        ]
-      },
-      "width_height_test": {
-        "name": "width_height_test",
-        "encodes": [
-          {
-            "name": "source",
-            "gpuid": 0,
-            "width": 0,
-            "enable": true,
-            "height": 0,
-            "Overlays": [],
-            "interval": 0,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_source",
-            "videoCodec": "PassThru",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": false,
-            "videoBitrate": "${SourceVideoBitrate}"
-          },
-          {
-            "name": "720p",
-            "gpuid": -1,
-            "width": 0,
-            "enable": true,
-            "height": 720,
-            "fitMode": "fit-height",
-            "profile": "main",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_720p",
-            "videoCodec": "H.264",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": true,
-            "videoBitrate": "1300000",
-            "implementation": "default"
-          },
-          {
-            "name": "360p",
-            "gpuid": -1,
-            "width": 640,
-            "enable": true,
-            "height": 0,
-            "fitMode": "fit-height",
-            "profile": "main",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_360p",
-            "videoCodec": "H.264",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": true,
-            "videoBitrate": "850000",
-            "implementation": "default"
-          },
-          {
-            "name": "240p",
-            "gpuid": -1,
-            "width": 0,
-            "enable": true,
-            "height": 240,
-            "fitMode": "fit-height",
-            "profile": "baseline",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_240p",
-            "videoCodec": "H.264",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": true,
-            "videoBitrate": "350000",
-            "implementation": "default"
-          },
-          {
-            "name": "160p",
-            "gpuid": -1,
-            "width": 284,
-            "enable": true,
-            "height": 0,
-            "fitMode": "fit-height",
-            "profile": "baseline",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_160p",
-            "videoCodec": "H.264",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": true,
-            "videoBitrate": "200000",
-            "implementation": "default"
-          },
-          {
-            "name": "h263",
-            "gpuid": -1,
-            "width": 176,
-            "enable": false,
-            "height": 144,
-            "fitMode": "letterbox",
-            "profile": "baseline",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "PassThru",
-            "streamName": "mp4:${SourceStreamName}_h263",
-            "videoCodec": "H.263",
-            "audioBitrate": "${SourceAudioBitrate}",
-            "followSource": false,
-            "videoBitrate": "150000",
-            "implementation": "default"
-          }
-        ],
-        "version": "1541749568000",
-        "overlays": [
-          {
-            "x": 4,
-            "y": 4,
-            "align": "left,top",
-            "index": 0,
-            "width": "${ImageWidth}",
-            "enable": false,
-            "height": "${ImageHeight}",
-            "opacity": 100,
-            "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-            "overlayName": "WowzaLogo",
-            "checkForUpdates": false
-          }
-        ],
-        "deinterlace": false,
-        "description": "Default width_height_test.xml file",
-        "implementation": "default",
-        "streamNameGroups": [
-          {
-            "name": "all",
-            "Members": [
-              {
-                "encodeName": "source",
-                "memberName": "source",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "720p",
-                "memberName": "720p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "360p",
-                "memberName": "360p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "240p",
-                "memberName": "240p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "160p",
-                "memberName": "160p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              }
-            ],
-            "streamName": "${SourceStreamName}_all"
-          },
-          {
-            "name": "mobile",
-            "Members": [
-              {
-                "encodeName": "240p",
-                "memberName": "240p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "160p",
-                "memberName": "160p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              }
-            ],
-            "streamName": "${SourceStreamName}_mobile"
-          }
-        ]
-      },
-      "transcode-h265-divx": {
-        "name": "transcode-h265-divx",
-        "encodes": [
-          {
-            "name": "4k",
-            "gpuid": -1,
-            "width": 4096,
-            "enable": false,
-            "height": 2160,
-            "fitMode": "letterbox",
-            "profile": "main",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "AAC",
-            "streamName": "mp4:${SourceStreamName}_4k",
-            "videoCodec": "H.265",
-            "audioBitrate": "96000",
-            "followSource": false,
-            "videoBitrate": "12000000",
-            "implementation": "default"
-          },
-          {
-            "name": "1080p",
-            "gpuid": -1,
-            "width": 1920,
-            "enable": false,
-            "height": 1080,
-            "fitMode": "letterbox",
-            "profile": "main",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "AAC",
-            "streamName": "mp4:${SourceStreamName}_1080p",
-            "videoCodec": "H.265",
-            "audioBitrate": "96000",
-            "followSource": false,
-            "videoBitrate": "8000000",
-            "implementation": "default"
-          },
-          {
-            "name": "720p",
-            "gpuid": -1,
-            "width": 1280,
-            "enable": true,
-            "height": 720,
-            "fitMode": "letterbox",
-            "profile": "main",
-            "Overlays": [
-              {
-                "x": 4,
-                "y": 4,
-                "align": "left,top",
-                "index": 0,
-                "width": "${ImageWidth}",
-                "enable": false,
-                "height": "${ImageHeight}",
-                "opacity": 100,
-                "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-                "overlayName": "WowzaLogo",
-                "checkForUpdates": false
-              }
-            ],
-            "interval": 60,
-            "audioCodec": "AAC",
-            "streamName": "mp4:${SourceStreamName}_720p",
-            "videoCodec": "H.265",
-            "audioBitrate": "96000",
-            "followSource": false,
-            "videoBitrate": "5000000",
-            "implementation": "default"
-          }
-        ],
-        "version": "1541749568000",
-        "overlays": [
-          {
-            "x": 4,
-            "y": 4,
-            "align": "left,top",
-            "index": 0,
-            "width": "${ImageWidth}",
-            "enable": false,
-            "height": "${ImageHeight}",
-            "opacity": 100,
-            "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
-            "overlayName": "WowzaLogo",
-            "checkForUpdates": false
-          }
-        ],
-        "deinterlace": false,
-        "description": "Default H.265 / DivX Transcode.xml file",
-        "implementation": "default",
-        "streamNameGroups": [
-          {
-            "name": "all",
-            "Members": [
-              {
-                "encodeName": "4k",
-                "memberName": "4k",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "1080p",
-                "memberName": "1080p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              },
-              {
-                "encodeName": "720p",
-                "memberName": "720p",
-                "wowzaAudioOnly": false,
-                "wowzaVideoOnly": false
-              }
-            ],
-            "streamName": "${SourceStreamName}_all"
-          }
-        ]
+      "transcoderTemplateAppConfig": {
+        "audioonly": {
+          "name": "audioonly",
+          "encodes": [
+            {
+              "name": "aac",
+              "gpuid": 0,
+              "width": 0,
+              "enable": true,
+              "height": 0,
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_aac",
+              "videoCodec": "PassThru",
+              "audioBitrate": "48000",
+              "followSource": false,
+              "videoBitrate": "${SourceVideoBitrate}"
+            }
+          ],
+          "version": "1541749568000",
+          "overlays": [],
+          "deinterlace": false,
+          "description": "Default audioonly.xml file",
+          "streamNameGroups": []
+        },
+        "transcode": {
+          "name": "transcode",
+          "encodes": [
+            {
+              "name": "720p",
+              "gpuid": -1,
+              "width": 1280,
+              "enable": false,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_720p",
+              "videoCodec": "H.264",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "1300000",
+              "implementation": "default"
+            },
+            {
+              "name": "360p",
+              "gpuid": -1,
+              "width": 640,
+              "enable": true,
+              "height": 360,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_360p",
+              "videoCodec": "H.264",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "850000",
+              "implementation": "default"
+            },
+            {
+              "name": "240p",
+              "gpuid": -1,
+              "width": 360,
+              "enable": false,
+              "height": 240,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_240p",
+              "videoCodec": "H.264",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "350000",
+              "implementation": "default"
+            },
+            {
+              "name": "160p",
+              "gpuid": -1,
+              "width": 284,
+              "enable": true,
+              "height": 160,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_160p",
+              "videoCodec": "H.264",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "200000",
+              "implementation": "default"
+            },
+            {
+              "name": "h263",
+              "gpuid": -1,
+              "width": 176,
+              "enable": false,
+              "height": 144,
+              "fitMode": "letterbox",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_h263",
+              "videoCodec": "H.263",
+              "audioBitrate": "64000",
+              "followSource": false,
+              "videoBitrate": "150000",
+              "implementation": "default"
+            }
+          ],
+          "version": "1541749568000",
+          "overlays": [
+            {
+              "x": 4,
+              "y": 4,
+              "align": "left,top",
+              "index": 0,
+              "width": "${ImageWidth}",
+              "enable": false,
+              "height": "${ImageHeight}",
+              "opacity": 100,
+              "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+              "overlayName": "WowzaLogo",
+              "checkForUpdates": false
+            }
+          ],
+          "deinterlace": false,
+          "description": "Default transcode.xml file",
+          "implementation": "default",
+          "streamNameGroups": [
+            {
+              "name": "all",
+              "Members": [
+                {
+                  "encodeName": "720p",
+                  "memberName": "720p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "360p",
+                  "memberName": "360p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_all"
+            },
+            {
+              "name": "mobile",
+              "Members": [
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_mobile"
+            }
+          ]
+        },
+        "transrate": {
+          "name": "transrate",
+          "encodes": [
+            {
+              "name": "source",
+              "gpuid": 0,
+              "width": 0,
+              "enable": true,
+              "height": 0,
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_source",
+              "videoCodec": "PassThru",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": false,
+              "videoBitrate": "${SourceVideoBitrate}"
+            },
+            {
+              "name": "720p",
+              "gpuid": -1,
+              "width": 1280,
+              "enable": false,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_720p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "1300000",
+              "implementation": "default"
+            },
+            {
+              "name": "360p",
+              "gpuid": -1,
+              "width": 640,
+              "enable": true,
+              "height": 360,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_360p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "850000",
+              "implementation": "default"
+            },
+            {
+              "name": "240p",
+              "gpuid": -1,
+              "width": 360,
+              "enable": false,
+              "height": 240,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_240p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "350000",
+              "implementation": "default"
+            },
+            {
+              "name": "160p",
+              "gpuid": -1,
+              "width": 284,
+              "enable": true,
+              "height": 160,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_160p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "200000",
+              "implementation": "default"
+            },
+            {
+              "name": "h263",
+              "gpuid": -1,
+              "width": 176,
+              "enable": false,
+              "height": 144,
+              "fitMode": "letterbox",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_h263",
+              "videoCodec": "H.263",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": false,
+              "videoBitrate": "150000",
+              "implementation": "default"
+            }
+          ],
+          "version": "1541749568000",
+          "overlays": [
+            {
+              "x": 4,
+              "y": 4,
+              "align": "left,top",
+              "index": 0,
+              "width": "${ImageWidth}",
+              "enable": false,
+              "height": "${ImageHeight}",
+              "opacity": 100,
+              "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+              "overlayName": "WowzaLogo",
+              "checkForUpdates": false
+            }
+          ],
+          "deinterlace": false,
+          "description": "Default transrate.xml file",
+          "implementation": "default",
+          "streamNameGroups": [
+            {
+              "name": "all",
+              "Members": [
+                {
+                  "encodeName": "source",
+                  "memberName": "source",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "720p",
+                  "memberName": "720p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "360p",
+                  "memberName": "360p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_all"
+            },
+            {
+              "name": "mobile",
+              "Members": [
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_mobile"
+            }
+          ]
+        },
+        "test_stream": {
+          "name": "test_stream",
+          "encodes": [
+            {
+              "name": "source",
+              "gpuid": 0,
+              "width": 0,
+              "enable": true,
+              "height": 0,
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_source",
+              "videoCodec": "PassThru",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": false,
+              "videoBitrate": "${SourceVideoBitrate}"
+            },
+            {
+              "name": "360p",
+              "gpuid": -1,
+              "width": 640,
+              "enable": true,
+              "height": 360,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_360p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "850000",
+              "implementation": "default"
+            },
+            {
+              "name": "240p",
+              "gpuid": -1,
+              "width": 360,
+              "enable": true,
+              "height": 240,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_240p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "350000",
+              "implementation": "default"
+            },
+            {
+              "name": "h263",
+              "gpuid": -1,
+              "width": 176,
+              "enable": false,
+              "height": 144,
+              "fitMode": "letterbox",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_h263",
+              "videoCodec": "H.263",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": false,
+              "videoBitrate": "150000",
+              "implementation": "default"
+            }
+          ],
+          "version": "1541749568000",
+          "overlays": [
+            {
+              "x": 4,
+              "y": 4,
+              "align": "left,top",
+              "index": 0,
+              "width": "${ImageWidth}",
+              "enable": false,
+              "height": "${ImageHeight}",
+              "opacity": 100,
+              "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+              "overlayName": "WowzaLogo",
+              "checkForUpdates": false
+            }
+          ],
+          "deinterlace": false,
+          "description": "Default transrate.xml file",
+          "implementation": "default",
+          "streamNameGroups": [
+            {
+              "name": "all",
+              "Members": [
+                {
+                  "encodeName": "source",
+                  "memberName": "source",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "720p",
+                  "memberName": "720p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "360p",
+                  "memberName": "360p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_all"
+            },
+            {
+              "name": "mobile",
+              "Members": [
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_mobile"
+            }
+          ]
+        },
+        "width_height_test": {
+          "name": "width_height_test",
+          "encodes": [
+            {
+              "name": "source",
+              "gpuid": 0,
+              "width": 0,
+              "enable": true,
+              "height": 0,
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_source",
+              "videoCodec": "PassThru",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": false,
+              "videoBitrate": "${SourceVideoBitrate}"
+            },
+            {
+              "name": "720p",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_720p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "1300000",
+              "implementation": "default"
+            },
+            {
+              "name": "360p",
+              "gpuid": -1,
+              "width": 640,
+              "enable": true,
+              "height": 0,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_360p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "850000",
+              "implementation": "default"
+            },
+            {
+              "name": "240p",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 240,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_240p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "350000",
+              "implementation": "default"
+            },
+            {
+              "name": "160p",
+              "gpuid": -1,
+              "width": 284,
+              "enable": true,
+              "height": 0,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_160p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "200000",
+              "implementation": "default"
+            },
+            {
+              "name": "h263",
+              "gpuid": -1,
+              "width": 176,
+              "enable": false,
+              "height": 144,
+              "fitMode": "letterbox",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_h263",
+              "videoCodec": "H.263",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": false,
+              "videoBitrate": "150000",
+              "implementation": "default"
+            }
+          ],
+          "version": "1541749568000",
+          "overlays": [
+            {
+              "x": 4,
+              "y": 4,
+              "align": "left,top",
+              "index": 0,
+              "width": "${ImageWidth}",
+              "enable": false,
+              "height": "${ImageHeight}",
+              "opacity": 100,
+              "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+              "overlayName": "WowzaLogo",
+              "checkForUpdates": false
+            }
+          ],
+          "deinterlace": false,
+          "description": "Default width_height_test.xml file",
+          "implementation": "default",
+          "streamNameGroups": [
+            {
+              "name": "all",
+              "Members": [
+                {
+                  "encodeName": "source",
+                  "memberName": "source",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "720p",
+                  "memberName": "720p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "360p",
+                  "memberName": "360p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_all"
+            },
+            {
+              "name": "mobile",
+              "Members": [
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_mobile"
+            }
+          ]
+        },
+        "transcode-h265-divx": {
+          "name": "transcode-h265-divx",
+          "encodes": [
+            {
+              "name": "4k",
+              "gpuid": -1,
+              "width": 4096,
+              "enable": false,
+              "height": 2160,
+              "fitMode": "letterbox",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_4k",
+              "videoCodec": "H.265",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "12000000",
+              "implementation": "default"
+            },
+            {
+              "name": "1080p",
+              "gpuid": -1,
+              "width": 1920,
+              "enable": false,
+              "height": 1080,
+              "fitMode": "letterbox",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_1080p",
+              "videoCodec": "H.265",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "8000000",
+              "implementation": "default"
+            },
+            {
+              "name": "720p",
+              "gpuid": -1,
+              "width": 1280,
+              "enable": true,
+              "height": 720,
+              "fitMode": "letterbox",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_720p",
+              "videoCodec": "H.265",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "5000000",
+              "implementation": "default"
+            }
+          ],
+          "version": "1541749568000",
+          "overlays": [
+            {
+              "x": 4,
+              "y": 4,
+              "align": "left,top",
+              "index": 0,
+              "width": "${ImageWidth}",
+              "enable": false,
+              "height": "${ImageHeight}",
+              "opacity": 100,
+              "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+              "overlayName": "WowzaLogo",
+              "checkForUpdates": false
+            }
+          ],
+          "deinterlace": false,
+          "description": "Default H.265 / DivX Transcode.xml file",
+          "implementation": "default",
+          "streamNameGroups": [
+            {
+              "name": "all",
+              "Members": [
+                {
+                  "encodeName": "4k",
+                  "memberName": "4k",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "1080p",
+                  "memberName": "1080p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "720p",
+                  "memberName": "720p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_all"
+            }
+          ]
+        }
       }
+    }
+  },
+  "camcastStream": {
+    "id": "836917de-a8c9-4fa3-9171-3cbb8db4cafd",
+    "kind": "stream",
+    "name": "live",
+    "wowza": {
+      "streamNameGroups": [
+        {
+          "name": "stream1_all",
+          "renditions": [
+            "stream1_high",
+            "stream1_720",
+            "stream1_480",
+            "stream1_360",
+            "stream1_288"
+          ]
+        }
+      ],
+      "transcoderAppConfig": {
+        "version": "1572631716000",
+        "licensed": true,
+        "licenses": -1,
+        "available": true,
+        "templates": {
+          "templates": [
+            {
+              "id": "audioonly",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/audioonly"
+            },
+            {
+              "id": "transcode-h265-divx",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/transcode-h265-divx"
+            },
+            {
+              "id": "transcode",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/transcode"
+            },
+            {
+              "id": "transrate",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/transrate"
+            },
+            {
+              "id": "bild.stream",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/bild.stream"
+            },
+            {
+              "id": "stream1",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/stream1"
+            },
+            {
+              "id": "ingest",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/ingest"
+            },
+            {
+              "id": "stream1.stream",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/stream1.stream"
+            },
+            {
+              "id": "live",
+              "href": "/v2/servers/_defaultServer_/vhosts/_defaultVHost_/applications/live/transcoder/templates/live"
+            }
+          ],
+          "vhostName": "_defaultVHost_"
+        },
+        "profileDir": "${com.wowza.wms.context.VHostConfigHome}/transcoder/profiles",
+        "templateDir": "${com.wowza.wms.context.VHostConfigHome}/transcoder/templates",
+        "licensesInUse": 0,
+        "templatesInUse": "${SourceStreamName}.xml,transrate.xml",
+        "createTemplateDir": false,
+        "liveStreamTranscoder": "transcoder"
+      },
+      "transcoderTemplateAppConfig": {
+        "live": {
+          "name": "live",
+          "encodes": [
+            {
+              "name": "stream1_1080",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 1080,
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "PassThru",
+              "streamName": "stream1_high",
+              "videoCodec": "PassThru",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": false,
+              "videoBitrate": "${SourceVideoBitrate}"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_720",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_720",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_1080",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "2200000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_480",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 480,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_480",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_720",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "1222000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_360",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 360,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_360",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_480",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "772000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_288",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 288,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_288",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_360",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "512000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "facebook4",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "facebook",
+              "videoCodec": "H.264",
+              "description": "Copy of: facebook3",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "4000000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_4mbit",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 0,
+              "fitMode": "match-source",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_1080",
+              "videoCodec": "H.264",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "4000000",
+              "implementation": "NVENC"
+            }
+          ],
+          "version": "1572628495000",
+          "overlays": [],
+          "deinterlace": false,
+          "implementation": "NVCUVID",
+          "streamNameGroups": [
+            {
+              "name": "stream1_all",
+              "Members": [
+                {
+                  "encodeName": "stream1_1080",
+                  "memberName": "stream1_1080",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_720",
+                  "memberName": "stream1_720",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_480",
+                  "memberName": "stream1_480",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_360",
+                  "memberName": "stream1_360",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_288",
+                  "memberName": "stream1_288",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "stream1_all"
+            }
+          ]
+        },
+        "ingest": {
+          "name": "ingest",
+          "encodes": [
+            {
+              "name": "stream1_1080",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 1080,
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "PassThru",
+              "streamName": "stream1_high",
+              "videoCodec": "PassThru",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": false,
+              "videoBitrate": "${SourceVideoBitrate}"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_720",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_720",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_1080",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "2200000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_480",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 480,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_480",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_720",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "1222000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_360",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 360,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_360",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_480",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "772000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_288",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 288,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_288",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_360",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "512000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "facebook4",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "facebook",
+              "videoCodec": "H.264",
+              "description": "Copy of: facebook3",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "4000000",
+              "implementation": "NVENC"
+            }
+          ],
+          "version": "1571063221000",
+          "overlays": [],
+          "deinterlace": false,
+          "implementation": "NVCUVID",
+          "streamNameGroups": [
+            {
+              "name": "stream1_all",
+              "Members": [
+                {
+                  "encodeName": "stream1_1080",
+                  "memberName": "stream1_1080",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_720",
+                  "memberName": "stream1_720",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_480",
+                  "memberName": "stream1_480",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_360",
+                  "memberName": "stream1_360",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_288",
+                  "memberName": "stream1_288",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "stream1_all"
+            }
+          ]
+        },
+        "stream1": {
+          "name": "stream1",
+          "encodes": [
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_1080",
+              "gpuid": -1,
+              "width": 0,
+              "enable": false,
+              "height": 1080,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_1080",
+              "videoCodec": "H.264",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "5200000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_720",
+              "gpuid": -1,
+              "width": 0,
+              "enable": false,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_720",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_1080",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "2600000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_480",
+              "gpuid": -1,
+              "width": 0,
+              "enable": false,
+              "height": 480,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_480",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_720",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "1600000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_360",
+              "gpuid": -1,
+              "width": 0,
+              "enable": false,
+              "height": 360,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_360",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_480",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "1024000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_288",
+              "gpuid": -1,
+              "width": 0,
+              "enable": false,
+              "height": 288,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_288",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_360",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "512000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "facebook1",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "facebook1",
+              "videoCodec": "H.264",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "4000000",
+              "implementation": "NVENC"
+            }
+          ],
+          "version": "1571063214000",
+          "overlays": [],
+          "deinterlace": false,
+          "implementation": "NVCUVID",
+          "streamNameGroups": [
+            {
+              "name": "stream1_all",
+              "Members": [
+                {
+                  "encodeName": "stream1_1080",
+                  "memberName": "stream1_1080",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_720",
+                  "memberName": "stream1_720",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_480",
+                  "memberName": "stream1_480",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_360",
+                  "memberName": "stream1_360",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_288",
+                  "memberName": "stream1_288",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "stream1_all"
+            }
+          ]
+        },
+        "audioonly": {
+          "name": "audioonly",
+          "encodes": [
+            {
+              "name": "aac",
+              "gpuid": 0,
+              "width": 0,
+              "enable": true,
+              "height": 0,
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_aac",
+              "videoCodec": "PassThru",
+              "audioBitrate": "48000",
+              "followSource": false,
+              "videoBitrate": "${SourceVideoBitrate}"
+            }
+          ],
+          "version": "1541717232000",
+          "overlays": [],
+          "deinterlace": false,
+          "description": "Default audioonly.xml file",
+          "streamNameGroups": []
+        },
+        "transcode": {
+          "name": "transcode",
+          "encodes": [
+            {
+              "name": "720p",
+              "gpuid": -1,
+              "width": 1280,
+              "enable": false,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_720p",
+              "videoCodec": "H.264",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "1300000",
+              "implementation": "default"
+            },
+            {
+              "name": "360p",
+              "gpuid": -1,
+              "width": 640,
+              "enable": true,
+              "height": 360,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_360p",
+              "videoCodec": "H.264",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "850000",
+              "implementation": "default"
+            },
+            {
+              "name": "240p",
+              "gpuid": -1,
+              "width": 360,
+              "enable": false,
+              "height": 240,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_240p",
+              "videoCodec": "H.264",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "350000",
+              "implementation": "default"
+            },
+            {
+              "name": "160p",
+              "gpuid": -1,
+              "width": 284,
+              "enable": true,
+              "height": 160,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_160p",
+              "videoCodec": "H.264",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "200000",
+              "implementation": "default"
+            },
+            {
+              "name": "h263",
+              "gpuid": -1,
+              "width": 176,
+              "enable": false,
+              "height": 144,
+              "fitMode": "letterbox",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_h263",
+              "videoCodec": "H.263",
+              "audioBitrate": "64000",
+              "followSource": false,
+              "videoBitrate": "150000",
+              "implementation": "default"
+            }
+          ],
+          "version": "1541717232000",
+          "overlays": [
+            {
+              "x": 4,
+              "y": 4,
+              "align": "left,top",
+              "index": 0,
+              "width": "${ImageWidth}",
+              "enable": false,
+              "height": "${ImageHeight}",
+              "opacity": 100,
+              "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+              "overlayName": "WowzaLogo",
+              "checkForUpdates": false
+            }
+          ],
+          "deinterlace": false,
+          "description": "Default transcode.xml file",
+          "implementation": "default",
+          "streamNameGroups": [
+            {
+              "name": "all",
+              "Members": [
+                {
+                  "encodeName": "720p",
+                  "memberName": "720p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "360p",
+                  "memberName": "360p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_all"
+            },
+            {
+              "name": "mobile",
+              "Members": [
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_mobile"
+            }
+          ]
+        },
+        "transrate": {
+          "name": "transrate",
+          "encodes": [
+            {
+              "name": "source",
+              "gpuid": 0,
+              "width": 0,
+              "enable": true,
+              "height": 0,
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_source",
+              "videoCodec": "PassThru",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": false,
+              "videoBitrate": "${SourceVideoBitrate}"
+            },
+            {
+              "name": "720p",
+              "gpuid": -1,
+              "width": 1280,
+              "enable": false,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_720p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "1300000",
+              "implementation": "default"
+            },
+            {
+              "name": "360p",
+              "gpuid": -1,
+              "width": 640,
+              "enable": true,
+              "height": 360,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_360p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "850000",
+              "implementation": "default"
+            },
+            {
+              "name": "240p",
+              "gpuid": -1,
+              "width": 360,
+              "enable": false,
+              "height": 240,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_240p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "350000",
+              "implementation": "default"
+            },
+            {
+              "name": "160p",
+              "gpuid": -1,
+              "width": 284,
+              "enable": true,
+              "height": 160,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_160p",
+              "videoCodec": "H.264",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": true,
+              "videoBitrate": "200000",
+              "implementation": "default"
+            },
+            {
+              "name": "h263",
+              "gpuid": -1,
+              "width": 176,
+              "enable": false,
+              "height": 144,
+              "fitMode": "letterbox",
+              "profile": "baseline",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "PassThru",
+              "streamName": "mp4:${SourceStreamName}_h263",
+              "videoCodec": "H.263",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": false,
+              "videoBitrate": "150000",
+              "implementation": "default"
+            }
+          ],
+          "version": "1541717232000",
+          "overlays": [
+            {
+              "x": 4,
+              "y": 4,
+              "align": "left,top",
+              "index": 0,
+              "width": "${ImageWidth}",
+              "enable": false,
+              "height": "${ImageHeight}",
+              "opacity": 100,
+              "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+              "overlayName": "WowzaLogo",
+              "checkForUpdates": false
+            }
+          ],
+          "deinterlace": false,
+          "description": "Default transrate.xml file",
+          "implementation": "default",
+          "streamNameGroups": [
+            {
+              "name": "all",
+              "Members": [
+                {
+                  "encodeName": "source",
+                  "memberName": "source",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "720p",
+                  "memberName": "720p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "360p",
+                  "memberName": "360p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_all"
+            },
+            {
+              "name": "mobile",
+              "Members": [
+                {
+                  "encodeName": "240p",
+                  "memberName": "240p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "160p",
+                  "memberName": "160p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_mobile"
+            }
+          ]
+        },
+        "bild.stream": {
+          "name": "bild.stream",
+          "encodes": [
+            {
+              "name": "stream1_1080",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 1080,
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "PassThru",
+              "streamName": "stream1_high",
+              "videoCodec": "PassThru",
+              "audioBitrate": "${SourceAudioBitrate}",
+              "followSource": false,
+              "videoBitrate": "${SourceVideoBitrate}"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_720",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_720",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_1080",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "2200000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_480",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 480,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_480",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_720",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "1222000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_360",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 360,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_360",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_480",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "772000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_288",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 288,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_288",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_360",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "512000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "facebook4",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "facebook",
+              "videoCodec": "H.264",
+              "description": "Copy of: facebook3",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "4000000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_4mbit",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 0,
+              "fitMode": "match-source",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_1080",
+              "videoCodec": "H.264",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "4000000",
+              "implementation": "NVENC"
+            }
+          ],
+          "version": "1571066074000",
+          "overlays": [],
+          "deinterlace": false,
+          "implementation": "NVCUVID",
+          "streamNameGroups": [
+            {
+              "name": "stream1_all",
+              "Members": [
+                {
+                  "encodeName": "stream1_1080",
+                  "memberName": "stream1_1080",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_720",
+                  "memberName": "stream1_720",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_480",
+                  "memberName": "stream1_480",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_360",
+                  "memberName": "stream1_360",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_288",
+                  "memberName": "stream1_288",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "stream1_all"
+            }
+          ]
+        },
+        "stream1.stream": {
+          "name": "stream1.stream",
+          "encodes": [
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_1080",
+              "gpuid": -1,
+              "width": 0,
+              "enable": false,
+              "height": 1080,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_1080",
+              "videoCodec": "H.264",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "5200000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_720",
+              "gpuid": -1,
+              "width": 0,
+              "enable": false,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_720",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_1080",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "2600000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_480",
+              "gpuid": -1,
+              "width": 0,
+              "enable": false,
+              "height": 480,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_480",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_720",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "1600000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_360",
+              "gpuid": -1,
+              "width": 0,
+              "enable": false,
+              "height": 360,
+              "fitMode": "fit-height",
+              "profile": "main",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_360",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_480",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "1024000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "stream1_288",
+              "gpuid": -1,
+              "width": 0,
+              "enable": false,
+              "height": 288,
+              "fitMode": "fit-height",
+              "profile": "baseline",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "stream1_288",
+              "videoCodec": "H.264",
+              "description": "Copy of: stream1_360",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "512000",
+              "implementation": "NVENC"
+            },
+            {
+              "crop": "0,0,0,0",
+              "name": "facebook1",
+              "gpuid": -1,
+              "width": 0,
+              "enable": true,
+              "height": 720,
+              "fitMode": "fit-height",
+              "profile": "high",
+              "Overlays": [],
+              "interval": 0,
+              "audioCodec": "AAC",
+              "streamName": "facebook1",
+              "videoCodec": "H.264",
+              "audioBitrate": "128000",
+              "followSource": true,
+              "videoBitrate": "4000000",
+              "implementation": "NVENC"
+            }
+          ],
+          "version": "1571063265000",
+          "overlays": [],
+          "deinterlace": false,
+          "implementation": "NVCUVID",
+          "streamNameGroups": [
+            {
+              "name": "stream1_all",
+              "Members": [
+                {
+                  "encodeName": "stream1_1080",
+                  "memberName": "stream1_1080",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_720",
+                  "memberName": "stream1_720",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_480",
+                  "memberName": "stream1_480",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_360",
+                  "memberName": "stream1_360",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "stream1_288",
+                  "memberName": "stream1_288",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "stream1_all"
+            }
+          ]
+        },
+        "transcode-h265-divx": {
+          "name": "transcode-h265-divx",
+          "encodes": [
+            {
+              "name": "4k",
+              "gpuid": -1,
+              "width": 4096,
+              "enable": false,
+              "height": 2160,
+              "fitMode": "letterbox",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_4k",
+              "videoCodec": "H.265",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "12000000",
+              "implementation": "default"
+            },
+            {
+              "name": "1080p",
+              "gpuid": -1,
+              "width": 1920,
+              "enable": false,
+              "height": 1080,
+              "fitMode": "letterbox",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_1080p",
+              "videoCodec": "H.265",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "8000000",
+              "implementation": "default"
+            },
+            {
+              "name": "720p",
+              "gpuid": -1,
+              "width": 1280,
+              "enable": true,
+              "height": 720,
+              "fitMode": "letterbox",
+              "profile": "main",
+              "Overlays": [
+                {
+                  "x": 4,
+                  "y": 4,
+                  "align": "left,top",
+                  "index": 0,
+                  "width": "${ImageWidth}",
+                  "enable": false,
+                  "height": "${ImageHeight}",
+                  "opacity": 100,
+                  "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+                  "overlayName": "WowzaLogo",
+                  "checkForUpdates": false
+                }
+              ],
+              "interval": 60,
+              "audioCodec": "AAC",
+              "streamName": "mp4:${SourceStreamName}_720p",
+              "videoCodec": "H.265",
+              "audioBitrate": "96000",
+              "followSource": false,
+              "videoBitrate": "5000000",
+              "implementation": "default"
+            }
+          ],
+          "version": "1541717232000",
+          "overlays": [
+            {
+              "x": 4,
+              "y": 4,
+              "align": "left,top",
+              "index": 0,
+              "width": "${ImageWidth}",
+              "enable": false,
+              "height": "${ImageHeight}",
+              "opacity": 100,
+              "imagePath": "${com.wowza.wms.context.VHostConfigHome}/content/wowzalogo.png",
+              "overlayName": "WowzaLogo",
+              "checkForUpdates": false
+            }
+          ],
+          "deinterlace": false,
+          "description": "Default H.265 / DivX Transcode.xml file",
+          "implementation": "default",
+          "streamNameGroups": [
+            {
+              "name": "all",
+              "Members": [
+                {
+                  "encodeName": "4k",
+                  "memberName": "4k",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "1080p",
+                  "memberName": "1080p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                },
+                {
+                  "encodeName": "720p",
+                  "memberName": "720p",
+                  "wowzaAudioOnly": false,
+                  "wowzaVideoOnly": false
+                }
+              ],
+              "streamName": "${SourceStreamName}_all"
+            }
+          ]
+        }
+      }
+    },
+    "presets": [
+      "P720p30fps16x9",
+      "P360p30fps16x9",
+      "P360p30fps16x9",
+      "P360p30fps4x3",
+      "P720p30fps16x9",
+      "P144p30fps16x9"
+    ],
+    "renditions": {
+      "facebook": "/stream/836917de-a8c9-4fa3-9171-3cbb8db4cafd/P720p30fps16x9.m3u8",
+      "stream1_288": "/stream/836917de-a8c9-4fa3-9171-3cbb8db4cafd/P360p30fps4x3.m3u8",
+      "stream1_360": "/stream/836917de-a8c9-4fa3-9171-3cbb8db4cafd/P360p30fps16x9.m3u8",
+      "stream1_480": "/stream/836917de-a8c9-4fa3-9171-3cbb8db4cafd/P360p30fps16x9.m3u8",
+      "stream1_720": "/stream/836917de-a8c9-4fa3-9171-3cbb8db4cafd/P720p30fps16x9.m3u8",
+      "stream1_1080": "/stream/836917de-a8c9-4fa3-9171-3cbb8db4cafd/P144p30fps16x9.m3u8",
+      "stream1_high": "/stream/836917de-a8c9-4fa3-9171-3cbb8db4cafd/source.m3u8"
     }
   }
 }

--- a/packages/api/src/controllers/wowza-hydrate.test.js
+++ b/packages/api/src/controllers/wowza-hydrate.test.js
@@ -1,5 +1,5 @@
 import wowzaHydrate from './wowza-hydrate'
-const stream = require('./wowza-hydrate.test-data.json')
+const { stream, camcastStream } = require('./wowza-hydrate.test-data.json')
 const streamWithoutTransrate = JSON.parse(JSON.stringify(stream))
 streamWithoutTransrate.wowza.transcoderAppConfig.templatesInUse =
   '${SourceStreamName}.xml'
@@ -87,5 +87,15 @@ describe('wowzaHydrate', () => {
     }
     const outputStream = wowzaHydrate(inputStream)
     expect(outputStream).toEqual(inputStream)
+  })
+
+  it('should handle duplicate stream cases', () => {
+    const newStream = wowzaHydrate({ ...camcastStream })
+    expect(newStream.presets).toEqual([
+      'P720p30fps16x9',
+      'P360p30fps16x9',
+      'P360p30fps4x3',
+      'P144p30fps16x9',
+    ])
   })
 })


### PR DESCRIPTION
Sometimes we land on the same preset for more than one Wowza transcode config. When that happens, we shouldn't tell go-livepeer to transcode a preset more than once.