### PR TITLE
ar/token object bug fix and schema change

### DIFF
--- a/packages/api/src/cli.js
+++ b/packages/api/src/cli.js
@@ -18,7 +18,7 @@ export default function parseCli(argv) {
     `,
     )
     .env('LP_')
-    .strict(true)
+    //.strict(true)
     .options({
       port: {
         describe: 'port to listen on',

--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -224,6 +224,23 @@ describe('controllers/stream', () => {
       expect(document).toEqual(stream)
     })
 
+    it('should create a stream, `token` registered, no userId', async () => {
+      await server.store.create({
+        id: client.apiKey,
+        kind: 'apitoken',
+      })
+      const res = await client.post('/stream', { ...postMockStream })
+      expect(res.status).toBe(201)
+      const stream = await res.json()
+      expect(stream.id).toBeDefined()
+      expect(stream.kind).toBe('stream')
+      expect(stream.name).toBe('test_stream')
+      const tokenObject = await server.store.get(`apitoken/${client.apiKey}`)
+      expect(stream.userId).toBe(tokenObject.userId)
+      const document = await server.store.get(`stream/${stream.id}`)
+      expect(document).toEqual(stream)
+    })
+
     it('should not accept empty body for creating a stream', async () => {
       const res = await client.post('/stream')
       expect(res.status).toBe(422)

--- a/packages/api/src/middleware/auth.js
+++ b/packages/api/src/middleware/auth.js
@@ -131,7 +131,7 @@ function authFactory(params) {
           userId: userId,
         }
         await req.store.replace(newTokenObject)
-        const user = await req.store.get(`user/${tokenObject.userId}`)
+        const user = await req.store.get(`user/${newTokenObject.userId}`)
         req.user = user
       } catch (error) {
         console.log(error)

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -16,7 +16,6 @@ components:
         - kind
         - name
         - presets
-        - renditions
       additionalProperties: false
       properties:
         id:


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
- Fixes token object bug, which was causing user object to be empty
- Makes `renditions` not required in schema (unrelated, but needed to happen)

**How did you test each of these updates (required)**
Local testing

**Screenshots (optional):**
https://my.papertrailapp.com/groups/16613582/events?focus=1132073364589547669&q=mcw-staging%20api

<img width="1586" alt="Screen Shot 2019-11-15 at 2 35 10 PM" src="https://user-images.githubusercontent.com/16169518/68970430-39e4ea80-07b5-11ea-89c3-2e70ea1d5821.png">

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
