### PR TITLE
wip: mist-proxy

### DIFF
--- a/packages/mist-proxy/.prettierrc
+++ b/packages/mist-proxy/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/packages/mist-proxy/package.json
+++ b/packages/mist-proxy/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mist-proxy",
+  "version": "0.0.1",
+  "description": "MistServer API proxy",
+  "main": "dist/mist-proxy.js",
+  "repository": "https://github.com/livepeer/livepeerjs.git",
+  "author": "Livepeer",
+  "license": "MIT",
+  "private": false,
+  "dependencies": {
+    "body-parser": "^1.19.0",
+    "express": "^4.17.1",
+    "express-async-errors": "^3.1.1",
+    "http-proxy-middleware": "^1.0.3",
+    "isomorphic-fetch": "^2.2.1",
+    "morgan": "^1.10.0",
+    "uuid": "^7.0.2"
+  },
+  "devDependencies": {
+    "esm": "^3.2.25"
+  }
+}

--- a/packages/mist-proxy/src/mist-proxy.js
+++ b/packages/mist-proxy/src/mist-proxy.js
@@ -1,0 +1,69 @@
+import express from 'express'
+import morgan from 'morgan'
+import uuid from 'uuid/v4'
+import bodyParser from 'body-parser'
+import fetch from 'isomorphic-fetch'
+import httpProxy from 'http-proxy'
+import 'express-async-errors'
+
+const app = express()
+
+app.use(morgan('combined'))
+// app.use(bodyParser.json())
+
+const proxy = new httpProxy.createProxyServer({
+  ignorePath: true,
+  secure: true,
+  changeOrigin: true,
+})
+
+const doProxy = async (req, res, opts) => {
+  console.log(`proxying ${req.method} ${req.url} ----> ${opts.target}`)
+  return new Promise((resolve, reject) => {
+    proxy.web(req, res, opts, e => {
+      if (e) {
+        console.log(`Fail: ${opts.target}`)
+        return reject(e)
+      }
+      console.log(`Success: ${opts.target}`)
+      resolve()
+    })
+  })
+}
+
+app.post('/api/stream', async (req, res) => {
+  // res.json({ id: uuid() })
+  await doProxy(req, res, { target: 'https://livepeer.live/api/stream' })
+})
+
+app.get('/api/broadcaster', async (req, res) => {
+  const upstreamReq = await fetch('https://livepeer.live/api/broadcaster')
+  const data = await upstreamReq.json()
+  const outputData = data.map(broadcaster => {
+    let { address } = broadcaster
+    // If we only encode once, mist decodes it on the way out! So we need to encode twice
+    // to pass it all the way back to the POST handler.
+    address = encodeURIComponent(address)
+    address = encodeURIComponent(address)
+    return {
+      address: `http://${req.headers.host}/${address}`,
+    }
+  })
+  res.json(outputData)
+})
+
+app.post('/:server/live/:id/:seq.ts', async (req, res) => {
+  let { server, id, seq } = req.params
+  server = decodeURIComponent(server)
+  const target = `${server}/live/${id}/${seq}.ts`
+  await doProxy(req, res, { target })
+})
+
+app.get('/:server/stream/:id/:rendition/:seq.ts', async (req, res) => {
+  let { server, id, rendition, seq } = req.params
+  server = decodeURIComponent(server)
+  const target = `${server}/stream/${id}/${rendition}/${seq}.ts`
+  await doProxy(req, res, { target })
+})
+
+app.listen(3012)

