### PR TITLE
api: add fractional FPS profile support

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -367,10 +367,19 @@ app.post('/hook', async (req, res) => {
     }
   }
 
+  // Rewrite fpsDen to snake_case for go-livepeer
+  const profiles = (stream.profiles || []).map((profile) => {
+    return {
+      ...profile,
+      fpsDen: undefined,
+      fps_den: profile.fpsDen,
+    }
+  })
+
   res.json({
     manifestId: streamId,
     presets: stream.presets,
-    profiles: stream.profiles,
+    profiles: profiles,
     objectStore: objectStore,
   })
 })

--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -367,19 +367,10 @@ app.post('/hook', async (req, res) => {
     }
   }
 
-  // Rewrite fpsDen to snake_case for go-livepeer
-  const profiles = (stream.profiles || []).map((profile) => {
-    return {
-      ...profile,
-      fpsDen: undefined,
-      fps_den: profile.fpsDen,
-    }
-  })
-
   res.json({
     manifestId: streamId,
     presets: stream.presets,
-    profiles: profiles,
+    profiles: stream.profiles,
     objectStore: objectStore,
   })
 })

--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -434,4 +434,91 @@ describe('controllers/stream', () => {
       expect(res.status).toBe(422)
     })
   })
+
+  describe('profiles', () => {
+    let stream
+    let fractionalStream
+    let client, adminUser, adminToken, nonAdminUser, nonAdminToken
+    beforeEach(async () => {
+      ;({
+        client,
+        adminUser,
+        adminToken,
+        nonAdminUser,
+        nonAdminToken,
+      } = await setupUsers(server))
+      client.jwtAuth = nonAdminToken['token']
+
+      await server.store.create(store)
+      stream = {
+        kind: 'stream',
+        name: 'test stream',
+        profiles: [
+          {
+            name: '1080p',
+            bitrate: 6000000,
+            fps: 30,
+            width: 1920,
+            height: 1080,
+          },
+          {
+            name: '720p',
+            bitrate: 2000000,
+            fps: 30,
+            width: 1280,
+            height: 720,
+          },
+          {
+            name: '360p',
+            bitrate: 500000,
+            fps: 30,
+            width: 640,
+            height: 360,
+          },
+        ],
+      }
+      fractionalStream = {
+        ...stream,
+        profiles: [
+          {
+            name: '1080p29.97',
+            bitrate: 6000000,
+            fps: 30000,
+            fpsDen: 1001,
+            width: 1920,
+            height: 1080,
+          },
+        ],
+      }
+    })
+
+    it('should handle profiles', async () => {
+      const res = await client.post('/stream', stream)
+      expect(res.status).toBe(201)
+      const data = await res.json()
+      expect(data.profiles).toEqual(stream.profiles)
+      const hookRes = await client.post('/stream/hook', {
+        url: `https://example.com/live/${data.id}/0.ts`,
+      })
+      expect(hookRes.status).toBe(200)
+      const hookData = await hookRes.json()
+      expect(hookData.profiles).toEqual(stream.profiles)
+    })
+
+    it('should handle fractional FPS profiles', async () => {
+      const res = await client.post('/stream', fractionalStream)
+      expect(res.status).toBe(201)
+      const data = await res.json()
+      expect(data.profiles).toEqual(fractionalStream.profiles)
+      const hookRes = await client.post('/stream/hook', {
+        url: `https://example.com/live/${data.id}/0.ts`,
+      })
+      expect(hookRes.status).toBe(200)
+      const hookData = await hookRes.json()
+      const expectedProfile = { ...fractionalStream.profiles[0] }
+      expectedProfile.fps_den = expectedProfile.fpsDen
+      delete expectedProfile.fpsDen
+      expect(hookData.profiles).toEqual([expectedProfile])
+    })
+  })
 })

--- a/packages/api/src/controllers/stream.test.js
+++ b/packages/api/src/controllers/stream.test.js
@@ -492,33 +492,19 @@ describe('controllers/stream', () => {
       }
     })
 
-    it('should handle profiles', async () => {
-      const res = await client.post('/stream', stream)
-      expect(res.status).toBe(201)
-      const data = await res.json()
-      expect(data.profiles).toEqual(stream.profiles)
-      const hookRes = await client.post('/stream/hook', {
-        url: `https://example.com/live/${data.id}/0.ts`,
-      })
-      expect(hookRes.status).toBe(200)
-      const hookData = await hookRes.json()
-      expect(hookData.profiles).toEqual(stream.profiles)
-    })
-
-    it('should handle fractional FPS profiles', async () => {
-      const res = await client.post('/stream', fractionalStream)
-      expect(res.status).toBe(201)
-      const data = await res.json()
-      expect(data.profiles).toEqual(fractionalStream.profiles)
-      const hookRes = await client.post('/stream/hook', {
-        url: `https://example.com/live/${data.id}/0.ts`,
-      })
-      expect(hookRes.status).toBe(200)
-      const hookData = await hookRes.json()
-      const expectedProfile = { ...fractionalStream.profiles[0] }
-      expectedProfile.fps_den = expectedProfile.fpsDen
-      delete expectedProfile.fpsDen
-      expect(hookData.profiles).toEqual([expectedProfile])
+    it('should handle profiles, including fractional fps', async () => {
+      for (const testStream of [stream, fractionalStream]) {
+        const res = await client.post('/stream', testStream)
+        expect(res.status).toBe(201)
+        const data = await res.json()
+        expect(data.profiles).toEqual(testStream.profiles)
+        const hookRes = await client.post('/stream/hook', {
+          url: `https://example.com/live/${data.id}/0.ts`,
+        })
+        expect(hookRes.status).toBe(200)
+        const hookData = await hookRes.json()
+        expect(hookData.profiles).toEqual(testStream.profiles)
+      }
     })
   })
 })

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -111,7 +111,7 @@ components:
                 minimum: 400
               fps:
                 type: integer
-                minimum: 1
+                minimum: 0
               fpsDen:
                 type: integer
                 minimum: 1

--- a/packages/api/src/schema/schema.yaml
+++ b/packages/api/src/schema/schema.yaml
@@ -111,7 +111,10 @@ components:
                 minimum: 400
               fps:
                 type: integer
-                minimum: 0
+                minimum: 1
+              fpsDen:
+                type: integer
+                minimum: 1
         objectStoreId:
           type: string
           example: D8321C3E-B29C-45EB-A1BB-A623D8BE0F65
@@ -342,8 +345,8 @@ components:
           example: E1F53135E559C253
           writeOnly: true
         admin:
-            type: boolean
-            example: true
+          type: boolean
+          example: true
         kind:
           type: string
           readOnly: true


### PR DESCRIPTION
Some awkwardness around the fact that the API uses camelCase and the webhook uses `snake_case`. Not too hard to handle, but perhaps we should standardize for consistency across the Livepeer ecosystem?