### PR TITLE
removing superflous event creation

### DIFF
--- a/packages/livepeer.com/www/components/Layout/index.tsx
+++ b/packages/livepeer.com/www/components/Layout/index.tsx
@@ -25,7 +25,7 @@ if (process.env.NODE_ENV === "production") {
 // Track client-side page views with Segment & HubSpot
 if (process.env.NODE_ENV === "production") {
   Router.events.on("routeChangeComplete", url => {
-    window.analytics.page(url);
+    window.analytics.page();
     var _hsq = (window["hsq"] = window["hsq"] || []);
     _hsq.push(["setPath", url]);
     _hsq.push(["trackPageView"]);

--- a/packages/livepeer.com/www/pages/_document.tsx
+++ b/packages/livepeer.com/www/pages/_document.tsx
@@ -12,7 +12,7 @@ class MyDocument extends Document {
       apiKey: process.env.SEGMENT_WRITE_KEY,
       // note: the page option only covers SSR tracking.
       // The Layout component is used to track other events using `window.analytics.page()`
-      page: true
+      page: false
     };
 
     return snippet.min(opts);


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Step 1 in getting to ...

Inbound traffic and traffic by referral source (stack traffic to get the total traffic)
- Default last 30 days or Default last 7 days
- Can we change the time frame easily?
- Referral traffic sources should be high level: lp.org, email, organic, paid 
- Paid (Google, LI, FB, Other?) 

