### PR TITLE
ar/adding segment http api

### DIFF
--- a/packages/api/src/controllers/api-token.js
+++ b/packages/api/src/controllers/api-token.js
@@ -68,23 +68,25 @@ app.post(
   async (req, res) => {
     const id = uuid()
     const userId = req.user.id
-    await req.store.create({
-      id: id,
-      userId: userId,
-      kind: 'api-token',
-      name: req.body.name,
-    })
 
-    const apiToken = await req.store.get(`api-token/${id}`)
-
-    if (apiToken) {
+    await Promise.all([
+      req.store.create({
+        id: id,
+        userId: userId,
+        kind: 'api-token',
+        name: req.body.name,
+      }),
       trackAction(
         userId,
         req.user.email,
         { name: 'Api Token Created' },
         req.config.segmentApiKey,
-      )
+        )
+      ])
 
+    const apiToken = await req.store.get(`api-token/${id}`)
+
+    if (apiToken) {
       res.status(201)
       res.json(apiToken)
     } else {

--- a/packages/api/src/controllers/api-token.js
+++ b/packages/api/src/controllers/api-token.js
@@ -56,7 +56,10 @@ app.get('/', authMiddleware({}), async (req, res) => {
     })
   }
 
-  const { data: userTokens } = await req.store.queryObjects({ kind: 'api-token', query: { userId: userId } })
+  const { data: userTokens } = await req.store.queryObjects({
+    kind: 'api-token',
+    query: { userId: userId },
+  })
   res.status(200)
   res.json(userTokens)
 })
@@ -81,8 +84,8 @@ app.post(
         req.user.email,
         { name: 'Api Token Created' },
         req.config.segmentApiKey,
-        )
-      ])
+      ),
+    ])
 
     const apiToken = await req.store.get(`api-token/${id}`)
 

--- a/packages/api/src/controllers/helpers.js
+++ b/packages/api/src/controllers/helpers.js
@@ -156,7 +156,7 @@ export async function trackAction(userId, email, event, apiKey) {
     traits: {
       email: email,
     },
-    email: email
+    email: email,
   }
   await fetchSegmentApi(identifyInfo, 'identify', apiKey)
 
@@ -188,5 +188,4 @@ export async function fetchSegmentApi(body, endpoint, apiKey) {
     body: JSON.stringify(body),
     headers: headers,
   })
-
 }

--- a/packages/api/src/controllers/helpers.js
+++ b/packages/api/src/controllers/helpers.js
@@ -181,11 +181,10 @@ export async function fetchSegmentApi(body, endpoint, apiKey) {
     Authorization: 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
   }
 
