### PR TITLE
Removing NotFoundErrors from API

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -53,10 +53,7 @@ app.post('/', authMiddleware({}), validatePost('stream'), async (req, res) => {
       )
       objectStoreID = req.body.objectStoreId
     } catch (e) {
-      console.error(e)
-      if (e.type !== 'NotFoundError') {
-        throw e
-      }
+      throw e
     }
   }
 

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -43,18 +43,10 @@ app.get('/:id', authMiddleware({}), async (req, res) => {
 app.post('/', authMiddleware({}), validatePost('stream'), async (req, res) => {
   const id = uuid()
 
-  console.log(`idddddd: ${req.body.objectStoreId}`)
-
   let objectStoreID
   if (req.body.objectStoreId) {
-    try {
-      await req.store.get(
-        `objectstores/${req.user.id}/${req.body.objectStoreId}`,
-      )
-      objectStoreID = req.body.objectStoreId
-    } catch (e) {
-      throw e
-    }
+    await req.store.get(`objectstores/${req.user.id}/${req.body.objectStoreId}`)
+    objectStoreID = req.body.objectStoreId
   }
 
   const doc = wowzaHydrate({

--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -130,6 +130,34 @@ describe('controllers/stream', () => {
       expect(document).toEqual(stream)
     })
 
+    it('should create a stream, delete it, and error when attempting additional detele or replace', async () => {
+      const res = await client.post('/stream', { ...postMockStream })
+      expect(res.status).toBe(201)
+      const stream = await res.json()
+      expect(stream.id).toBeDefined()
+
+      const document = await server.store.get(`stream/${stream.id}`)
+      expect(document).toEqual(stream)
+
+      await server.store.delete(`stream/${stream.id}`)
+      const deleted = await server.store.get(`stream/${stream.id}`)
+      expect(deleted).toBe(null)
+
+      // it should return a NotFound Error when trying to delete a record that doesn't exist
+      try {
+        await server.store.delete(`stream/${stream.id}`)
+      } catch (err) {
+        expect(err.status).toBe(404)
+      }
+
+      // it should return a NotFound Error when trying to replace a record that doesn't exist
+      try {
+        await server.store.replace(document)
+      } catch (err) {
+        expect(err.status).toBe(404)
+      }
+    })
+
     it('should not get all streams with non-admin user', async () => {
       client.googleAuthorization = ''
       user = {

--- a/packages/api/src/middleware/auth.js
+++ b/packages/api/src/middleware/auth.js
@@ -37,7 +37,6 @@ async function generateUserAndToken(req, res, next) {
     const user = await req.store.get(`user/${userId}`)
     req.user = user
   } catch (error) {
-    console.error(error)
     throw error
   }
 
@@ -102,12 +101,8 @@ function authFactory(params) {
 
     logger.info('authFactory params ', params)
     let tokenObject
-    try {
-      // if tokenObject does not exist, create tokenObject and user
-      tokenObject = await req.store.get(`apitoken/${req.token}`)
-    } catch (e) {
-      throw e
-    }
+    // if tokenObject does not exist, create tokenObject and user
+    tokenObject = await req.store.get(`apitoken/${req.token}`)
 
     if (!tokenObject) {
       logger.warn('api Token not found... generating one')
@@ -135,7 +130,6 @@ function authFactory(params) {
         const user = await req.store.get(`user/${newTokenObject.userId}`)
         req.user = user
       } catch (error) {
-        console.log(error)
         res.status(403)
         return res.json({ errors: [error.toString()] })
       }
@@ -166,14 +160,10 @@ async function getUserWithGoogleAuth(req, res, next) {
   } catch (e) {
     throw new Error('invalid oauth token')
   }
+
   const payload = ticket.getPayload()
-  var user
-  try {
-    user = await req.store.get(`user/${payload.sub}`)
-  } catch (error) {
-    console.error(error)
-    throw error
-  }
+  let user = await req.store.get(`user/${payload.sub}`)
+
   if (!user) {
     await req.store.create({
       id: payload.sub,

--- a/packages/api/src/middleware/auth.js
+++ b/packages/api/src/middleware/auth.js
@@ -106,13 +106,14 @@ function authFactory(params) {
       // if tokenObject does not exist, create tokenObject and user
       tokenObject = await req.store.get(`apitoken/${req.token}`)
     } catch (e) {
-      if (e.type !== 'NotFoundError') {
-        throw e
-      }
+      throw e
+    }
 
+    if (!tokenObject) {
       logger.warn('api Token not found... generating one')
       tokenObject = await generateUserAndToken(req, res, next)
     }
+
     if (tokenObject && !tokenObject.userId) {
       // if tokenObject exists, but no userId, create user and add userId to tokenObject
       try {
@@ -170,10 +171,10 @@ async function getUserWithGoogleAuth(req, res, next) {
   try {
     user = await req.store.get(`user/${payload.sub}`)
   } catch (error) {
-    if (error.type !== 'NotFoundError') {
-      console.error(error)
-      throw error
-    }
+    console.error(error)
+    throw error
+  }
+  if (!user) {
     await req.store.create({
       id: payload.sub,
       name: payload.name,
@@ -181,9 +182,9 @@ async function getUserWithGoogleAuth(req, res, next) {
       domain: payload['hd'],
       kind: 'user',
     })
-    user = await req.store.get(`user/${payload.sub}`)
   }
 
+  user = await req.store.get(`user/${payload.sub}`)
   return user
 }
 

--- a/packages/api/src/store/cloudflare-store.js
+++ b/packages/api/src/store/cloudflare-store.js
@@ -1,5 +1,4 @@
 import logger from '../logger'
-import { NotFoundError } from './errors'
 import fetch from 'isomorphic-fetch'
 import { parse as parseUrl, format as stringifyUrl } from 'url'
 import querystring from 'querystring'
@@ -35,9 +34,7 @@ export default class CloudflareStore {
 
     const values = []
     for (let i = 0; i < respData.result.length; i++) {
-      const reqUrl = `${CLOUDFLARE_URL}/${accountId}/storage/kv/namespaces/${namespace}/values/${
-        respData.result[i].name
-      }`
+      const reqUrl = `${CLOUDFLARE_URL}/${accountId}/storage/kv/namespaces/${namespace}/values/${respData.result[i].name}`
       const resp = await cloudflareFetch(reqUrl)
       await sleep(200)
       values.push(resp)
@@ -111,7 +108,7 @@ async function cloudflareFetch(
     console.log(errorMessage)
 
     if (res.status == 404) {
-      throw new NotFoundError()
+      return null
     } else if (res.status == 429) {
       console.log('Sleeping for 3 seconds')
       await sleep(3000)

--- a/packages/api/src/store/cloudflare-store.js
+++ b/packages/api/src/store/cloudflare-store.js
@@ -2,6 +2,7 @@ import logger from '../logger'
 import fetch from 'isomorphic-fetch'
 import { parse as parseUrl, format as stringifyUrl } from 'url'
 import querystring from 'querystring'
+import { NotFoundError } from './errors'
 
 const CLOUDFLARE_URL = 'https://api.cloudflare.com/client/v4/accounts'
 const DEFAULT_LIMIT = 10
@@ -75,12 +76,26 @@ export default class CloudflareStore {
     }
     const key = `${kind}/${id}`
     const reqUrl = `${CLOUDFLARE_URL}/${accountId}/storage/kv/namespaces/${namespace}/values/${key}`
-    await cloudflareFetch(reqUrl, { data: data, method: 'PUT', retries: 0 })
+    const resp = await cloudflareFetch(reqUrl, {
+      data: data,
+      method: 'PUT',
+      retries: 0,
+    })
+    if (!resp) {
+      throw new NotFoundError()
+    }
   }
 
   async delete(id) {
     const reqUrl = `${CLOUDFLARE_URL}/${accountId}/storage/kv/namespaces/${namespace}/values/${id}`
-    await cloudflareFetch(reqUrl, { data: null, method: 'DELETE', retries: 0 })
+    const resp = await cloudflareFetch(reqUrl, {
+      data: null,
+      method: 'DELETE',
+      retries: 0,
+    })
+    if (!resp) {
+      throw new NotFoundError()
+    }
   }
 }
 

--- a/packages/api/src/store/errors.js
+++ b/packages/api/src/store/errors.js
@@ -1,0 +1,7 @@
+export class NotFoundError extends Error {
+  constructor(message) {
+    super(message)
+    this.type = 'NotFoundError'
+    this.status = 404
+  }
+}

--- a/packages/api/src/store/errors.js
+++ b/packages/api/src/store/errors.js
@@ -1,7 +1,0 @@
-export class NotFoundError extends Error {
-  constructor(message) {
-    super(message)
-    this.type = 'NotFoundError'
-    this.status = 404
-  }
-}

--- a/packages/api/src/store/index.js
+++ b/packages/api/src/store/index.js
@@ -1,4 +1,3 @@
 export { default as LevelStore } from './level-store'
 export { default as PostgresStore } from './postgres-store'
 export { default as CloudflareStore } from './cloudflare-store'
-export * from './errors'

--- a/packages/api/src/store/level-store.js
+++ b/packages/api/src/store/level-store.js
@@ -81,6 +81,7 @@ export default class LevelStore {
       if (err.name === 'NotFoundError') {
         return null
       }
+      throw err
     }
     return JSON.parse(res)
   }
@@ -94,14 +95,9 @@ export default class LevelStore {
       throw new Error(`Missing required values: id, kind`)
     }
     await this.ready
-    let item
-    try {
-      item = await this.get(`${kind}/${id}`)
-      if (item) {
-        throw new Error(`${id} already exists`)
-      }
-    } catch (err) {
-      throw err
+    const item = await this.get(`${kind}/${id}`)
+    if (item) {
+      throw new Error(`${id} already exists`)
     }
     await this.db.put(`${kind}/${id}`, JSON.stringify(data))
   }

--- a/packages/api/src/store/level-store.js
+++ b/packages/api/src/store/level-store.js
@@ -1,5 +1,6 @@
 import level from 'level'
 import fs from 'fs-extra'
+import { NotFoundError } from './errors'
 
 // default limit value in level is -1 , ref: https://github.com/Level/level#dbcreatereadstreamoptions
 const DEFAULT_LIMIT = -1
@@ -113,13 +114,19 @@ export default class LevelStore {
     await this.ready
 
     // Make sure it exists first, this throws if not
-    await this.db.get(`${kind}/${id}`)
+    const record = await this.db.get(`${kind}/${id}`)
+    if (!record) {
+      throw new NotFoundError()
+    }
     await this.db.put(`${kind}/${id}`, JSON.stringify(data))
   }
 
   async delete(id) {
     // Make sure it exists first, this throws if not
-    await this.db.get(id)
+    const record = await this.db.get(id)
+    if (!record) {
+      throw new NotFoundError()
+    }
     await this.db.del(id)
   }
 }

--- a/packages/api/src/store/postgres-store.js
+++ b/packages/api/src/store/postgres-store.js
@@ -1,5 +1,6 @@
 import { Pool } from 'pg'
 import logger from '../logger'
+import { NotFoundError } from './errors'
 import { timeout } from '../util'
 import { parse as parseUrl, format as stringifyUrl } from 'url'
 
@@ -93,6 +94,10 @@ export default class PostgresStore {
       `UPDATE ${TABLE_NAME} SET data = $1 WHERE id = $2`,
       [JSON.stringify(data), key],
     )
+
+    if (res.rowCount < 1) {
+      throw new NotFoundError()
+    }
   }
 
   async delete(id) {

--- a/packages/api/src/store/postgres-store.js
+++ b/packages/api/src/store/postgres-store.js
@@ -105,6 +105,10 @@ export default class PostgresStore {
       `DELETE FROM ${TABLE_NAME} WHERE id = $1`,
       [id],
     )
+
+    if (res.rowCount < 1) {
+      throw new NotFoundError()
+    }
   }
 }
 

--- a/packages/api/src/store/postgres-store.js
+++ b/packages/api/src/store/postgres-store.js
@@ -1,6 +1,5 @@
 import { Pool } from 'pg'
 import logger from '../logger'
-import { NotFoundError } from './errors'
 import { timeout } from '../util'
 import { parse as parseUrl, format as stringifyUrl } from 'url'
 
@@ -59,7 +58,7 @@ export default class PostgresStore {
     )
 
     if (res.rowCount < 1) {
-      throw new NotFoundError()
+      return null
     }
     return res.rows[0].data
   }
@@ -94,9 +93,6 @@ export default class PostgresStore {
       `UPDATE ${TABLE_NAME} SET data = $1 WHERE id = $2`,
       [JSON.stringify(data), key],
     )
-    if (res.rowCount < 1) {
-      throw new NotFoundError()
-    }
   }
 
   async delete(id) {
@@ -104,9 +100,6 @@ export default class PostgresStore {
       `DELETE FROM ${TABLE_NAME} WHERE id = $1`,
       [id],
     )
-    if (res.rowCount < 1) {
-      throw new NotFoundError()
-    }
   }
 }
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

We have a pattern of returning NotFoundError when an item isn't found in the database. As a result, the following is repeated often:

```javascript
if (e.type !== 'NotFoundError') {
        throw e
}
```

**Specific updates (required)**
We should return null from req.store.get instead of `NotFoundError`.

**Does this pull request close any open issues?**
https://github.com/livepeer/livepeerjs/issues/525

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
