### PR TITLE
improvement: remove unnecessary refetch upon 3box message signing

### DIFF
--- a/packages/explorer-2.0/components/EditProfile/index.tsx
+++ b/packages/explorer-2.0/components/EditProfile/index.tsx
@@ -26,22 +26,6 @@ interface Props {
   refetch?: any
 }
 
-const GET_THREE_BOX_SPACE = gql`
-  query($id: ID!) {
-    threeBoxSpace(id: $id) {
-      __typename
-      id
-      did
-      name
-      website
-      description
-      image
-      addressLinks
-      defaultProfile
-    }
-  }
-`
-
 const UPDATE_PROFILE = gql`
   mutation updateProfile(
     $name: String
@@ -179,13 +163,6 @@ export default ({ threeBoxSpace, refetch, account }: Props) => {
         )
         space = await box.openSpace('livepeer')
         await box.syncDone
-        if (refetch) {
-          refetch({
-            variables: {
-              account: account,
-            },
-          })
-        }
         setCreateProfileModalOpen(false)
         setEditProfileOpen(true)
       }

--- a/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
+++ b/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
@@ -66,10 +66,7 @@ export default withApollo(() => {
     }
   }, [context.chainId])
 
-  if (
-    ((loading || loadingMyAccount) && !data) ||
-    (context.active && !dataMyAccount)
-  ) {
+  if (loading || loadingMyAccount) {
     return (
       <Layout>
         <Flex


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR removes an unnecessary refetch after signing the 3box messages that's causing the page to reload and disrupting the profile creation user flow.

**Checklist:**
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
