### PR TITLE
www: make html, body, and __next height: 100%

### DIFF
--- a/packages/livepeer.com/www/components/Layout/index.tsx
+++ b/packages/livepeer.com/www/components/Layout/index.tsx
@@ -1,7 +1,7 @@
 import { DefaultSeo } from "next-seo";
 import Navigation from "../Navigation";
 import Footer from "../Footer";
-import { Box } from "@theme-ui/components";
+import { Flex, Box } from "@theme-ui/components";
 import { useEffect } from "react";
 import ReactGA from "react-ga";
 import "lazysizes";
@@ -43,7 +43,13 @@ export default ({ title, description, children, image, url }: Props) => {
     }
   };
   return (
-    <Box>
+    <Flex
+      sx={{
+        height: "100%",
+        flexDirection: "column",
+        justifyContent: "space-between"
+      }}
+    >
       <DefaultSeo {...seo} />
       <Box>
         <Box
@@ -60,6 +66,6 @@ export default ({ title, description, children, image, url }: Props) => {
         {children}
       </Box>
       <Footer />
-    </Box>
+    </Flex>
   );
 };

--- a/packages/livepeer.com/www/lib/theme.tsx
+++ b/packages/livepeer.com/www/lib/theme.tsx
@@ -90,7 +90,8 @@ export const theme = {
       fontFamily: "body",
       lineHeight: "body",
       fontWeight: "body",
-      letterSpacing: "body"
+      letterSpacing: "body",
+      height: "100%"
     },
     h1: {
       color: "text",

--- a/packages/livepeer.com/www/pages/_app.tsx
+++ b/packages/livepeer.com/www/pages/_app.tsx
@@ -20,7 +20,7 @@ export default class MyApp extends App {
         </Head>
         <>
           <ThemeProvider>
-            <Box>
+            <Box sx={{ height: "100%" }}>
               <DefaultSeo {...SEO} />
               <Reset />
               <Component {...pageProps} />

--- a/packages/livepeer.com/www/pages/_document.tsx
+++ b/packages/livepeer.com/www/pages/_document.tsx
@@ -9,6 +9,13 @@ class MyDocument extends Document {
   render() {
     return (
       <Html lang="en">
+        <style jsx global>{`
+          html,
+          body,
+          #__next {
+            height: 100%;
+          }
+        `}</style>
         <Head />
         <body>
           <Main />


### PR DESCRIPTION
Just getting my feet wet with this particular front-end stack. Also this is kind of an old-school way to solve this — anything better come to mind?

Basically I want to avoid the case where the page is kinda small and the footer shows up right after the header.

After: 
![image](https://user-images.githubusercontent.com/257909/77607464-a72d2880-6ed7-11ea-9fae-79e7983f482a.png)

I don't have a before screenshot but imagine the footer smooshed right up against the text there