### PR TITLE
update tv redirect link

### DIFF
--- a/now.json
+++ b/now.json
@@ -21,7 +21,7 @@
       "src": "/tv",
       "status": 301,
       "headers": {
-        "Location": "https://media.livepeer.org/play?url=https://chi.livepeer.live/origin/hls/4br7%2Badam_obs/index.m3u8"
+        "Location": "https://media.livepeer.org/play?url=https%3A%2F%2Fd21gyr0uv5jqnv.cloudfront.net%2F4br7%252Badam_obs%2Findex.m3u8"
       }
     },
     { "src": "^/(.*)", "dest": "/packages/livepeer.com/www/$1" }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR updates the livepeer.com/tv redirect link to a CDN enabled one. 