-  const request = await fetch(`${segmentApiUrl}/${endpoint}`, {
+  await fetch(`${segmentApiUrl}/${endpoint}`, {
     method: 'POST',
     body: JSON.stringify(body),
     headers: headers,
   })
 
-  return request
 }

--- a/packages/api/src/controllers/helpers.js
+++ b/packages/api/src/controllers/helpers.js
@@ -156,6 +156,7 @@ export async function trackAction(userId, email, event, apiKey) {
     traits: {
       email: email,
     },
+    email: email
   }
   await fetchSegmentApi(identifyInfo, 'identify', apiKey)
 
@@ -167,6 +168,7 @@ export async function trackAction(userId, email, event, apiKey) {
   const trackInfo = {
     userId: userId,
     event: event.name,
+    email: email,
     properties: properties,
   }
 

--- a/packages/api/src/controllers/helpers.js
+++ b/packages/api/src/controllers/helpers.js
@@ -1,7 +1,7 @@
 import crypto from 'isomorphic-webcrypto'
 import util from 'util'
+import fetch from 'isomorphic-fetch'
 import SendgridMail from '@sendgrid/mail'
-import SegmentAnalytics from 'analytics-node'
 
 let Encoder
 if (typeof TextEncoder === 'undefined') {
@@ -146,26 +146,46 @@ export async function sendgridEmail({
   await SendgridMail.send(msg)
 }
 
-export async function trackAction(userId, email, event, segmentApiKey) {
-  if (!segmentApiKey) {
+export async function trackAction(userId, email, event, apiKey) {
+  if (!apiKey) {
     return
   }
-  var analytics = new SegmentAnalytics(segmentApiKey, { flushAt: 1 })
-  analytics.identify({
+
+  const identifyInfo = {
     userId: userId,
     traits: {
       email: email,
     },
-  })
+  }
+  await fetchSegmentApi(identifyInfo, 'identify', apiKey)
 
   const properties = {}
   if ('properties' in event) {
     properties = { ...properties, ...event.properties }
   }
 
-  analytics.track({
+  const trackInfo = {
     userId: userId,
     event: event.name,
     properties: properties,
+  }
+
+  await fetchSegmentApi(trackInfo, 'track', apiKey)
+}
+
+export async function fetchSegmentApi(body, endpoint, apiKey) {
+  const segmentApiUrl = 'https://api.segment.io/v1'
+
+  const headers = {
+    'Content-Type': 'application/json',
+    Authorization: 'Basic ' + Buffer.from(`${apiKey}:`).toString('base64'),
+  }
+
+  const request = await fetch(`${segmentApiUrl}/${endpoint}`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: headers,
   })
+
+  return request
 }

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -86,14 +86,14 @@ app.post('/', authMiddleware({}), validatePost('stream'), async (req, res) => {
     id,
     createdAt,
   })
-
-  await req.store.create(doc)
+  await Promise.all([
+  req.store.create(doc),
   trackAction(
     req.user.id,
     req.user.email,
     { name: 'Stream Created' },
     req.config.segmentApiKey,
-  )
+  )])
 
   res.status(201)
   res.json(doc)

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -19,7 +19,12 @@ app.get('/', authMiddleware({ admin: true }), async (req, res) => {
   logger.info(`cursor params ${req.query.cursor}, limit ${limit}`)
   const filter = all ? undefined : o => !o[Object.keys(o)[0]].deleted
 
-  const resp = await req.store.list({ prefix: `stream/`, cursor, limit, filter })
+  const resp = await req.store.list({
+    prefix: `stream/`,
+    cursor,
+    limit,
+    filter,
+  })
   let output = resp.data
   res.status(200)
 
@@ -47,7 +52,7 @@ app.get('/user/:userId', authMiddleware({}), async (req, res) => {
     query: { userId: req.params.userId },
     cursor,
     limit,
-    filter: (o => !o.deleted)
+    filter: o => !o.deleted,
   })
   res.status(200)
   if (streams.length > 0 && cursorOut) {
@@ -58,7 +63,10 @@ app.get('/user/:userId', authMiddleware({}), async (req, res) => {
 
 app.get('/:id', authMiddleware({}), async (req, res) => {
   const stream = await req.store.get(`stream/${req.params.id}`)
-  if (!stream || (stream.userId !== req.user.id || stream.deleted) && !req.isUIAdmin) {
+  if (
+    !stream ||
+    ((stream.userId !== req.user.id || stream.deleted) && !req.isUIAdmin)
+  ) {
     // do not reveal that stream exists
     res.status(404)
     return res.json({ errors: ['not found'] })
@@ -87,13 +95,14 @@ app.post('/', authMiddleware({}), validatePost('stream'), async (req, res) => {
     createdAt,
   })
   await Promise.all([
-  req.store.create(doc),
-  trackAction(
-    req.user.id,
-    req.user.email,
-    { name: 'Stream Created' },
-    req.config.segmentApiKey,
-  )])
+    req.store.create(doc),
+    trackAction(
+      req.user.id,
+      req.user.email,
+      { name: 'Stream Created' },
+      req.config.segmentApiKey,
+    ),
+  ])
 
   res.status(201)
   res.json(doc)
@@ -102,7 +111,11 @@ app.post('/', authMiddleware({}), validatePost('stream'), async (req, res) => {
 app.delete('/:id', authMiddleware({}), async (req, res) => {
   const { id } = req.params
   const stream = await req.store.get(`stream/${id}`, false)
-  if (!stream || stream.deleted || stream.userId !== req.user.id && !req.isUIAdmin) {
+  if (
+    !stream ||
+    stream.deleted ||
+    (stream.userId !== req.user.id && !req.isUIAdmin)
+  ) {
     res.status(404)
     return res.json({ errors: ['not found'] })
   }

--- a/packages/api/src/controllers/user.js
+++ b/packages/api/src/controllers/user.js
@@ -12,7 +12,11 @@ import qs from 'qs'
 const app = Router()
 
 app.get('/', authMiddleware({ admin: true }), async (req, res) => {
-  const resp = await req.store.list({ prefix: `user/`, cursor: req.query.cursor, limit: req.query.limit })
+  const resp = await req.store.list({
+    prefix: `user/`,
+    cursor: req.query.cursor,
+    limit: req.query.limit,
+  })
   res.status(200)
 
   if (resp.data.length > 0) {
@@ -69,7 +73,7 @@ app.post('/', validatePost('user'), async (req, res) => {
       email,
       { name: 'user registered' },
       req.config.segmentApiKey,
-    )
+    ),
   ])
 
   const user = await req.store.get(`user/${id}`)
@@ -79,7 +83,7 @@ app.post('/', validatePost('user'), async (req, res) => {
 
   const verificationUrl = `${protocol}://${
     req.headers.host
-    }/app/user/verify?${qs.stringify({ email, emailValidToken })}`
+  }/app/user/verify?${qs.stringify({ email, emailValidToken })}`
   const unsubscribeUrl = `${protocol}://${req.headers.host}/#contactSection`
 
   if (!validUser && user) {
@@ -123,7 +127,7 @@ app.post('/', validatePost('user'), async (req, res) => {
 app.post('/token', validatePost('user'), async (req, res) => {
   const { data: userIds } = await req.store.query({
     kind: 'user',
-    query: { email: req.body.email }
+    query: { email: req.body.email },
   })
   if (userIds.length < 1) {
     res.status(404)
@@ -155,7 +159,7 @@ app.post('/token', validatePost('user'), async (req, res) => {
 app.post('/verify', validatePost('user-verification'), async (req, res) => {
   const { data: userIds } = await req.store.query({
     kind: 'user',
-    query: { email: req.body.email }
+    query: { email: req.body.email },
   })
   if (userIds.length < 1) {
     res.status(404)
@@ -213,9 +217,11 @@ app.post(
   validatePost('password-reset'),
   async (req, res) => {
     const { email, password, resetToken } = req.body
-    const { data: [userId] } = await req.store.query({
+    const {
+      data: [userId],
+    } = await req.store.query({
       kind: 'user',
-      query: { email: email }
+      query: { email: email },
     })
     if (!userId) {
       res.status(404)
@@ -231,7 +237,7 @@ app.post(
     const { data: tokens } = await req.store.query({
       kind: 'password-reset-token',
       query: {
-        userId: user.id
+        userId: user.id,
       },
     })
 
@@ -285,9 +291,11 @@ app.post(
   validatePost('password-reset-token'),
   async (req, res) => {
     const email = req.body.email
-    const { data: [userId] } = await req.store.query({
+    const {
+      data: [userId],
+    } = await req.store.query({
       kind: 'user',
-      query: { email: email }
+      query: { email: email },
     })
     if (!userId) {
       res.status(404)
@@ -317,7 +325,7 @@ app.post(
 
       const verificationUrl = `${protocol}://${
         req.headers.host
-        }/reset-password?${qs.stringify({ email, resetToken })}`
+      }/reset-password?${qs.stringify({ email, resetToken })}`
       const unsubscribeUrl = `${protocol}://${req.headers.host}/#contactSection`
 
       await sendgridEmail({
@@ -361,7 +369,7 @@ app.post(
   async (req, res) => {
     const { data: userIds } = await req.store.query({
       kind: 'user',
-      query: { email: req.body.email }
+      query: { email: req.body.email },
     })
     if (userIds.length < 1) {
       res.status(404)

--- a/packages/api/src/test-server.js
+++ b/packages/api/src/test-server.js
@@ -19,7 +19,6 @@ const jwtSecret = 'secret'
 const supportAddr = 'Livepeer Team/angie@livepeer.org'
 const sendgridTemplateId = 'iamanid'
 const sendgridApiKey = 'SG. iamanapikey'
-const segmentApiKey = 'segmentapikey'
 
 fs.ensureDirSync(dbPath)
 
@@ -36,7 +35,6 @@ params.jwtSecret = jwtSecret
 params.supportAddr = supportAddr
 params.sendgridTemplateId = sendgridTemplateId
 params.sendgridApiKey = sendgridApiKey
-params.segmentApiKey = segmentApiKey
 
 if (!params.insecureTestToken) {
   params.insecureTestToken = uuid()

--- a/packages/livepeer.com/www/hooks/use-api.tsx
+++ b/packages/livepeer.com/www/hooks/use-api.tsx
@@ -9,6 +9,12 @@ import qs from "qs";
  * helpers around a nice auto-generated TypeScript client from our Swagger schema.
  */
 
+declare global {
+  interface Window {
+    _hsq: any;
+  }
+}
+
 type ApiState = {
   user?: User;
   token?: string;
@@ -25,6 +31,15 @@ const storeToken = token => {
       Safari private window and you don't want the token to persist anyway.
     `);
   }
+};
+
+const trackPageView = (email, path = null) => {
+  var _hsq = (window._hsq = window._hsq || []);
+  _hsq.push(["identify", { email: email }]);
+  if (path) {
+    _hsq.push(["setPath", path]);
+  }
+  _hsq.push(["trackPageView"]);
 };
 
 const getStoredToken = () => {
@@ -69,6 +84,7 @@ const makeContext = (state: ApiState, setState) => {
     },
 
     async login(email, password) {
+      trackPageView(email);
       const [res, body] = await context.fetch("/user/token", {
         method: "POST",
         body: JSON.stringify({ email, password }),
@@ -94,6 +110,7 @@ const makeContext = (state: ApiState, setState) => {
     },
 
     async register(email, password) {
+      trackPageView(email);
       const [res, body] = await context.fetch("/user", {
         method: "POST",
         body: JSON.stringify({ email, password }),
@@ -108,6 +125,7 @@ const makeContext = (state: ApiState, setState) => {
     },
 
     async verify(email, emailValidToken) {
+      trackPageView(email);
       const res = await context.fetch("/user/verify", {
         method: "POST",
         body: JSON.stringify({ email, emailValidToken }),
@@ -119,6 +137,7 @@ const makeContext = (state: ApiState, setState) => {
     },
 
     async makePasswordResetToken(email) {
+      trackPageView(email);
       const [res, body] = await context.fetch("/user/password/reset-token", {
         method: "POST",
         body: JSON.stringify({ email }),
@@ -130,6 +149,7 @@ const makeContext = (state: ApiState, setState) => {
     },
 
     async resetPassword(email, resetToken, password) {
+      trackPageView(email);
       const [res, body] = await context.fetch("/user/password/reset", {
         method: "POST",
         body: JSON.stringify({ email, resetToken, password }),
@@ -198,6 +218,7 @@ const makeContext = (state: ApiState, setState) => {
     },
 
     async createApiToken(params): Promise<ApiToken> {
+      trackPageView(params.email, "/create-api-token");
       const [res, token] = await context.fetch(`/api-token`, {
         method: "POST",
         body: JSON.stringify(params),

--- a/packages/livepeer.com/www/pages/_document.tsx
+++ b/packages/livepeer.com/www/pages/_document.tsx
@@ -32,6 +32,15 @@ class MyDocument extends Document {
         <body>
           <Main />
           <NextScript />
+          {
+            <script
+              type="text/javascript"
+              id="hs-script-loader"
+              async
+              defer
+              src="//js.hs-scripts.com/6160488.js"
+            />
+          }
         </body>
       </Html>
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -33023,7 +33023,7 @@ pull-window@^2.1.4:
   dependencies:
     looper "^2.0.0"
 
-"pull-ws@github:hugomrdias/pull-ws#fix/bundle-size":
+pull-ws@hugomrdias/pull-ws#fix/bundle-size:
   version "3.3.1"
   resolved "https://codeload.github.com/hugomrdias/pull-ws/tar.gz/8e2ce0bb3b1cd6804828316e937fff8e0bef6225"
   dependencies:


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**

Segment tracking calls were not working inside of our CloudFlare worker. Was using the Segment npm package previously to send data to Segment. This PR reworks the code to use the Segment HTTP-API. Had to batch controller `trackAction` calls with `req.store.create` in a `Promise.all` so as to speed up async calls and to prevent CloudFlare from exiting before completing Segment calls.

Issue could have potentially have had to do with conflicting Axios versions, since we're using a forked version of Axios with support for `fetch()`. 

**How did you test each of these updates (required)**
Tested locally and  on the CloudFlare worker directly.

**Does this pull request close any open issues?**
https://github.com/livepeer/livepeerjs/issues/730
