### PR TITLE
update explorer subgraph environment var

### DIFF
--- a/packages/explorer-2.0/now.json
+++ b/packages/explorer-2.0/now.json
@@ -48,7 +48,7 @@
       "PORTIS_DAPP_ID": "@portis_dapp_id",
       "GA_TRACKING_ID": "@ga_tracking_id",
       "NETWORK": "mainnet",
-      "SUBGRAPH": "https://api.thegraph.com/subgraphs/name/livepeer/livepeer-canary",
+      "SUBGRAPH": "https://api.thegraph.com/subgraphs/name/livepeer/livepeer",
       "RPC_URL_1": "https://mainnet.infura.io/v3/39df858a55ee42f4b2a8121978f9f98e",
       "RPC_URL_4": "https://rinkeby.infura.io/v3/39df858a55ee42f4b2a8121978f9f98e",
       "CONTROLLER_ADDRESS": "0xf96d54e490317c557a967abfa5d6e33006be69b3",


### PR DESCRIPTION
**What does this pull request do? Explain your changes.**
Updates subgraph env var from `livepeer/livepeer-canary` to `livepeer/livepeer`


