### PR TITLE
Firestore user list bug fix

### DIFF
--- a/packages/api/src/store/firestore-store.js
+++ b/packages/api/src/store/firestore-store.js
@@ -167,7 +167,9 @@ export default class FirestoreStore {
   async list(prefix, cursor, limit) {
     const [results, nextPageToken] = await this.doList(prefix, cursor, limit)
     const data = results.map(doc => {
-      return JSON.parse(doc.fields.data.stringValue)
+      return {
+        [doc.name.split('docs/')[1]]: JSON.parse(doc.fields.data.stringValue),
+      }
     })
     return {
       data,

--- a/packages/livepeer.com/www/components/UserTable/index.tsx
+++ b/packages/livepeer.com/www/components/UserTable/index.tsx
@@ -18,6 +18,7 @@ export default ({ userId, id }) => {
   const close = () => {
     setAdminModal(false);
     setRemoveAdminModal(false);
+    setSelectedUser(null);
   };
   return (
     <Box


### PR DESCRIPTION

**What does this pull request do? Explain your changes. (required)**
Fixes issue on livepeer.monster with firestore DB. List function was returning wrong object structure. 

**Bug:**

![image](https://user-images.githubusercontent.com/16169518/81233776-6ab81680-8fc5-11ea-9d27-5a261d9142ff.png)

... because of user list coming back from Firestore:

<img width="1680" alt="Screen Shot 2020-05-06 at 5 29 06 PM" src="https://user-images.githubusercontent.com/16169518/81233818-86232180-8fc5-11ea-849f-831035c7a3de.png">

list now looks like this:

<img width="1680" alt="Screen Shot 2020-05-06 at 5 33 15 PM" src="https://user-images.githubusercontent.com/16169518/81233833-90ddb680-8fc5-11ea-9d14-e7847d722d4e.png">


**Does this pull request close any open issues?**
https://github.com/livepeer/livepeerjs/issues/685

**Checklist:**
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
