### PR TITLE
Updated sales@livepeer.com hyperlink

### DIFF
--- a/packages/livepeer.com/www/docs/index.mdx
+++ b/packages/livepeer.com/www/docs/index.mdx
@@ -157,4 +157,4 @@ consume the transcoded HLS stream from the same broadcaster. You can serve the
 transcoded outputs through a CDN or save them for future use.
 
 Livepeer is currently testing this feature with select beta users. If you would
-like to use this today, email [mailto:sales@livepeer.com](sales@livepeer.com).
+like to use this today, email [sales@livepeer.com](mailto:sales@livepeer.com?subject=[Beta%20request]%20RTMP%20API).


### PR DESCRIPTION
The sales@livepeer.com link was broken. This should fix it.