### PR TITLE
save correct internal external addresses

### DIFF
--- a/packages/api/src/app-router.js
+++ b/packages/api/src/app-router.js
@@ -70,9 +70,11 @@ export default async function makeApp(params) {
         kubeOrchestratorService,
         kubeBroadcasterTemplate,
         kubeOrchestratorTemplate,
+        broadcasters,
+        orchestrators
       }),
-    )
-  }
+      )
+    }
 
   app.use(hardcodedNodes({ orchestrators, broadcasters }))
 

--- a/packages/api/src/middleware/kubernetes.js
+++ b/packages/api/src/middleware/kubernetes.js
@@ -5,6 +5,7 @@
 import { render } from 'mustache'
 import * as k8s from '@kubernetes/client-node'
 import { timeout } from '../util'
+import { hardcodedNodes } from '.'
 
 export default function kubernetesMiddleware({
   kubeNamespace,
@@ -12,6 +13,8 @@ export default function kubernetesMiddleware({
   kubeOrchestratorService,
   kubeBroadcasterTemplate,
   kubeOrchestratorTemplate,
+  broadcasters,
+  orchestrators
 }) {
   const kc = new k8s.KubeConfig()
   kc.loadFromDefault()
@@ -68,11 +71,19 @@ export default function kubernetesMiddleware({
 
   return (req, res, next) => {
     if (kubeBroadcasterService) {
-      req.getBroadcasters = getBroadcasters
+      if (broadcasters && req.headers.host.endsWith('cluster.local')) {
+        req.getBroadcasters = getBroadcasters
+      } else {
+        hardcodedNodes({ orchestrators, broadcasters })
+      }
     }
 
     if (kubeOrchestratorService) {
-      req.getOrchestrators = getOrchestrators
+      if (orchestrators && req.headers.host.endsWith('cluster.local')) {
+        req.getOrchestrators = getOrchestrators
+      } else {
+        hardcodedNodes({ orchestrators, broadcasters })
+      }
     }
 
     return next()


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
https://github.com/livepeer/livepeerjs/issues/572

**Specific updates (required)**
Behavior:

- If --kube-broadcaster-service is defined, populate /api/broadcasters from kubernetes
- if --broadcasters is defined, populate /api/broadcasters from that hardcoded list
- if BOTH are defined, serve Kubernetes broadcasters to folks making requests from .cluster.local domains, otherwise serve out the hardcoded ones
- 

**How did you test each of these updates (required)**
Locally

**Does this pull request close any open issues?**
https://github.com/livepeer/livepeerjs/issues/572

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
