### PR TITLE
Reduce explorer poll interval

### DIFF
--- a/packages/explorer-2.0/components/StakingGuide/Step5.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/Step5.tsx
@@ -19,7 +19,7 @@ export default ({ goTo, nextStep }) => {
     variables: {
       account: context?.account?.toLowerCase(),
     },
-    pollInterval: 10000,
+    pollInterval: 20000,
     skip: !context.active, // skip this query if wallet not connected
     ssr: false,
   })

--- a/packages/explorer-2.0/components/TokenholdersView/index.tsx
+++ b/packages/explorer-2.0/components/TokenholdersView/index.tsx
@@ -48,7 +48,7 @@ export default () => {
       skip: 0,
     },
     ssr: false,
-    pollInterval: 10000,
+    pollInterval: 20000,
     notifyOnNetworkStatusChange: true,
   })
 

--- a/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
+++ b/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
@@ -33,7 +33,7 @@ const Account = () => {
     variables: {
       account: query.account.toString().toLowerCase(),
     },
-    pollInterval: 10000,
+    pollInterval: 20000,
     ssr: false,
   })
 
@@ -43,7 +43,7 @@ const Account = () => {
       variables: {
         account: context?.account?.toLowerCase(),
       },
-      pollInterval: 10000,
+      pollInterval: 20000,
       skip: !context.active, // skip this query if wallet not connected
       ssr: false,
     },

--- a/packages/explorer-2.0/pages/index.tsx
+++ b/packages/explorer-2.0/pages/index.tsx
@@ -25,7 +25,7 @@ const Home = () => {
       variables: {
         account: context?.account?.toLowerCase(),
       },
-      pollInterval: 10000,
+      pollInterval: 20000,
       skip: !context.active,
       ssr: false,
     },


### PR DESCRIPTION
**What does this pull request do? Explain your changes**
The explorer currently polls account data every 10 seconds to keep data fresh. Each poll interval 
makes ~10 network requests to Infura which means if 100 people have the explorer open for 24 hours that's ~8,640,000 calls to Infura which is around what we're seeing. This PR reduces polling from 10 seconds to every 20 seconds in an effort to reduce the amount of Infura requests.

In the future, we should look into replacing polling all together with websockets. Both the hosted subgraph and Infura offer websocket support.