### PR TITLE
Reduce unneccesary polling

### DIFF
--- a/packages/explorer-2.0/pages/index.tsx
+++ b/packages/explorer-2.0/pages/index.tsx
@@ -17,7 +17,6 @@ const Home = () => {
   const accountQuery = require('../queries/account.gql')
   const context = useWeb3React()
   const { data, loading } = useQuery(orchestratorsViewQuery, {
-    pollInterval: 10000,
     ssr: false,
   })
   const { data: dataMyAccount, loading: loadingMyAccount } = useQuery(


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The explorer currently polls data on the orchestrators and accounts views every 10 seconds to keep data fresh. Each poll interval on the orchestrators view contains about 10 network requests to infura which means if 100 people have the explorer open for 24 hours that's ~8,640,000 calls to Infura. This PR removes polling from the orchestrator view in an effort to reduce the amount of calls.

In the future, we should look into replacing polling all together with websockets.
