### PR TITLE
fix subgraph poll tally when delegator switches to an orchestrator that voted

### DIFF
--- a/packages/subgraph/test/integration/test.js
+++ b/packages/subgraph/test/integration/test.js
@@ -597,6 +597,21 @@ contract('Subgraph Integration Tests', accounts => {
     await tallyPollAndCheckResult()
   })
 
+  it('correctly tallies poll after delegator moves stake to a transcoder that voted', async () => {
+    let bondAmount = 1000
+    await Token.methods.approve(bondingManagerAddress, bondAmount).send({
+      from: delegator1,
+    })
+    await BondingManager.methods
+      .bond(bondAmount, transcoder1)
+      .send({ from: delegator1 })
+
+    voters[transcoder1].overrides.push(delegator1)
+
+    await waitForSubgraphToBeSynced()
+    await tallyPollAndCheckResult()
+  })
+
   it('correctly tallies poll after transcoder 1 resigns', async () => {
     let unbondAmount = await getStake(transcoder1)
     await BondingManager.methods


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR addresses a discrepancy in the offchain poll tally subgraph results that occurs when a delegator switches stake to an orchestrator that voted in a poll. The discrepancy is too small to notice in the explorer UI right now due to precision rounding but can be confirmed running the [poll tally audit script](https://github.com/livepeer/poll-tally-audit).

The Livepeer Canary subgraph is currently syncing with this fix. After it’s done syncing I’ll run the audit again and once it passes we can merge this PR and point to the updated subgraph.

**How did you test each of these updates (required)**
Added an integration test for when a delegator switches to an orchestrator that voted in a poll.

**Screenshots (optional):**
Current [poll tally audit](https://github.com/livepeer/poll-tally-audit) results:
<img width="635" alt="Screen Shot 2020-05-18 at 7 18 32 PM" src="https://user-images.githubusercontent.com/555740/82268176-5f0d0e00-993c-11ea-948f-24752a4381ef.png">

