### PR TITLE
update subgraph Protocol entity with new fields

### DIFF
--- a/packages/subgraph/abis/Controller.json
+++ b/packages/subgraph/abis/Controller.json
@@ -12,11 +12,18 @@
     "constant": true,
     "inputs": [],
     "name": "paused",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_id", "type": "bytes32" }],
+    "name": "getContractInfo",
     "outputs": [
-      {
-        "name": "",
-        "type": "bool"
-      }
+      { "name": "", "type": "address" },
+      { "name": "", "type": "bytes20" }
     ],
     "payable": false,
     "stateMutability": "view",
@@ -35,12 +42,7 @@
     "constant": true,
     "inputs": [],
     "name": "owner",
-    "outputs": [
-      {
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "outputs": [{ "name": "", "type": "address" }],
     "payable": false,
     "stateMutability": "view",
     "type": "function"
@@ -48,11 +50,40 @@
   {
     "constant": false,
     "inputs": [
-      {
-        "name": "newOwner",
-        "type": "address"
-      }
+      { "name": "_id", "type": "bytes32" },
+      { "name": "_contractAddress", "type": "address" },
+      { "name": "_gitCommitHash", "type": "bytes20" }
     ],
+    "name": "setContractInfo",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "name": "_id", "type": "bytes32" }],
+    "name": "getContract",
+    "outputs": [{ "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_id", "type": "bytes32" },
+      { "name": "_controller", "type": "address" }
+    ],
+    "name": "updateController",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "name": "newOwner", "type": "address" }],
     "name": "transferOwnership",
     "outputs": [],
     "payable": false,
@@ -68,134 +99,22 @@
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": false,
-        "name": "id",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "name": "contractAddress",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "name": "gitCommitHash",
-        "type": "bytes20"
-      }
+      { "indexed": false, "name": "id", "type": "bytes32" },
+      { "indexed": false, "name": "contractAddress", "type": "address" },
+      { "indexed": false, "name": "gitCommitHash", "type": "bytes20" }
     ],
     "name": "SetContractInfo",
     "type": "event"
   },
-  {
-    "anonymous": false,
-    "inputs": [],
-    "name": "Pause",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [],
-    "name": "Unpause",
-    "type": "event"
-  },
+  { "anonymous": false, "inputs": [], "name": "Pause", "type": "event" },
+  { "anonymous": false, "inputs": [], "name": "Unpause", "type": "event" },
   {
     "anonymous": false,
     "inputs": [
-      {
-        "indexed": true,
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "name": "newOwner",
-        "type": "address"
-      }
+      { "indexed": true, "name": "previousOwner", "type": "address" },
+      { "indexed": true, "name": "newOwner", "type": "address" }
     ],
     "name": "OwnershipTransferred",
     "type": "event"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
-        "name": "_id",
-        "type": "bytes32"
-      },
-      {
-        "name": "_contractAddress",
-        "type": "address"
-      },
-      {
-        "name": "_gitCommitHash",
-        "type": "bytes20"
-      }
-    ],
-    "name": "setContractInfo",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
-        "name": "_id",
-        "type": "bytes32"
-      },
-      {
-        "name": "_controller",
-        "type": "address"
-      }
-    ],
-    "name": "updateController",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [
-      {
-        "name": "_id",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getContractInfo",
-    "outputs": [
-      {
-        "name": "",
-        "type": "address"
-      },
-      {
-        "name": "",
-        "type": "bytes20"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [
-      {
-        "name": "_id",
-        "type": "bytes32"
-      }
-    ],
-    "name": "getContract",
-    "outputs": [
-      {
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
   }
 ]

--- a/packages/subgraph/abis/RoundsManager.json
+++ b/packages/subgraph/abis/RoundsManager.json
@@ -70,6 +70,20 @@
     "type": "function"
   },
   {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_controller",
+        "type": "address"
+      }
+    ],
+    "name": "setController",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "constant": true,
     "inputs": [],
     "name": "roundLockAmount",
@@ -118,6 +132,30 @@
       }
     ],
     "name": "NewRound",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "controller",
