### PR TITLE
add last reward round to an orchestrator's campaign view

### DIFF
--- a/packages/explorer-2.0/components/CampaignView/index.tsx
+++ b/packages/explorer-2.0/components/CampaignView/index.tsx
@@ -3,8 +3,11 @@ import * as Utils from 'web3-utils'
 import Card from '../Card'
 import { abbreviateNumber } from '../../lib/utils'
 import { Box } from 'theme-ui'
+import { MdCheck, MdClose } from 'react-icons/md'
+import ReactTooltip from 'react-tooltip'
+import Help from '../../public/img/help.svg'
 
-export default ({ transcoder }) => {
+export default ({ currentRound, transcoder }) => {
   const callsMade = transcoder.pools.filter(r => r.rewardTokens != null).length
   return (
     <Box sx={{ pt: 4 }}>
@@ -116,6 +119,59 @@ export default ({ transcoder }) => {
                   ? 0
                   : 100 - parseInt(transcoder.feeShare, 10) / 10000}
                 %
+              </Box>
+            }
+          />
+          <Card
+            sx={{ flex: 1 }}
+            title={
+              <Flex sx={{ alignItems: 'center' }}>
+                <Box sx={{ color: 'muted' }}>Last Reward Round</Box>
+                <Flex>
+                  <ReactTooltip
+                    id="tooltip-last-reward-round"
+                    className="tooltip"
+                    place="top"
+                    type="dark"
+                    effect="solid"
+                  />
+                  <Help
+                    data-tip="The last round that an orchestrator received rewards as an active orchestrator. A checkmark indicates it called reward for the current round."
+                    data-for="tooltip-last-reward-round"
+                    sx={{
+                      color: 'muted',
+                      cursor: 'pointer',
+                      ml: 1,
+                    }}
+                  />
+                </Flex>
+              </Flex>
+            }
+            subtitle={
+              <Box
+                sx={{
+                  fontSize: [3, 3, 4, 4, 5],
+                  color: 'text',
+                  position: 'relative',
+                  fontWeight: 500,
+                  lineHeight: 'heading',
+                  fontFamily: 'monospace',
+                }}
+              >
+                <Flex sx={{ alignItems: 'center' }}>
+                  {transcoder.lastRewardRound.id}{' '}
+                  {transcoder.active && (
+                    <Flex>
+                      {transcoder.lastRewardRound.id === currentRound.id ? (
+                        <MdCheck
+                          sx={{ fontSize: 2, color: 'primary', ml: 1 }}
+                        />
+                      ) : (
+                        <MdClose sx={{ fontSize: 2, color: 'red', ml: 1 }} />
+                      )}
+                    </Flex>
+                  )}
+                </Flex>
               </Box>
             }
           />

--- a/packages/explorer-2.0/components/CampaignView/index.tsx
+++ b/packages/explorer-2.0/components/CampaignView/index.tsx
@@ -136,7 +136,7 @@ export default ({ currentRound, transcoder }) => {
                     effect="solid"
                   />
                   <Help
-                    data-tip="The last round that an orchestrator received rewards as an active orchestrator. A checkmark indicates it called reward for the current round."
+                    data-tip="The last round that an orchestrator received rewards while active. A checkmark indicates it called reward for the current round."
                     data-for="tooltip-last-reward-round"
                     sx={{
                       color: 'muted',

--- a/packages/explorer-2.0/components/HistoryView/index.tsx
+++ b/packages/explorer-2.0/components/HistoryView/index.tsx
@@ -61,26 +61,30 @@ export default () => {
       sx={{ overflow: 'hidden !important' }}
       scrollThreshold={0.5}
       dataLength={data && data.transactions.length}
-      next={() => {
+      next={async () => {
         stopPolling()
         if (!loading && data.transactions.length >= 10) {
-          fetchMore({
-            variables: {
-              skip: data.transactions.length,
-            },
-            updateQuery: (previousResult: any, { fetchMoreResult }: any) => {
-              if (!fetchMoreResult) {
-                return previousResult
-              }
-              return {
-                ...previousResult,
-                transactions: [
-                  ...previousResult.transactions,
-                  ...fetchMoreResult.transactions,
-                ],
-              }
-            },
-          })
+          try {
+            await fetchMore({
+              variables: {
+                skip: data.transactions.length,
+              },
+              updateQuery: (previousResult: any, { fetchMoreResult }: any) => {
+                if (!fetchMoreResult) {
+                  return previousResult
+                }
+                return {
+                  ...previousResult,
+                  transactions: [
+                    ...previousResult.transactions,
+                    ...fetchMoreResult.transactions,
+                  ],
+                }
+              },
+            })
+          } catch (e) {
+            return e
+          }
         }
       }}
       hasMore={true}

--- a/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
+++ b/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
@@ -155,7 +155,12 @@ const Account = () => {
           transcoder={data.transcoder}
         />
         <Tabs tabs={tabs} />
-        {slug == 'campaign' && <CampaignView transcoder={data.transcoder} />}
+        {slug == 'campaign' && (
+          <CampaignView
+            currentRound={data.currentRound[0]}
+            transcoder={data.transcoder}
+          />
+        )}
         {slug == 'fees' && (
           <FeesView
             delegator={data.delegator}

--- a/packages/explorer-2.0/queries/accountView.gql
+++ b/packages/explorer-2.0/queries/accountView.gql
@@ -53,6 +53,9 @@ query($account: ID!) {
     active
     totalStake
     totalGeneratedFees
+    lastRewardRound {
+      id
+    }
     pools(first: 30, orderBy: id, orderDirection: desc) {
       rewardTokens
     }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds an O's last reward round to its campaign view and adds an indication whether or not it called reward for the current round. It also fixes a runtime error I noticed [caused by Apollo](https://github.com/apollographql/apollo-client/issues/4114) that would occur when navigating from the history view to the campaign view (or any other route for that matter) while in the middle of loading more history results. 

**Does this pull request close any open issues?**
Fixes #538 

**Screenshots (optional):**
<img width="304" alt="Screen Shot 2020-05-15 at 10 31 31 AM" src="https://user-images.githubusercontent.com/555740/82091365-38916d80-96c5-11ea-81d1-a2c71621467b.png">
