### PR TITLE
bug fix: adding hardcodedNodes fallback

### DIFF
--- a/packages/api/src/app-router.js
+++ b/packages/api/src/app-router.js
@@ -72,9 +72,9 @@ export default async function makeApp(params) {
         kubeOrchestratorTemplate,
       }),
     )
-  } else {
-    app.use(hardcodedNodes({ orchestrators, broadcasters }))
   }
+
+  app.use(hardcodedNodes({ orchestrators, broadcasters }))
 
   // Add a controller for each route at the /${httpPrefix} route
   const prefixRouter = Router() // amalgamates our endpoints together and serves them out


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Fixes error on stage/prod: `TypeError: req.getBroadcasters is not a function`

https://my.papertrailapp.com/events?q=getBroadcasters

**Fixes:**
https://github.com/livepeer/livepeerjs/issues/564

**Specific updates (required)**

We implemented a hack to have `—broadcasters` hardcoded instead of `—broadcastedService` in our k8 deployment. 

This: https://github.com/livepeer/livepeerjs/commit/abe14a12d04c1b925e2bf36f68daf4dc27e41e73#diff-1daa3ceb9fc0b9b0f690c6c4980f64cbR75-R77 

was changed from this: https://github.com/livepeer/livepeerjs/commit/abe14a12d04c1b925e2bf36f68daf4dc27e41e73#diff-5b799c64ad01cad68d3e23d0b1d04a9bL88-L90

I am reverting back the change so `hardcoded-nodes.js` can set `getBroadcasters` when it isn't set by `kubernettes.js` here:
```if (!req.getBroadcasters) {
      req.getBroadcasters = async () => broadcasters
    }```

**How did you test each of these updates (required)**
Tested on dev 