--- a/packages/mist-proxy/src/util.js
+++ b/packages/mist-proxy/src/util.js
@@ -1,0 +1,37 @@
+import { randomBytes } from 'crypto'
+import anyBase from 'any-base'
+
+const BASE_36 = 'abcdefghijklmnopqrstuvwxyz0123456789'
+const SEGMENT_COUNT = 3
+const SEGMENT_LENGTH = 4
+const hexToBase36 = anyBase(anyBase.HEX, BASE_36)
+
+/**
+ * Securely generate a stream key of a given length. Goals for stream keys: be reasonably secure
+ * but also easy to type if necessary. Base36 facilitates this.
+ *
+ * Returns stream keys of the form XXXX-XXXX-XXXX in Base66.
+ */
+export async function generateStreamKey() {
+  return new Promise((resolve, reject) => {
+    randomBytes(256, (err, buf) => {
+      if (err) {
+        return reject(err)
+      }
+      const raw = hexToBase36(buf.toString('hex'))
+      let result = ''
+      const TOTAL_LENGTH = SEGMENT_COUNT * SEGMENT_LENGTH
+      for (let i = 0; i < TOTAL_LENGTH; i += 1) {
+        result += raw[i]
+        if ((i + 1) % SEGMENT_LENGTH === 0 && i < TOTAL_LENGTH - 1) {
+          result += '-'
+        }
+      }
+      resolve(result)
+    })
+  })
+}
+
+if (!module.parent) {
+  generateStreamKey().then(x => console.log(x))
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5830,6 +5830,13 @@
   resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.5.1.tgz#d775e93630c2469c2f980fc27e3143240335db3b"
   integrity sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ==
 
+"@types/http-proxy@^1.17.3":
+  version "1.17.4"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.4.tgz#e7c92e3dbe3e13aa799440ff42e6d3a17a9d045b"
+  integrity sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/is-function@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/is-function/-/is-function-1.0.0.tgz#1b0b819b1636c7baf0d6785d030d12edf70c3e83"
@@ -9237,7 +9244,7 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-basic-auth@~2.0.0:
+basic-auth@~2.0.0, basic-auth@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
   integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
@@ -10029,6 +10036,14 @@ buffer@^5.0.5, buffer@^5.1.0, buffer@^5.2.1, buffer@^5.4.2, buffer@^5.4.3:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
   integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+
+buffer@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.5.0.tgz#9c3caa3d623c33dd1c7ef584b89b88bf9c9bc1ce"
+  integrity sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -12821,6 +12836,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 deprecate@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deprecate/-/deprecate-1.1.1.tgz#4632e981fc815eeaf00be945a40359c0f8bf9913"
@@ -14358,7 +14378,7 @@ eslint@^6.6.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-esm@3.2.25, esm@^3.2.20, esm@^3.2.22:
+esm@3.2.25, esm@^3.2.20, esm@^3.2.22, esm@^3.2.25:
   version "3.2.25"
   resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
   integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
@@ -18109,6 +18129,17 @@ http-proxy-middleware@^0.20.0:
     http-proxy "^1.17.0"
     is-glob "^4.0.1"
     lodash "^4.17.14"
+    micromatch "^4.0.2"
+
+http-proxy-middleware@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-1.0.3.tgz#f73daad8dac622d51fe1769960c914b9b1f75a72"
+  integrity sha512-GHvPeBD+A357zS5tHjzj6ISrVOjjCiy0I92bdyTJz0pNmIjFxO0NX/bX+xkGgnclKQE/5hHAB9JEQ7u9Pw4olg==
+  dependencies:
+    "@types/http-proxy" "^1.17.3"
+    http-proxy "^1.18.0"
+    is-glob "^4.0.1"
+    lodash "^4.17.15"
     micromatch "^4.0.2"
 
 http-proxy@^1.17.0, http-proxy@^1.18.0:
@@ -24086,6 +24117,17 @@ moo@^0.5.0:
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
   integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
 
+morgan@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"
+  integrity sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==
+  dependencies:
+    basic-auth "~2.0.1"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-finished "~2.3.0"
+    on-headers "~1.0.2"
+
 morgan@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
@@ -24244,7 +24286,15 @@ multicast-dns@^7.2.0:
     dns-packet "^4.0.0"
     thunky "^1.0.2"
 
-multicodec@0.5.6, multicodec@^1.0.0, multicodec@~0.5.0, multicodec@~0.5.1, multicodec@~0.5.3:
+multicodec@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-1.0.1.tgz#4e2812d726b9f7c7d615d3ebc5787d36a08680f9"
+  integrity sha512-yrrU/K8zHyAH2B0slNVeq3AiwluflHpgQ3TAzwNJcuO2AoPyXgBT2EDkdbP1D8B/yFOY+S2hDYmFlI1vhVFkQw==
+  dependencies:
+    buffer "^5.5.0"
+    varint "^5.0.0"
+
+multicodec@~0.5.0, multicodec@~0.5.1, multicodec@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/multicodec/-/multicodec-0.5.6.tgz#fdf250b6febe57053221f0aeeb83e6cae073a05e"
   integrity sha512-YQthT12rnqyAosc+xSprD3JpmrfxXYABM9FEFw7oVxTonsWmIYng1iIppqpIfGBFZ3YKMgJKx6UTREuv91EcKw==
@@ -34836,6 +34886,11 @@ uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0, uuid@^3.2.1, uuid@^3.2.2, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.2.tgz#7ff5c203467e91f5e0d85cfcbaaf7d2ebbca9be6"
+  integrity sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw==
 
 v8-compile-cache@^2.0.0, v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
This is a little proxy server that can intercept requests from Mist using the "custom API url" feature. It's designed to run alongside MistServer in a sidecar container. Right now, it does nothing, just proxying connections through to the API and the broadcasters. But, it's designed to work by intercepting incoming stream requests and combining them into a single multipart transcode. This allows for multiple rendition support and multipart return support without any changes to MistProcLivepeer.