### PR TITLE
Increase precision in voting percentages

### DIFF
--- a/packages/explorer-2.0/components/VotingWidget/index.tsx
+++ b/packages/explorer-2.0/components/VotingWidget/index.tsx
@@ -111,7 +111,7 @@ export default ({ data }) => {
                 <Box sx={{ lineHeight: 1, pr: 1, color: 'text', fontSize: 1 }}>
                   {isNaN(yesVoteStake / totalVoteStake)
                     ? 0
-                    : ((yesVoteStake / totalVoteStake) * 100).toPrecision(4)}
+                    : ((yesVoteStake / totalVoteStake) * 100).toPrecision(5)}
                   %
                 </Box>
               </Flex>
@@ -152,7 +152,7 @@ export default ({ data }) => {
                 <Box sx={{ lineHeight: 1, pr: 1, color: 'text', fontSize: 1 }}>
                   {isNaN(noVoteStake / totalVoteStake)
                     ? 0
-                    : ((noVoteStake / totalVoteStake) * 100).toPrecision(4)}
+                    : ((noVoteStake / totalVoteStake) * 100).toPrecision(5)}
                   %
                 </Box>
               </Flex>

--- a/packages/explorer-2.0/pages/voting/[poll].tsx
+++ b/packages/explorer-2.0/pages/voting/[poll].tsx
@@ -225,7 +225,7 @@ const Poll = () => {
                       lineHeight: 'heading',
                     }}
                   >
-                    {pollData.totalSupport.toPrecision(4)}%
+                    {pollData.totalSupport.toPrecision(5)}%
                   </Box>
                 }
               >
@@ -239,7 +239,7 @@ const Poll = () => {
                         {isNaN(yesVoteStake / totalVoteStake)
                           ? 0
                           : ((yesVoteStake / totalVoteStake) * 100).toPrecision(
-                              4,
+                              5,
                             )}
                         %)
                       </Box>
@@ -260,7 +260,7 @@ const Poll = () => {
                         {isNaN(noVoteStake / totalVoteStake)
                           ? 0
                           : ((noVoteStake / totalVoteStake) * 100).toPrecision(
-                              4,
+                              5,
                             )}
                         %)
                       </Box>
@@ -307,7 +307,7 @@ const Poll = () => {
                       lineHeight: 'heading',
                     }}
                   >
-                    {pollData.totalParticipation.toPrecision(4)}%
+                    {pollData.totalParticipation.toPrecision(5)}%
                   </Box>
                 }
               >
@@ -320,7 +320,7 @@ const Poll = () => {
                     }}
                   >
                     <span sx={{ color: 'muted' }}>
-                      Voters ({pollData.totalParticipation.toPrecision(4)}
+                      Voters ({pollData.totalParticipation.toPrecision(5)}
                       %)
                     </span>
                     <span>
@@ -331,7 +331,7 @@ const Poll = () => {
                   </Flex>
                   <Flex sx={{ fontSize: 1, justifyContent: 'space-between' }}>
                     <span sx={{ color: 'muted' }}>
-                      Nonvoters ({pollData.nonVoters.toPrecision(4)}
+                      Nonvoters ({pollData.nonVoters.toPrecision(5)}
                       %)
                     </span>
                     <span>


### PR DESCRIPTION
**What does this pull request do? Explain your changes**
This PR increases the total support and total participation precision from 4 to 5 units, so that even if you vote with very little stake, you can still see a change in the total support or total participation percentage before it rounds up.

**Screenshots**
Notice, the total support now displays as 99.999% rather than 100% to reflect the single "No" vote with 54.43 LPT at stake.
<!-- Drag some screenshots here, if applicable -->
![image](https://user-images.githubusercontent.com/555740/81750529-ac403a00-947b-11ea-9041-2be9075fe94e.png)


**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