+        "type": "address"
+      }
+    ],
+    "name": "SetController",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "param",
+        "type": "string"
+      }
+    ],
+    "name": "ParameterUpdate",
     "type": "event"
   },
   {

--- a/packages/subgraph/networks.yaml
+++ b/packages/subgraph/networks.yaml
@@ -1,32 +1,38 @@
 mainnet:
   contracts:
+    controller:
+      address: 'f96d54e490317c557a967abfa5d6e33006be69b3'
+      startBlock: 5533890
     bondingManager:
       address: '511bc4556d823ae99630ae8de28b9b80df90ea2e'
-      startBlock: 5533890
+      startBlock: 5533958
     bondingManagerLIP11:
       address: '511bc4556d823ae99630ae8de28b9b80df90ea2e'
-      startBlock: 5533890
+      startBlock: 5533958
     bondingManagerLIP12:
       address: '511bc4556d823ae99630ae8de28b9b80df90ea2e'
-      startBlock: 5533890
+      startBlock: 5533958
     roundsManager:
       address: '3984fc4ceeef1739135476f625d36d6c35c40dc3'
-      startBlock: 5533890
+      startBlock: 5533997
     roundsManagerLIP12:
       address: '3984fc4ceeef1739135476f625d36d6c35c40dc3'
-      startBlock: 5533890
+      startBlock: 5533997
     livepeerToken:
       address: '58b6a8a3302369daec383334672404ee733ab239'
-      startBlock: 5533890
+      startBlock: 5533907
     minter:
       address: '8573f2f5a3bd960eee3d998473e50c75cdbe6828'
-      startBlock: 5533890
+      startBlock: 5533913
     ticketBroker:
       address: '5b1ce829384eebfa30286f12d1e7a695ca45f5d2'
       startBlock: 9274420
   networkName: mainnet
 rinkeby:
   contracts:
+    controller:
+      address: 'A268AEa9D048F8d3A592dD7f1821297972D4C8Ea'
+      startBlock: 5325848
     bondingManager:
       address: 'e75a5DccfFe8939F7f16CC7f63EB252bB542FE95'
       startBlock: 5325862

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -77,8 +77,6 @@ type Round @entity {
   length: BigInt
   "The time at which this round was initialized"
   timestamp: BigInt
-  "Last initialized round. After first round, this is the last round during which initializeRound() was called"
-  lastInitializedRound: BigInt
   "The block number at which this round was initialized"
   startBlock: BigInt
   "The pools associated with the round"
@@ -155,8 +153,22 @@ type UnbondingLock @entity {
 
 type Protocol @entity {
   id: ID!
-  totalWinningTickets: BigInt
+  currentRound: Round
+  inflation: BigInt
+  inflationChange: BigInt
+  lastInitializedRound: BigInt
+  lastRoundLengthUpdateRound: BigInt
+  lastRoundLengthUpdateStartBlock: BigInt
+  lockPeriod: BigInt
+  maxEarningsClaimsRounds: BigInt
+  numActiveTranscoders: BigInt
+  paused: Boolean
+  roundLength: BigInt
+  roundLockAmount: BigInt
+  targetBondingRate: BigInt
   totalGeneratedFees: BigInt
+  totalWinningTickets: BigInt
+  unbondingPeriod: BigInt
 }
 
 """
@@ -478,4 +490,55 @@ type Withdrawal implements Transaction @entity {
   sender: String
   deposit: BigInt
   reserve: BigInt
+}
+
+type SetCurrentRewardTokens implements Transaction @entity {
+  id: ID!
+  hash: String
+  blockNumber: BigInt!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+  timestamp: BigInt
+  from: String
+  to: String
+  round: Round
+  currentMintableTokens: BigInt
+  currentInflation: BigInt
+}
+
+type Pause implements Transaction @entity {
+  id: ID!
+  hash: String
+  blockNumber: BigInt!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+  timestamp: BigInt
+  from: String
+  to: String
+  round: Round
+}
+
+type Unpause implements Transaction @entity {
+  id: ID!
+  hash: String
+  blockNumber: BigInt!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+  timestamp: BigInt
+  from: String
+  to: String
+  round: Round
+}
+
+type ParameterUpdate implements Transaction @entity {
+  id: ID!
+  hash: String
+  blockNumber: BigInt!
+  gasUsed: BigInt!
+  gasPrice: BigInt!
+  timestamp: BigInt
+  from: String
+  to: String
+  round: Round
+  param: String
 }

--- a/packages/subgraph/src/mappings/bondingManager.ts
+++ b/packages/subgraph/src/mappings/bondingManager.ts
@@ -42,16 +42,10 @@ import { makePoolId, makeEventId } from './util'
 export function transcoderUpdated(event: TranscoderUpdateEvent): void {
   let transcoderAddress = event.params.transcoder
   let bondingManager = BondingManager.bind(event.address)
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
-  let transcoder = Transcoder.load(transcoderAddress.toHex())
-
-  // Create transcoder if it does not yet exist
-  if (transcoder == null) {
-    transcoder = new Transcoder(transcoderAddress.toHex())
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
+  let transcoder =
+    Transcoder.load(transcoderAddress.toHex()) ||
+    new Transcoder(transcoderAddress.toHex())
 
   let active = bondingManager.isActiveTranscoder(
     transcoderAddress,
@@ -93,10 +87,7 @@ export function transcoderUpdated(event: TranscoderUpdateEvent): void {
 export function transcoderResigned(event: TranscoderResignedEvent): void {
   let transcoderAddress = event.params.transcoder
   let transcoder = Transcoder.load(transcoderAddress.toHex())
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
 
   // Update transcoder
   transcoder.active = false
@@ -126,10 +117,7 @@ export function transcoderResigned(event: TranscoderResignedEvent): void {
 export function transcoderEvicted(event: TranscoderEvictedEvent): void {
   let transcoderAddress = event.params.transcoder
   let transcoder = Transcoder.load(transcoderAddress.toHex())
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
 
   // Update transcoder
   transcoder.active = false
@@ -157,10 +145,7 @@ export function transcoderSlashed(event: TranscoderSlashedEvent): void {
   let transcoderAddress = event.params.transcoder
   let transcoder = Transcoder.load(transcoderAddress.toHex())
   let bondingManager = BondingManager.bind(event.address)
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   let delegateData = bondingManager.getDelegator(transcoderAddress)
 
   // Update transcoder total stake
@@ -197,26 +182,17 @@ export function bond(call: BondCall): void {
     let amount = call.inputs._amount
     let delegatorData = bondingManager.getDelegator(delegatorAddress)
     let delegateData = bondingManager.getDelegator(newDelegateAddress)
-    let protocol = Protocol.load('0')
-    if (protocol == null) {
-      protocol = new Protocol('0')
-    }
+    let protocol = Protocol.load('0') || new Protocol('0')
     let round = Round.load(protocol.currentRound)
-
-    let transcoder = Transcoder.load(newDelegateAddress.toHex())
-    if (transcoder == null) {
-      transcoder = new Transcoder(newDelegateAddress.toHex())
-    }
-
-    let delegate = Delegator.load(newDelegateAddress.toHex())
-    if (delegate == null) {
-      delegate = new Delegator(newDelegateAddress.toHex())
-    }
-
-    let delegator = Delegator.load(delegatorAddress.toHex())
-    if (delegator == null) {
-      delegator = new Delegator(delegatorAddress.toHex())
-    }
+    let transcoder =
+      Transcoder.load(newDelegateAddress.toHex()) ||
+      new Transcoder(newDelegateAddress.toHex())
+    let delegate =
+      Delegator.load(newDelegateAddress.toHex()) ||
+      new Delegator(newDelegateAddress.toHex())
+    let delegator =
+      Delegator.load(delegatorAddress.toHex()) ||
+      new Delegator(delegatorAddress.toHex())
 
     // If self delegating, set status and assign reference to self
     if (delegatorAddress.toHex() == newDelegateAddress.toHex()) {
@@ -306,20 +282,11 @@ export function unbond(event: UnbondEvent): void {
   let delegatorAddress = event.params.delegator
   let delegator = Delegator.load(delegatorAddress.toHex())
   let transcoderAddress = delegator.delegate
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
-
-  let transcoder = Transcoder.load(transcoderAddress)
-  if (transcoder == null) {
-    transcoder = new Transcoder(transcoderAddress)
-  }
-
-  let delegate = Delegator.load(transcoderAddress)
-  if (delegate == null) {
-    delegate = new Delegator(transcoderAddress)
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
+  let transcoder =
+    Transcoder.load(transcoderAddress) || new Transcoder(transcoderAddress)
+  let delegate =
+    Delegator.load(transcoderAddress) || new Delegator(transcoderAddress)
 
   let delegateData = bondingManager.getDelegator(
     Address.fromString(transcoderAddress),
@@ -367,10 +334,7 @@ export function reward(event: RewardEvent): void {
   let transcoder = Transcoder.load(transcoderAddress.toHex())
   let delegate = Delegator.load(transcoderAddress.toHex())
   let delegateData = bondingManager.getDelegator(transcoderAddress)
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   let poolId = makePoolId(transcoderAddress, protocol.currentRound)
   let pool = Pool.load(poolId)
 
@@ -408,10 +372,7 @@ export function claimEarnings(call: ClaimEarningsCall): void {
   if (call.block.number.le(BigInt.fromI32(9274414))) {
     let delegatorAddress = call.from
     let endRound = call.inputs._endRound
-    let protocol = Protocol.load('0')
-    if (protocol == null) {
-      protocol = new Protocol('0')
-    }
+    let protocol = Protocol.load('0') || new Protocol('0')
     let delegator = Delegator.load(delegatorAddress.toHex())
     let bondingManager = BondingManager.bind(call.to)
     let delegatorData = bondingManager.getDelegator(delegatorAddress)
@@ -450,10 +411,7 @@ export function claimEarnings(call: ClaimEarningsCall): void {
 export function withdrawStake(event: WithdrawStakeEvent): void {
   let delegatorAddress = event.params.delegator
   let delegator = Delegator.load(delegatorAddress.toHex())
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
 
   // Store transaction info
   let withdrawStake = new WithdrawStake(
@@ -479,10 +437,7 @@ export function withdrawFees(event: WithdrawFeesEvent): void {
   let bondingManager = BondingManager.bind(event.address)
   let delegatorAddress = event.params.delegator
   let delegator = Delegator.load(delegatorAddress.toHex())
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   let delegatorData = bondingManager.getDelegator(delegatorAddress)
   let withdrawnFees = delegator.fees as BigInt
 
@@ -511,10 +466,7 @@ export function withdrawFees(event: WithdrawFeesEvent): void {
 
 export function parameterUpdate(event: ParameterUpdateEvent): void {
   let bondingManager = BondingManager.bind(event.address)
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
 
   if (event.params.param == 'unbondingPeriod') {
     protocol.unbondingPeriod = bondingManager.unbondingPeriod()

--- a/packages/subgraph/src/mappings/bondingManager_LIP11.ts
+++ b/packages/subgraph/src/mappings/bondingManager_LIP11.ts
@@ -33,29 +33,24 @@ export function bond(event: BondEvent): void {
   let additionalAmount = event.params.additionalAmount
   let delegateData = bondingManager.getDelegator(newDelegateAddress)
   let delegatorData = bondingManager.getDelegator(delegatorAddress)
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
+
   let round = Round.load(protocol.currentRound)
   let EMPTY_ADDRESS = Address.fromString(
     '0000000000000000000000000000000000000000',
   )
 
-  let transcoder = Transcoder.load(newDelegateAddress.toHex())
-  if (transcoder == null) {
-    transcoder = new Transcoder(newDelegateAddress.toHex())
-  }
+  let transcoder =
+    Transcoder.load(newDelegateAddress.toHex()) ||
+    new Transcoder(newDelegateAddress.toHex())
 
-  let delegate = Delegator.load(newDelegateAddress.toHex())
-  if (delegate == null) {
-    delegate = new Delegator(newDelegateAddress.toHex())
-  }
+  let delegate =
+    Delegator.load(newDelegateAddress.toHex()) ||
+    new Delegator(newDelegateAddress.toHex())
 
-  let delegator = Delegator.load(delegatorAddress.toHex())
-  if (delegator == null) {
-    delegator = new Delegator(delegatorAddress.toHex())
-  }
+  let delegator =
+    Delegator.load(delegatorAddress.toHex()) ||
+    new Delegator(delegatorAddress.toHex())
 
   // If self delegating, set status and assign reference to self
   if (delegatorAddress.toHex() == newDelegateAddress.toHex()) {
@@ -141,25 +136,20 @@ export function unbond(event: UnbondEvent): void {
   let amount = event.params.amount
   let delegator = Delegator.load(delegatorAddress.toHex())
   let delegateData = bondingManager.getDelegator(delegateAddress)
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
 
-  let transcoder = Transcoder.load(delegateAddress.toHex())
-  if (transcoder == null) {
-    transcoder = new Transcoder(delegateAddress.toHex())
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
 
-  let delegate = Delegator.load(delegateAddress.toHex())
-  if (delegate == null) {
-    delegate = new Delegator(delegateAddress.toHex())
-  }
+  let transcoder =
+    Transcoder.load(delegateAddress.toHex()) ||
+    new Transcoder(delegateAddress.toHex())
 
-  let unbondingLock = UnbondingLock.load(uniqueUnbondingLockId)
-  if (unbondingLock == null) {
-    unbondingLock = new UnbondingLock(uniqueUnbondingLockId)
-  }
+  let delegate =
+    Delegator.load(delegateAddress.toHex()) ||
+    new Delegator(delegateAddress.toHex())
+
+  let unbondingLock =
+    UnbondingLock.load(uniqueUnbondingLockId) ||
+    new UnbondingLock(uniqueUnbondingLockId)
 
   delegate.delegatedAmount = delegateData.value3
   transcoder.totalStake = delegateData.value3
@@ -231,10 +221,7 @@ export function rebond(event: RebondEvent): void {
   let delegator = Delegator.load(delegatorAddress.toHex())
   let delegateData = bondingManager.getDelegator(delegateAddress)
 
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
 
   // If rebonding from unbonded and is self-bonding then update transcoder status
   if (
@@ -286,10 +273,8 @@ export function withdrawStake(event: WithdrawStakeEvent): void {
   let delegatorAddress = event.params.delegator
   let unbondingLockId = event.params.unbondingLockId
   let amount = event.params.amount
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
+
   let uniqueUnbondingLockId = makeUnbondingLockId(
     delegatorAddress,
     unbondingLockId,

--- a/packages/subgraph/src/mappings/bondingManager_LIP12.ts
+++ b/packages/subgraph/src/mappings/bondingManager_LIP12.ts
@@ -1,6 +1,3 @@
-import { dataSource } from '@graphprotocol/graph-ts'
-
-// Import event types from the registrar contract ABIs
 import {
   TranscoderUpdate as TranscoderUpdateEvent,
   TranscoderActivated as TranscoderActivatedEvent,
@@ -15,20 +12,19 @@ import {
   EarningsClaimed,
   TranscoderActivated,
   TranscoderDeactivated,
+  Protocol,
 } from '../types/schema'
 
-import {
-  MAXIMUM_VALUE_UINT256,
-  getRoundsManagerInstance,
-  makeEventId,
-} from './util'
+import { MAXIMUM_VALUE_UINT256, makeEventId } from './util'
 
 export function transcoderUpdated(event: TranscoderUpdateEvent): void {
   let transcoderAddress = event.params.transcoder
   let rewardCut = event.params.rewardCut
   let feeShare = event.params.feeShare
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
   let transcoder = Transcoder.load(transcoderAddress.toHex())
 
   // Create transcoder if it does not yet exist
@@ -53,7 +49,7 @@ export function transcoderUpdated(event: TranscoderUpdateEvent): void {
   transcoderUpdated.timestamp = event.block.timestamp
   transcoderUpdated.from = event.transaction.from.toHex()
   transcoderUpdated.to = event.transaction.to.toHex()
-  transcoderUpdated.round = currentRound.toString()
+  transcoderUpdated.round = protocol.currentRound
   transcoderUpdated.rewardCut = rewardCut
   transcoderUpdated.feeShare = feeShare
   transcoderUpdated.delegate = transcoderAddress.toHex()
@@ -62,8 +58,10 @@ export function transcoderUpdated(event: TranscoderUpdateEvent): void {
 
 export function transcoderActivated(event: TranscoderActivatedEvent): void {
   let transcoderAddress = event.params.transcoder
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
   let transcoder = Transcoder.load(transcoderAddress.toHex())
   if (transcoder == null) {
     transcoder = new Transcoder(transcoderAddress.toHex())
@@ -86,7 +84,7 @@ export function transcoderActivated(event: TranscoderActivatedEvent): void {
   transcoderActivated.timestamp = event.block.timestamp
   transcoderActivated.from = event.transaction.from.toHex()
   transcoderActivated.to = event.transaction.to.toHex()
-  transcoderActivated.round = currentRound.toString()
+  transcoderActivated.round = protocol.currentRound
   transcoderActivated.activationRound = event.params.activationRound
   transcoderActivated.delegate = transcoderAddress.toHex()
   transcoderActivated.save()
@@ -95,8 +93,10 @@ export function transcoderActivated(event: TranscoderActivatedEvent): void {
 export function transcoderDeactivated(event: TranscoderDeactivatedEvent): void {
   let transcoderAddress = event.params.transcoder
   let transcoder = Transcoder.load(transcoderAddress.toHex())
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
 
   transcoder.active = false
   transcoder.deactivationRound = event.params.deactivationRound
@@ -113,7 +113,7 @@ export function transcoderDeactivated(event: TranscoderDeactivatedEvent): void {
   transcoderDeactivated.timestamp = event.block.timestamp
   transcoderDeactivated.from = event.transaction.from.toHex()
   transcoderDeactivated.to = event.transaction.to.toHex()
-  transcoderDeactivated.round = currentRound.toString()
+  transcoderDeactivated.round = protocol.currentRound
   transcoderDeactivated.deactivationRound = event.params.deactivationRound
   transcoderDeactivated.delegate = transcoderAddress.toHex()
   transcoderDeactivated.save()
@@ -126,8 +126,10 @@ export function earningsClaimed(event: EarningsClaimedEvent): void {
   let fees = event.params.fees
   let startRound = event.params.startRound
   let endRound = event.params.startRound
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
   let delegator = Delegator.load(delegatorAddress.toHex())
 
   delegator.lastClaimRound = event.params.endRound.toString()
@@ -145,7 +147,7 @@ export function earningsClaimed(event: EarningsClaimedEvent): void {
   earningsClaimed.timestamp = event.block.timestamp
   earningsClaimed.from = event.transaction.from.toHex()
   earningsClaimed.to = event.transaction.to.toHex()
-  earningsClaimed.round = currentRound.toString()
+  earningsClaimed.round = protocol.currentRound
   earningsClaimed.delegate = delegateAddress.toHex()
   earningsClaimed.delegator = delegatorAddress.toHex()
   earningsClaimed.startRound = startRound.toString()

--- a/packages/subgraph/src/mappings/bondingManager_LIP12.ts
+++ b/packages/subgraph/src/mappings/bondingManager_LIP12.ts
@@ -21,16 +21,10 @@ export function transcoderUpdated(event: TranscoderUpdateEvent): void {
   let transcoderAddress = event.params.transcoder
   let rewardCut = event.params.rewardCut
   let feeShare = event.params.feeShare
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
-  let transcoder = Transcoder.load(transcoderAddress.toHex())
-
-  // Create transcoder if it does not yet exist
-  if (transcoder == null) {
-    transcoder = new Transcoder(transcoderAddress.toHex())
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
+  let transcoder =
+    Transcoder.load(transcoderAddress.toHex()) ||
+    new Transcoder(transcoderAddress.toHex())
 
   transcoder.rewardCut = rewardCut
   transcoder.feeShare = feeShare
@@ -58,14 +52,11 @@ export function transcoderUpdated(event: TranscoderUpdateEvent): void {
 
 export function transcoderActivated(event: TranscoderActivatedEvent): void {
   let transcoderAddress = event.params.transcoder
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
-  let transcoder = Transcoder.load(transcoderAddress.toHex())
-  if (transcoder == null) {
-    transcoder = new Transcoder(transcoderAddress.toHex())
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
+
+  let transcoder =
+    Transcoder.load(transcoderAddress.toHex()) ||
+    new Transcoder(transcoderAddress.toHex())
 
   transcoder.active = true
   transcoder.lastActiveStakeUpdateRound = event.params.activationRound
@@ -93,10 +84,7 @@ export function transcoderActivated(event: TranscoderActivatedEvent): void {
 export function transcoderDeactivated(event: TranscoderDeactivatedEvent): void {
   let transcoderAddress = event.params.transcoder
   let transcoder = Transcoder.load(transcoderAddress.toHex())
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
 
   transcoder.active = false
   transcoder.deactivationRound = event.params.deactivationRound
@@ -126,10 +114,7 @@ export function earningsClaimed(event: EarningsClaimedEvent): void {
   let fees = event.params.fees
   let startRound = event.params.startRound
   let endRound = event.params.startRound
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   let delegator = Delegator.load(delegatorAddress.toHex())
 
   delegator.lastClaimRound = event.params.endRound.toString()

--- a/packages/subgraph/src/mappings/controller.ts
+++ b/packages/subgraph/src/mappings/controller.ts
@@ -1,0 +1,53 @@
+import { dataSource } from '@graphprotocol/graph-ts'
+import { Protocol, Pause, Unpause } from '../types/schema'
+import { getRoundsManagerInstance, makeEventId } from './util'
+import {
+  Pause as PauseEvent,
+  Unpause as UnpauseEvent,
+} from '../types/Controller/Controller'
+
+export function pause(event: PauseEvent): void {
+  let roundsManager = getRoundsManagerInstance(dataSource.network())
+  let currentRound = roundsManager.currentRound()
+
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
+  protocol.paused = true
+  protocol.save()
+
+  let pause = new Pause(makeEventId(event.transaction.hash, event.logIndex))
+  pause.hash = event.transaction.hash.toHex()
+  pause.blockNumber = event.block.number
+  pause.gasUsed = event.transaction.gasUsed
+  pause.gasPrice = event.transaction.gasPrice
+  pause.timestamp = event.block.timestamp
+  pause.from = event.transaction.from.toHex()
+  pause.to = event.transaction.to.toHex()
+  pause.round = currentRound.toString()
+  pause.save()
+}
+
+export function unpause(event: UnpauseEvent): void {
+  let roundsManager = getRoundsManagerInstance(dataSource.network())
+  let currentRound = roundsManager.currentRound()
+
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
+  protocol.paused = false
+  protocol.save()
+
+  let unpause = new Unpause(makeEventId(event.transaction.hash, event.logIndex))
+  unpause.hash = event.transaction.hash.toHex()
+  unpause.blockNumber = event.block.number
+  unpause.gasUsed = event.transaction.gasUsed
+  unpause.gasPrice = event.transaction.gasPrice
+  unpause.timestamp = event.block.timestamp
+  unpause.from = event.transaction.from.toHex()
+  unpause.to = event.transaction.to.toHex()
+  unpause.round = currentRound.toString()
+  unpause.save()
+}

--- a/packages/subgraph/src/mappings/controller.ts
+++ b/packages/subgraph/src/mappings/controller.ts
@@ -1,15 +1,11 @@
-import { dataSource } from '@graphprotocol/graph-ts'
 import { Protocol, Pause, Unpause } from '../types/schema'
-import { getRoundsManagerInstance, makeEventId } from './util'
+import { makeEventId } from './util'
 import {
   Pause as PauseEvent,
   Unpause as UnpauseEvent,
 } from '../types/Controller/Controller'
 
 export function pause(event: PauseEvent): void {
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
-
   let protocol = Protocol.load('0')
   if (protocol == null) {
     protocol = new Protocol('0')
@@ -25,14 +21,11 @@ export function pause(event: PauseEvent): void {
   pause.timestamp = event.block.timestamp
   pause.from = event.transaction.from.toHex()
   pause.to = event.transaction.to.toHex()
-  pause.round = currentRound.toString()
+  pause.round = protocol.currentRound
   pause.save()
 }
 
 export function unpause(event: UnpauseEvent): void {
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
-
   let protocol = Protocol.load('0')
   if (protocol == null) {
     protocol = new Protocol('0')
@@ -48,6 +41,6 @@ export function unpause(event: UnpauseEvent): void {
   unpause.timestamp = event.block.timestamp
   unpause.from = event.transaction.from.toHex()
   unpause.to = event.transaction.to.toHex()
-  unpause.round = currentRound.toString()
+  unpause.round = protocol.currentRound
   unpause.save()
 }

--- a/packages/subgraph/src/mappings/controller.ts
+++ b/packages/subgraph/src/mappings/controller.ts
@@ -6,10 +6,7 @@ import {
 } from '../types/Controller/Controller'
 
 export function pause(event: PauseEvent): void {
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   protocol.paused = true
   protocol.save()
 
@@ -26,10 +23,7 @@ export function pause(event: PauseEvent): void {
 }
 
 export function unpause(event: UnpauseEvent): void {
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   protocol.paused = false
   protocol.save()
 

--- a/packages/subgraph/src/mappings/livepeerToken.ts
+++ b/packages/subgraph/src/mappings/livepeerToken.ts
@@ -7,17 +7,8 @@ export function approval(event: ApprovalEvent): void {
   let owner = event.params.owner
   let amount = event.params.value
   let spender = event.params.spender
-
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
-
-  // Create delegator if it does not yet exist
-  let delegator = Delegator.load(owner.toHex())
-  if (delegator == null) {
-    delegator = new Delegator(owner.toHex())
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
+  let delegator = Delegator.load(owner.toHex()) || new Delegator(owner.toHex())
 
   delegator.allowance = amount
   delegator.save()

--- a/packages/subgraph/src/mappings/livepeerToken.ts
+++ b/packages/subgraph/src/mappings/livepeerToken.ts
@@ -1,7 +1,6 @@
-import { dataSource } from '@graphprotocol/graph-ts'
 import { Approval as ApprovalEvent } from '../types/LivepeerToken/LivepeerToken'
-import { Delegator, Approval } from '../types/schema'
-import { getRoundsManagerInstance, makeEventId } from './util'
+import { Delegator, Approval, Protocol } from '../types/schema'
+import { makeEventId } from './util'
 
 // Handler for NewRound events
 export function approval(event: ApprovalEvent): void {
@@ -9,8 +8,10 @@ export function approval(event: ApprovalEvent): void {
   let amount = event.params.value
   let spender = event.params.spender
 
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
 
   // Create delegator if it does not yet exist
   let delegator = Delegator.load(owner.toHex())
@@ -33,7 +34,7 @@ export function approval(event: ApprovalEvent): void {
   approval.from = event.transaction.from.toHex()
   approval.to = event.transaction.to.toHex()
   approval.spender = spender.toHex()
-  approval.round = currentRound.toString()
+  approval.round = protocol.currentRound
   approval.amount = amount
   approval.delegator = delegator.id
   approval.save()

--- a/packages/subgraph/src/mappings/minter.ts
+++ b/packages/subgraph/src/mappings/minter.ts
@@ -15,10 +15,7 @@ export function setCurrentRewardTokens(
   event: SetCurrentRewardTokensEvent,
 ): void {
   let minter = Minter.bind(event.address)
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   let round = new Round(protocol.currentRound)
   round.mintableTokens = event.params.currentMintableTokens
   round.save()
@@ -50,11 +47,7 @@ export function setCurrentRewardTokens(
 
 export function parameterUpdate(event: ParameterUpdateEvent): void {
   let minter = Minter.bind(event.address)
-
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
 
   if (event.params.param == 'targetBondingRate') {
     protocol.targetBondingRate = minter.targetBondingRate()

--- a/packages/subgraph/src/mappings/minter.ts
+++ b/packages/subgraph/src/mappings/minter.ts
@@ -1,12 +1,87 @@
 import { dataSource } from '@graphprotocol/graph-ts'
-import { SetCurrentRewardTokens } from '../types/Minter/Minter'
-import { Round } from '../types/schema'
-import { getRoundsManagerInstance } from './util'
+import {
+  Minter,
+  SetCurrentRewardTokens as SetCurrentRewardTokensEvent,
+  ParameterUpdate as ParameterUpdateEvent,
+} from '../types/Minter/Minter'
+import {
+  Round,
+  Protocol,
+  ParameterUpdate,
+  SetCurrentRewardTokens,
+} from '../types/schema'
+import { getRoundsManagerInstance, makeEventId } from './util'
 
-export function setCurrentRewardTokens(event: SetCurrentRewardTokens): void {
+export function setCurrentRewardTokens(
+  event: SetCurrentRewardTokensEvent,
+): void {
+  let minter = Minter.bind(event.address)
   let roundsManager = getRoundsManagerInstance(dataSource.network())
   let currentRound = roundsManager.currentRound()
   let round = new Round(currentRound.toString())
   round.mintableTokens = event.params.currentMintableTokens
   round.save()
+
+  // The variables targetBondingRate, inflationChange, and inflation are
+  // initially set inside the Minter's constructor, however constructors are
+  // currently disallowed in call handlers so we'll set them in here for now
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
+  protocol.targetBondingRate = minter.targetBondingRate()
+  protocol.inflationChange = minter.inflationChange()
+  protocol.inflation = minter.inflation()
+  protocol.save()
+
+  let setCurrentRewardTokens = new SetCurrentRewardTokens(
+    makeEventId(event.transaction.hash, event.logIndex),
+  )
+  setCurrentRewardTokens.hash = event.transaction.hash.toHex()
+  setCurrentRewardTokens.blockNumber = event.block.number
+  setCurrentRewardTokens.gasUsed = event.transaction.gasUsed
+  setCurrentRewardTokens.gasPrice = event.transaction.gasPrice
+  setCurrentRewardTokens.timestamp = event.block.timestamp
+  setCurrentRewardTokens.from = event.transaction.from.toHex()
+  setCurrentRewardTokens.to = event.transaction.to.toHex()
+  setCurrentRewardTokens.round = currentRound.toString()
+  setCurrentRewardTokens.currentMintableTokens =
+    event.params.currentMintableTokens
+  setCurrentRewardTokens.currentInflation = event.params.currentInflation
+  setCurrentRewardTokens.save()
+}
+
+export function parameterUpdate(event: ParameterUpdateEvent): void {
+  let minter = Minter.bind(event.address)
+  let roundsManager = getRoundsManagerInstance(dataSource.network())
+  let currentRound = roundsManager.currentRound()
+
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
+
+  if (event.params.param == 'targetBondingRate') {
+    protocol.targetBondingRate = minter.targetBondingRate()
+  }
+
+  if (event.params.param == 'inflationChange') {
+    protocol.inflationChange = minter.inflationChange()
+  }
+
+  protocol.save()
+
+  let parameterUpdate = new ParameterUpdate(
+    makeEventId(event.transaction.hash, event.logIndex),
+  )
+  parameterUpdate.hash = event.transaction.hash.toHex()
+  parameterUpdate.blockNumber = event.block.number
+  parameterUpdate.gasUsed = event.transaction.gasUsed
+  parameterUpdate.gasPrice = event.transaction.gasPrice
+  parameterUpdate.timestamp = event.block.timestamp
+  parameterUpdate.from = event.transaction.from.toHex()
+  parameterUpdate.to = event.transaction.to.toHex()
+  parameterUpdate.round = currentRound.toString()
+  parameterUpdate.param = event.params.param
+  parameterUpdate.save()
 }

--- a/packages/subgraph/src/mappings/roundsManager.ts
+++ b/packages/subgraph/src/mappings/roundsManager.ts
@@ -84,10 +84,7 @@ export function newRound(event: NewRoundEvent): void {
   round.save()
 
   // Update protocol
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   protocol.lastInitializedRound = roundsManager.lastInitializedRound()
   protocol.currentRound = roundNumber.toString()
   protocol.save()
@@ -109,11 +106,7 @@ export function newRound(event: NewRoundEvent): void {
 
 export function parameterUpdate(event: ParameterUpdateEvent): void {
   let roundsManager = RoundsManager.bind(event.address)
-
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
 
   if (event.params.param == 'roundLength') {
     protocol.roundLength = roundsManager.roundLength()

--- a/packages/subgraph/src/mappings/roundsManager.ts
+++ b/packages/subgraph/src/mappings/roundsManager.ts
@@ -56,7 +56,7 @@ export function newRound(event: NewRoundEvent): void {
     // "rewardTokens" is null for a given transcoder and round then we know
     // the transcoder failed to call reward()
     if (active) {
-      poolId = makePoolId(currentTranscoder, roundNumber)
+      poolId = makePoolId(currentTranscoder, roundNumber.toString())
       pool = new Pool(poolId)
       pool.round = roundNumber.toString()
       pool.delegate = currentTranscoder.toHex()
@@ -109,7 +109,6 @@ export function newRound(event: NewRoundEvent): void {
 
 export function parameterUpdate(event: ParameterUpdateEvent): void {
   let roundsManager = RoundsManager.bind(event.address)
-  let currentRound = roundsManager.currentRound()
 
   let protocol = Protocol.load('0')
   if (protocol == null) {
@@ -143,7 +142,7 @@ export function parameterUpdate(event: ParameterUpdateEvent): void {
   parameterUpdate.timestamp = event.block.timestamp
   parameterUpdate.from = event.transaction.from.toHex()
   parameterUpdate.to = event.transaction.to.toHex()
-  parameterUpdate.round = currentRound.toString()
+  parameterUpdate.round = protocol.currentRound
   parameterUpdate.param = event.params.param
   parameterUpdate.save()
 }

--- a/packages/subgraph/src/mappings/roundsManager.ts
+++ b/packages/subgraph/src/mappings/roundsManager.ts
@@ -1,16 +1,29 @@
 // Import types and APIs from graph-ts
-import { Address, dataSource } from '@graphprotocol/graph-ts'
+import { Address, dataSource, BigInt } from '@graphprotocol/graph-ts'
 
 // Import event types from the registrar contract ABIs
 import {
   RoundsManager,
   NewRound as NewRoundEvent,
+  ParameterUpdate as ParameterUpdateEvent,
 } from '../types/RoundsManager/RoundsManager'
 
 // Import entity types generated from the GraphQL schema
-import { Transcoder, Pool, Round, InitializeRound } from '../types/schema'
+import {
+  Transcoder,
+  Pool,
+  Round,
+  InitializeRound,
+  Protocol,
+  ParameterUpdate,
+} from '../types/schema'
 
-import { makePoolId, getBondingManagerInstance, makeEventId } from './util'
+import {
+  PERC_DIVISOR,
+  makePoolId,
+  getBondingManagerInstance,
+  makeEventId,
+} from './util'
 
 // Handler for NewRound events
 export function newRound(event: NewRoundEvent): void {
@@ -66,12 +79,18 @@ export function newRound(event: NewRoundEvent): void {
   round = new Round(roundNumber.toString())
   round.initialized = true
   round.timestamp = event.block.timestamp
-  round.lastInitializedRound = roundsManager.lastInitializedRound()
   round.length = roundsManager.roundLength()
   round.startBlock = roundsManager.currentRoundStartBlock()
-
-  // Apply store updates
   round.save()
+
+  // Update protocol
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
+  protocol.lastInitializedRound = roundsManager.lastInitializedRound()
+  protocol.currentRound = roundNumber.toString()
+  protocol.save()
 
   // Store transaction info
   let initializeRound = new InitializeRound(
@@ -86,4 +105,45 @@ export function newRound(event: NewRoundEvent): void {
   initializeRound.to = event.transaction.to.toHex()
   initializeRound.round = roundNumber.toString()
   initializeRound.save()
+}
+
+export function parameterUpdate(event: ParameterUpdateEvent): void {
+  let roundsManager = RoundsManager.bind(event.address)
+  let currentRound = roundsManager.currentRound()
+
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
+
+  if (event.params.param == 'roundLength') {
+    protocol.roundLength = roundsManager.roundLength()
+    protocol.lastRoundLengthUpdateStartBlock = roundsManager.lastRoundLengthUpdateStartBlock()
+    protocol.lastRoundLengthUpdateRound = roundsManager.lastRoundLengthUpdateRound()
+  }
+
+  if (event.params.param == 'roundLockAmount') {
+    protocol.roundLockAmount = roundsManager.roundLockAmount()
+  }
+
+  protocol.lockPeriod = roundsManager
+    .roundLength()
+    .times(roundsManager.roundLockAmount())
+    .div(BigInt.fromI32(PERC_DIVISOR))
+
+  protocol.save()
+
+  let parameterUpdate = new ParameterUpdate(
+    makeEventId(event.transaction.hash, event.logIndex),
+  )
+  parameterUpdate.hash = event.transaction.hash.toHex()
+  parameterUpdate.blockNumber = event.block.number
+  parameterUpdate.gasUsed = event.transaction.gasUsed
+  parameterUpdate.gasPrice = event.transaction.gasPrice
+  parameterUpdate.timestamp = event.block.timestamp
+  parameterUpdate.from = event.transaction.from.toHex()
+  parameterUpdate.to = event.transaction.to.toHex()
+  parameterUpdate.round = currentRound.toString()
+  parameterUpdate.param = event.params.param
+  parameterUpdate.save()
 }

--- a/packages/subgraph/src/mappings/roundsManager_LIP12.ts
+++ b/packages/subgraph/src/mappings/roundsManager_LIP12.ts
@@ -1,10 +1,5 @@
 // Import types and APIs from graph-ts
-import {
-  Address,
-  dataSource,
-  EthereumBlock,
-  BigInt,
-} from '@graphprotocol/graph-ts'
+import { Address, dataSource } from '@graphprotocol/graph-ts'
 
 // Import event types from the registrar contract ABIs
 import {
@@ -43,7 +38,7 @@ export function newRound(event: NewRoundEvent): void {
     // reward() for a given round, we store its reward tokens inside this Pool
     // entry in a field called "rewardTokens". If "rewardTokens" is null for a
     // given transcoder and round then we know the transcoder failed to call reward()
-    poolId = makePoolId(currentTranscoder, roundNumber)
+    poolId = makePoolId(currentTranscoder, roundNumber.toString())
     pool = new Pool(poolId)
     pool.round = roundNumber.toString()
     pool.delegate = currentTranscoder.toHex()

--- a/packages/subgraph/src/mappings/roundsManager_LIP12.ts
+++ b/packages/subgraph/src/mappings/roundsManager_LIP12.ts
@@ -64,11 +64,7 @@ export function newRound(event: NewRoundEvent): void {
   round.startBlock = roundsManager.currentRoundStartBlock()
   round.save()
 
-  // Update protocol
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   protocol.lastInitializedRound = roundsManager.lastInitializedRound()
   protocol.currentRound = roundNumber.toString()
   protocol.save()

--- a/packages/subgraph/src/mappings/ticketBroker.ts
+++ b/packages/subgraph/src/mappings/ticketBroker.ts
@@ -20,10 +20,7 @@ import { BigInt, dataSource } from '@graphprotocol/graph-ts'
 import { getRoundsManagerInstance, makeEventId } from './util'
 
 export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   let round = Round.load(protocol.currentRound)
   let winningTicketRedeemed = new WinningTicketRedeemed(
     makeEventId(event.transaction.hash, event.logIndex),
@@ -54,10 +51,9 @@ export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
   }
 
   // Update accrued fees for this transcoder
-  let transcoder = Transcoder.load(event.params.recipient.toHex())
-  if (transcoder == null) {
-    transcoder = new Transcoder(event.params.recipient.toHex())
-  }
+  let transcoder =
+    Transcoder.load(event.params.recipient.toHex()) ||
+    new Transcoder(event.params.recipient.toHex())
   transcoder.totalGeneratedFees = transcoder.totalGeneratedFees.plus(
     event.params.faceValue,
   )
@@ -81,14 +77,10 @@ export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
 }
 
 export function depositFunded(event: DepositFundedEvent): void {
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
-  let broadcaster = Broadcaster.load(event.params.sender.toHex())
-  if (broadcaster == null) {
-    broadcaster = new Broadcaster(event.params.sender.toHex())
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
+  let broadcaster =
+    Broadcaster.load(event.params.sender.toHex()) ||
+    new Broadcaster(event.params.sender.toHex())
   broadcaster.deposit = broadcaster.deposit.plus(event.params.amount)
   broadcaster.save()
 
@@ -109,14 +101,11 @@ export function depositFunded(event: DepositFundedEvent): void {
 }
 
 export function reserveFunded(event: ReserveFundedEvent): void {
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
-  let broadcaster = Broadcaster.load(event.params.reserveHolder.toHex())
-  if (broadcaster == null) {
-    broadcaster = new Broadcaster(event.params.reserveHolder.toHex())
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
+  let broadcaster =
+    Broadcaster.load(event.params.reserveHolder.toHex()) ||
+    new Broadcaster(event.params.reserveHolder.toHex())
+
   broadcaster.reserve = broadcaster.reserve.plus(event.params.amount)
   broadcaster.save()
 
@@ -137,10 +126,7 @@ export function reserveFunded(event: ReserveFundedEvent): void {
 }
 
 export function reserveClaimed(event: ReserveClaimedEvent): void {
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   let broadcaster = Broadcaster.load(event.params.reserveHolder.toHex())
   broadcaster.reserve = broadcaster.reserve.minus(event.params.amount)
   broadcaster.save()
@@ -163,10 +149,7 @@ export function reserveClaimed(event: ReserveClaimedEvent): void {
 }
 
 export function withdrawal(event: WithdrawalEvent): void {
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
+  let protocol = Protocol.load('0') || new Protocol('0')
   let broadcaster = Broadcaster.load(event.params.sender.toHex())
   broadcaster.deposit = BigInt.fromI32(0)
   broadcaster.reserve = BigInt.fromI32(0)

--- a/packages/subgraph/src/mappings/ticketBroker.ts
+++ b/packages/subgraph/src/mappings/ticketBroker.ts
@@ -20,9 +20,11 @@ import { BigInt, dataSource } from '@graphprotocol/graph-ts'
 import { getRoundsManagerInstance, makeEventId } from './util'
 
 export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
-  let round = Round.load(currentRound.toString())
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
+  let round = Round.load(protocol.currentRound)
   let winningTicketRedeemed = new WinningTicketRedeemed(
     makeEventId(event.transaction.hash, event.logIndex),
   )
@@ -33,7 +35,7 @@ export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
   winningTicketRedeemed.timestamp = event.block.timestamp
   winningTicketRedeemed.from = event.transaction.from.toHex()
   winningTicketRedeemed.to = event.transaction.to.toHex()
-  winningTicketRedeemed.round = currentRound.toString()
+  winningTicketRedeemed.round = protocol.currentRound
   winningTicketRedeemed.sender = event.params.sender.toHex()
   winningTicketRedeemed.recipient = event.params.recipient.toHex()
   winningTicketRedeemed.faceValue = event.params.faceValue
@@ -62,10 +64,6 @@ export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
   transcoder.save()
 
   // Update total protocol fees and total winning tickets
-  let protocol = Protocol.load('0')
-  if (protocol == null) {
-    protocol = new Protocol('0')
-  }
   protocol.totalGeneratedFees = protocol.totalGeneratedFees.plus(
     event.params.faceValue,
   )
@@ -83,8 +81,10 @@ export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
 }
 
 export function depositFunded(event: DepositFundedEvent): void {
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
   let broadcaster = Broadcaster.load(event.params.sender.toHex())
   if (broadcaster == null) {
     broadcaster = new Broadcaster(event.params.sender.toHex())
@@ -102,15 +102,17 @@ export function depositFunded(event: DepositFundedEvent): void {
   depositFunded.timestamp = event.block.timestamp
   depositFunded.from = event.transaction.from.toHex()
   depositFunded.to = event.transaction.to.toHex()
-  depositFunded.round = currentRound.toString()
+  depositFunded.round = protocol.currentRound
   depositFunded.sender = event.params.sender.toHex()
   depositFunded.amount = event.params.amount
   depositFunded.save()
 }
 
 export function reserveFunded(event: ReserveFundedEvent): void {
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
   let broadcaster = Broadcaster.load(event.params.reserveHolder.toHex())
   if (broadcaster == null) {
     broadcaster = new Broadcaster(event.params.reserveHolder.toHex())
@@ -128,15 +130,17 @@ export function reserveFunded(event: ReserveFundedEvent): void {
   reserveFunded.timestamp = event.block.timestamp
   reserveFunded.from = event.transaction.from.toHex()
   reserveFunded.to = event.transaction.to.toHex()
-  reserveFunded.round = currentRound.toString()
+  reserveFunded.round = protocol.currentRound
   reserveFunded.reserveHolder = event.params.reserveHolder.toHex()
   reserveFunded.amount = event.params.amount
   reserveFunded.save()
 }
 
 export function reserveClaimed(event: ReserveClaimedEvent): void {
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
   let broadcaster = Broadcaster.load(event.params.reserveHolder.toHex())
   broadcaster.reserve = broadcaster.reserve.minus(event.params.amount)
   broadcaster.save()
@@ -151,7 +155,7 @@ export function reserveClaimed(event: ReserveClaimedEvent): void {
   reserveClaimed.timestamp = event.block.timestamp
   reserveClaimed.from = event.transaction.from.toHex()
   reserveClaimed.to = event.transaction.to.toHex()
-  reserveClaimed.round = currentRound.toString()
+  reserveClaimed.round = protocol.currentRound
   reserveClaimed.reserveHolder = event.params.reserveHolder.toHex()
   reserveClaimed.claimant = event.params.claimant.toHex()
   reserveClaimed.amount = event.params.amount
@@ -159,8 +163,10 @@ export function reserveClaimed(event: ReserveClaimedEvent): void {
 }
 
 export function withdrawal(event: WithdrawalEvent): void {
-  let roundsManager = getRoundsManagerInstance(dataSource.network())
-  let currentRound = roundsManager.currentRound()
+  let protocol = Protocol.load('0')
+  if (protocol == null) {
+    protocol = new Protocol('0')
+  }
   let broadcaster = Broadcaster.load(event.params.sender.toHex())
   broadcaster.deposit = BigInt.fromI32(0)
   broadcaster.reserve = BigInt.fromI32(0)
@@ -176,7 +182,7 @@ export function withdrawal(event: WithdrawalEvent): void {
   withdrawal.timestamp = event.block.timestamp
   withdrawal.from = event.transaction.from.toHex()
   withdrawal.to = event.transaction.to.toHex()
-  withdrawal.round = currentRound.toString()
+  withdrawal.round = protocol.currentRound
   withdrawal.sender = event.params.sender.toHex()
   withdrawal.deposit = event.params.deposit
   withdrawal.reserve = event.params.reserve

--- a/packages/subgraph/src/mappings/util.ts
+++ b/packages/subgraph/src/mappings/util.ts
@@ -21,17 +21,17 @@ export function leftPad(str: string, size: i32): string {
 // Make a derived pool ID from a transcoder address
 export function makePoolId(
   transcoderAddress: Address,
-  roundId: BigInt,
+  roundId: string,
 ): string {
-  return leftPad(roundId.toString(), 10) + '-' + transcoderAddress.toHex()
+  return leftPad(roundId, 10) + '-' + transcoderAddress.toHex()
 }
 
 // Make a derived share ID from a delegator address
 export function makeShareId(
   delegatorAddress: Address,
-  roundId: BigInt,
+  roundId: string,
 ): string {
-  return leftPad(roundId.toString(), 10) + '-' + delegatorAddress.toHex()
+  return leftPad(roundId, 10) + '-' + delegatorAddress.toHex()
 }
 
 // Make a derived unlocking ID from a delegator address

--- a/packages/subgraph/src/mappings/util.ts
+++ b/packages/subgraph/src/mappings/util.ts
@@ -2,13 +2,13 @@ import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts'
 import { BondingManager } from '../types/BondingManager/BondingManager'
 import { RoundsManager } from '../types/RoundsManager/RoundsManager'
 
-const PERC_DIVISOR = 1000000
-
 let x = BigInt.fromI32(2)
 let y = <u8>255
 let z = BigInt.fromI32(1)
 
 export let MAXIMUM_VALUE_UINT256: BigInt = x.pow(y).minus(z)
+
+export const PERC_DIVISOR = 1000000
 
 // Make a number the specified number of digits
 export function leftPad(str: string, size: i32): string {

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -32,6 +32,8 @@ dataSources:
         - WithdrawStake
         - WithdrawFees
         - Round
+        - ParameterUpdate
+        - Protocol
       abis:
         - name: BondingManager
           file: ./abis/BondingManager.json
@@ -54,6 +56,8 @@ dataSources:
           handler: withdrawStake
         - event: WithdrawFees(indexed address)
           handler: withdrawFees
+        - event: ParameterUpdate(string)
+          handler: parameterUpdate
       callHandlers:
         - function: claimEarnings(uint256)
           handler: claimEarnings
@@ -144,6 +148,8 @@ dataSources:
         - Pool
         - Round
         - InitializeRound
+        - ParameterUpdate
+        - Protocol
       abis:
         - name: RoundsManager
           file: ./abis/RoundsManager.json
@@ -152,6 +158,8 @@ dataSources:
       eventHandlers:
         - event: NewRound(uint256)
           handler: newRound
+        - event: ParameterUpdate(string)
+          handler: parameterUpdate
   - kind: ethereum/contract
     name: RoundsManager_LIP12
     network: {{networkName}}
@@ -214,6 +222,9 @@ dataSources:
       file: ./src/mappings/minter.ts
       entities:
         - Round
+        - Protocol
+        - ParameterUpdate
+        - SetCurrentRewardTokens
       abis:
         - name: Minter
           file: ./abis/Minter.json
@@ -222,6 +233,8 @@ dataSources:
       eventHandlers:
         - event: SetCurrentRewardTokens(uint256,uint256)
           handler: setCurrentRewardTokens
+        - event: ParameterUpdate(string)
+          handler: parameterUpdate
   - kind: ethereum/contract
     name: TicketBroker
     network: {{networkName}}
@@ -259,3 +272,30 @@ dataSources:
           handler: reserveClaimed
         - event: Withdrawal(indexed address,uint256,uint256)
           handler: withdrawal
+  - kind: ethereum/contract
+    name: Controller
+    network: {{networkName}}
+    source:
+      startBlock: {{contracts.controller.startBlock}}
+      address: {{contracts.controller.address}}
+      abi: Controller
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.3
+      language: wasm/assemblyscript
+      file: ./src/mappings/controller.ts   
+      entities:
+        - Protocol
+        - Pause
+        - Unpause
+      abis:
+        - name: Controller
+          file: ./abis/Controller.json
+        - name: RoundsManager
+          file: ./abis/RoundsManager.json
+      eventHandlers:
+        - event: Pause()
+          handler: pause
+        - event: Unpause()
+          handler: unpause
+    


### PR DESCRIPTION
**What does this pull request do? Explain your changes.**
This PR adds a new set of fields to the Protocol entity and introduces 4 new entities.

**Specific updates**
- Adds the following fields to the Protocol entity: 
`currentRound, inflation, inflationChange, lastInitializedRound, lastRoundLengthUpdateRound, lastRoundLengthUpdateStartBlock, lockPeriod, maxEarningsClaimsRounds, numActiveTranscoders, paused, roundLength, roundLockAmount, targetBondingRate, unbondingPeriod`
- Introduces the following new entities:
`SetCurrentRewardTokens, Pause, Unpause, ParameterUpdate`

**How did you test each of these updates**
The changes haven been deployed and synced on the Livepeer Canary subgraph

**Does this pull request close any open issues?**
#437 

**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
