### PR TITLE
fix 3box external account signature verification

### DIFF
--- a/packages/explorer-2.0/components/EditProfile/index.tsx
+++ b/packages/explorer-2.0/components/EditProfile/index.tsx
@@ -117,8 +117,12 @@ export default ({ threeBoxSpace, refetch, account }: Props) => {
       if (hasExistingProfile(profile)) {
         setHasProfile(true)
       }
+
+      const Web3 = require('web3') // use web3 lib for ecRecover method
+      const web3 = new Web3(context.library._web3Provider)
+
       if (signature && ethereumAccount) {
-        const verifiedAccount = await context.library.eth.personal.ecRecover(
+        const verifiedAccount = await web3.eth.personal.ecRecover(
           message.replace(/<br ?\/?>/g, '\n'),
           signature,
         )

--- a/packages/explorer-2.0/components/EditProfile/index.tsx
+++ b/packages/explorer-2.0/components/EditProfile/index.tsx
@@ -18,6 +18,7 @@ import { useDebounce } from 'use-debounce'
 import ThreeBoxSteps from '../ThreeBoxSteps'
 import Spinner from '../Spinner'
 import { useWeb3React } from '@web3-react/core'
+import { ethers } from 'ethers'
 
 interface Props {
   account: string
@@ -118,11 +119,8 @@ export default ({ threeBoxSpace, refetch, account }: Props) => {
         setHasProfile(true)
       }
 
-      const Web3 = require('web3') // use web3 lib for ecRecover method
-      const web3 = new Web3(context.library._web3Provider)
-
       if (signature && ethereumAccount) {
-        const verifiedAccount = await web3.eth.personal.ecRecover(
+        let verifiedAccount = ethers.utils.verifyMessage(
           message.replace(/<br ?\/?>/g, '\n'),
           signature,
         )

--- a/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
+++ b/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
@@ -66,7 +66,10 @@ export default withApollo(() => {
     }
   }, [context.chainId])
 
-  if (loading || loadingMyAccount) {
+  if (
+    ((loading || loadingMyAccount) && !data) ||
+    (context.active && !dataMyAccount)
+  ) {
     return (
       <Layout>
         <Flex


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes an issue causing the 3box signature verification to fail when adding an external account. This bug was introduced when we switched the web3 library we pass into `web3-react` (`ethers.js` instead of `web3.js`) since ether.js doesn't have a `ecrecover` method. 

It also prevents the account page from reloading and displaying the loading indicator after successfully linking an external account.

**Specific updates (required)**
- Instantiates web3 instance and uses `ecRecover` method for signature verification
- Checks if data has already been fetched and if so prevents loading indicator from taking over the page upon data refetching.

**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
