### PR TITLE
fix poll end time display

### DIFF
--- a/packages/explorer-2.0/lib/createSchema.tsx
+++ b/packages/explorer-2.0/lib/createSchema.tsx
@@ -146,9 +146,7 @@ export default async () => {
               _poll?.tally?.no ? _poll?.tally?.no : '0',
             ).add(Utils.toBN(_poll?.tally?.yes ? _poll?.tally?.yes : '0'))
 
-            return Utils.toBN(totalStake)
-              .sub(totalVoteStake)
-              .toString()
+            return Utils.toBN(totalStake).sub(totalVoteStake).toString()
           },
         },
         status: {
@@ -210,10 +208,16 @@ export default async () => {
         },
         endTime: {
           async resolve(_poll, _args, _context, _info) {
-            const blockData = await _context.livepeer.rpc.getBlock('latest')
-            return parseInt(blockData.number) > parseInt(_poll.endBlock)
-              ? blockData.timestamp
-              : null
+            const currentBlockData = await _context.livepeer.rpc.getBlock(
+              'latest',
+            )
+            if (parseInt(currentBlockData.number) < parseInt(_poll.endBlock)) {
+              return currentBlockData.timestamp
+            }
+            const endBlockData = await _context.livepeer.rpc.getBlock(
+              _poll.endBlock,
+            )
+            return endBlockData.timestamp
           },
         },
       },

--- a/packages/explorer-2.0/lib/createSchema.tsx
+++ b/packages/explorer-2.0/lib/createSchema.tsx
@@ -146,7 +146,9 @@ export default async () => {
               _poll?.tally?.no ? _poll?.tally?.no : '0',
             ).add(Utils.toBN(_poll?.tally?.yes ? _poll?.tally?.yes : '0'))
 
-            return Utils.toBN(totalStake).sub(totalVoteStake).toString()
+            return Utils.toBN(totalStake)
+              .sub(totalVoteStake)
+              .toString()
           },
         },
         status: {
@@ -212,7 +214,7 @@ export default async () => {
               'latest',
             )
             if (parseInt(currentBlockData.number) < parseInt(_poll.endBlock)) {
-              return currentBlockData.timestamp
+              return null
             }
             const endBlockData = await _context.livepeer.rpc.getBlock(
               _poll.endBlock,


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The poll end date is incorrectly displaying the timestamp associated with the latest block rather than the end block. This PR fixes that.

<img width="427" alt="Screen Shot 2020-05-21 at 11 40 17 AM" src="https://user-images.githubusercontent.com/555740/82576692-fa2dff80-9b57-11ea-9fa8-bab3ce61d1b9.png">
