### PR TITLE
explorer: batchClaimEarnings gas optimisations

### DIFF
--- a/packages/explorer-2.0/apollo/resolvers/Mutation.tsx
+++ b/packages/explorer-2.0/apollo/resolvers/Mutation.tsx
@@ -1,4 +1,4 @@
-import { MAX_EARNINGS_CLAIMS_ROUNDS } from '../../lib/utils'
+import { MAX_BATCH_CLAIM_ROUNDS } from '../../lib/utils'
 
 /**
  * Approve an amount for an ERC20 token transfer
@@ -52,50 +52,58 @@ export async function bond(_obj, _args, _ctx) {
  * @param {string} lastClaimRound - The delegator's last claim round
  * @param {string} endRound - The round to claim earnings until
  * @return {Promise}
+ * https://github.com/ethereum/web3.js/issues/1446
  */
 export async function batchClaimEarnings(_obj, _args, _ctx) {
   const Web3 = require('web3') // use web3 lib for batching transactions
   const web3 = new Web3(_ctx.provider)
-  const { lastClaimRound, endRound } = _args
+  const { lastClaimRound, endRound: lastEndRound} = _args
   const { abi, address } = _ctx.livepeer.config.contracts.BondingManager
   const bondingManager = new web3.eth.Contract(abi, address)
-  const totalRoundsToClaim = parseInt(endRound) - parseInt(lastClaimRound)
-  const quotient = Math.floor(totalRoundsToClaim / MAX_EARNINGS_CLAIMS_ROUNDS)
-  const remainder = totalRoundsToClaim % MAX_EARNINGS_CLAIMS_ROUNDS
+  const totalRoundsToClaim = parseInt(lastEndRound) - parseInt(lastClaimRound)
+  const quotient = Math.floor(totalRoundsToClaim / MAX_BATCH_CLAIM_ROUNDS)
+  const remainder = totalRoundsToClaim % MAX_BATCH_CLAIM_ROUNDS
   const calls = []
 
-  for (let i = 1; i <= quotient; i++) {
+  let batch = new web3.BatchRequest()
+
+  let maxBatchGas = parseInt(await _ctx.livepeer.rpc.estimateGas(
+    'BondingManager',
+    'claimEarnings',
+    [(parseInt(lastClaimRound) + MAX_BATCH_CLAIM_ROUNDS).toString()],
+  ))
+
+  function addCall(endRound, gas) {
     calls.push(
-      bondingManager.methods.claimEarnings(
-        (parseInt(lastClaimRound) + i * MAX_EARNINGS_CLAIMS_ROUNDS).toString(),
-      ).send,
+      new Promise((res, rej) => {
+        batch.add(
+          bondingManager.methods.claimEarnings(endRound)
+          .send
+          .request({
+            from: _ctx.account,
+            gas: parseInt(gas, 10) // truncate in case 'gas' is a float
+          },
+         (err, txHash) => {
+            if (err) rej(err);
+            else res(txHash)
+         })
+        )
+      })
     )
   }
 
+  for (let i = 1; i <= quotient; i++) {
+    let end = (parseInt(lastClaimRound) + i * MAX_BATCH_CLAIM_ROUNDS).toString()
+    addCall(end, maxBatchGas * 1.05) 
+  }
+
   if (remainder) {
-    calls.push(bondingManager.methods.claimEarnings(endRound).send)
+    addCall(lastEndRound, (maxBatchGas / MAX_BATCH_CLAIM_ROUNDS) * remainder * 1.05)
   }
 
-  function makeBatchRequest(calls) {
-    let batch = new web3.BatchRequest()
-    let promises = calls.map(call => {
-      return new Promise((res, rej) => {
-        let req = call.request({ from: _ctx.account }, (err, txHash) => {
-          if (err) {
-            rej(err)
-          }
-          res(txHash)
-        })
-        batch.add(req)
-      })
-    })
-    batch.execute()
-    return Promise.all(promises)
-  }
-
-  const txns = await makeBatchRequest(calls)
-  const lastTransactionInBatch = txns[calls.length - 1]
-  return lastTransactionInBatch
+  batch.execute()
+  // return txhash of last transaction in the batch
+  return (await Promise.all(calls)).pop()
 }
 
 /**
@@ -253,7 +261,7 @@ export async function updateProfile(_obj, _args, _ctx) {
       ...filtered,
     }
   } catch (e) {
-    console.error(e)
+    // console.error(e)
   }
 }
 
@@ -268,6 +276,6 @@ export async function removeAddressLink(_obj, _args, _ctx) {
   try {
     await box.removeAddressLink(address)
   } catch (e) {
-    console.error(e)
+    // console.error(e)
   }
 }

--- a/packages/explorer-2.0/data/claim-earnings.mdx
+++ b/packages/explorer-2.0/data/claim-earnings.mdx
@@ -3,6 +3,7 @@ Claiming your earnings is more of an accounting necessity than something that's 
 Fees that an orchestrators earns in ETH, are immediately distributed into a delegator's account when they claim earnings however.
 
 While delegators do need to do this calculation for every single round (day), claiming earnings once can do the calculation for 100 rounds.
+The Livepeer Explorer will automatically batch up requests per 50 rounds to optimise the [gas](https://ethgasstation.info/blog/what-is-gas/) usage.
 
 * Delegators or orchestrators claim earnings whenever they want to change their delegation status: unstake, stake towards another orhcestrator, stake more.
 * Claiming earnings once can update their status for up to 100 rounds. So if it's been longer than 100 rounds since the last update, you may have to claim earnings multiple times.

--- a/packages/explorer-2.0/lib/utils.tsx
+++ b/packages/explorer-2.0/lib/utils.tsx
@@ -66,6 +66,7 @@ export const MAXIUMUM_VALUE_UINT256 =
   '115792089237316195423570985008687907853269984665640564039457584007913129639935'
 
 export const MAX_EARNINGS_CLAIMS_ROUNDS = 100
+export const MAX_BATCH_CLAIM_ROUNDS = 50
 
 export function removeURLParameter(url, parameter) {
   //prefer to use l.search if you have a location/link object


### PR DESCRIPTION
<!-------------------------------------------------------------------------
 | Thanks for send a pull request! 🎉
 | First, please make sure you familiar with the contribution guidelines
 | https://github.com/livepeer/livepeerjs/blob/master/CONTRIBUTING.md
 -------------------------------------------------------------------------->

**What does this pull request do? Explain your changes. (required)**
This PR optimises gas usage for `batchClaimEarnings`. 

User reports have stated that when using metamask it would often set a very high tx gas limit or even default to the block gas limit. 

**Specific updates (required)**
- 3a3d415 - Add a gas estimation by doing an `eth_estimategas` RPC call before sending the transaction. This should prevent metamask from defaulting to high values.
- 9b5c485 - Change `MAX_EARNINGS_CLAIMS_ROUNDS` to `50`
  This will increase the number of transactions to be approved in metamask if there's a high number of rounds to claim for but it makes a tradeoff to better play into miner economics for gas price optimisation. Transactions with high gas limits (> 10%-20% of the block gas limit) are less likely to be included in blocks if they don't have a higher gas prices attached to them than what the average for a bunch of smaller transactions would be. However people are more inclined to commit to a higher gas price for smaller transactions to get faster confirmations. Leaving large , low gas price transactions in the memory pool for a long time.  

**How did you test each of these updates (required)**
<!-- A detailed description of how you tested your code changes. Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->

**Does this pull request close any open issues?**
Fixes #597

**Screenshots (optional):**
<!-- Drag some screenshots here, if applicable -->

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
