### PR TITLE
fix(ci): add missing explorer-2.0 dependencies in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ aliases:
   # Install libsecret
   - &install-apt-packages
     name: Install apt packages
-    command: sudo apt install libsecret-1-0 libudev-dev
+    command: sudo apt install libsecret-1-0 libudev-dev libusb-1.0-0-dev
 
   # Extention of aws command
   - &s3-cmd-flags-values

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,9 +73,9 @@ aliases:
       fi
 
   # Install libsecret
-  - &install-libsecret
-    name: Install libsecret
-    command: sudo apt install libsecret-1-0
+  - &install-apt-packages
+    name: Install apt packages
+    command: sudo apt install libsecret-1-0 libudev-dev
 
   # Extention of aws command
   - &s3-cmd-flags-values
@@ -110,7 +110,7 @@ jobs:
           # This actually only exists for paid plans. But it's good luck!
           docker_layer_caching: true
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
-      - run: *install-libsecret
+      - run: *install-apt-packages
       - run: *install-dependencies
       - run: *reporter
       - run: *install-gcloud
@@ -135,7 +135,7 @@ jobs:
 
     steps:
       - checkout
-      - run: *install-libsecret
+      - run: *install-apt-packages
       - run: *install-dependencies
       - run: *build-apps
       - save_cache: *save-apps
@@ -169,7 +169,7 @@ jobs:
 
     steps:
       - checkout
-      - run: *install-libsecret
+      - run: *install-apt-packages
       - run: *build-apps
 
       - run:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "dev": "lerna run --stream --no-sort --concurrency=999 dev",
     "updated": "lerna updated --json",
     "wrangler:staging": "wrangler publish --env staging",
-    "wrangler:production": "wrangler publish --env production"
+    "wrangler:production": "wrangler publish --env production",
+    "postinstall": "lerna run --stream postinstall"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.5.2",

--- a/packages/explorer-2.0/next.config.js
+++ b/packages/explorer-2.0/next.config.js
@@ -4,7 +4,7 @@ module.exports = {
     THREEBOX_ENABLED: true,
   },
   webpack(config, options) {
-    config.resolve.alias['scrypt.js'] = require.resolve('scrypt.js/js.js')
+    config.resolve.alias['scrypt'] = require.resolve('scrypt.js/js.js')
     return config
   },
 }

--- a/packages/explorer-2.0/next.config.js
+++ b/packages/explorer-2.0/next.config.js
@@ -3,4 +3,8 @@ module.exports = {
   env: {
     THREEBOX_ENABLED: true,
   },
+  webpack(config, options) {
+    config.resolve.alias['scrypt.js'] = require.resolve('scrypt.js/js.js')
+    return config
+  },
 }

--- a/packages/explorer-2.0/package.json
+++ b/packages/explorer-2.0/package.json
@@ -114,5 +114,8 @@
   "main": "package.json",
   "engines": {
     "node": "10.x"
+  },
+  "resolutions": {
+    "web3-react/@0x/subproviders": "6.0.13"
   }
 }

--- a/packages/explorer-2.0/package.json
+++ b/packages/explorer-2.0/package.json
@@ -114,8 +114,5 @@
   "main": "package.json",
   "engines": {
     "node": "10.x"
-  },
-  "resolutions": {
-    "web3-react/@0x/subproviders": "6.0.13"
   }
 }


### PR DESCRIPTION
We seem to have transitive requirements on these. I encouraged the graph-node folks to put their HID stuff in the `optionalDependencies`, perhaps these Ethereum folks could be convinced to do the same?