### PR TITLE
add totalTokenSupply endpoint

### DIFF
--- a/packages/explorer-2.0/pages/api/totalTokenSupply.tsx
+++ b/packages/explorer-2.0/pages/api/totalTokenSupply.tsx
@@ -1,11 +1,11 @@
 export default async (req, res) => {
-  const countdownRaw = await fetch(
+  const response = await fetch(
     `https://${
       process.env.NETWORK === 'rinkeby' ? 'api-rinkeby' : 'api'
     }.etherscan.io/api?module=stats&action=tokensupply&contractaddress=0x58b6a8a3302369daec383334672404ee733ab239&apikey=${
       process.env.ETHERSCAN_API_KEY
     }`,
   )
-  const { result: totalTokenSupply } = await countdownRaw.json()
+  const { result: totalTokenSupply } = await response.json()
   res.end(totalTokenSupply)
 }

--- a/packages/explorer-2.0/pages/api/totalTokenSupply.tsx
+++ b/packages/explorer-2.0/pages/api/totalTokenSupply.tsx
@@ -1,0 +1,11 @@
+export default async (req, res) => {
+  const countdownRaw = await fetch(
+    `https://${
+      process.env.NETWORK === 'rinkeby' ? 'api-rinkeby' : 'api'
+    }.etherscan.io/api?module=stats&action=tokensupply&contractaddress=0x58b6a8a3302369daec383334672404ee733ab239&apikey=${
+      process.env.ETHERSCAN_API_KEY
+    }`,
+  )
+  const { result: totalTokenSupply } = await countdownRaw.json()
+  res.end(totalTokenSupply)
+}

--- a/packages/explorer-2.0/pages/api/totalTokenSupply.tsx
+++ b/packages/explorer-2.0/pages/api/totalTokenSupply.tsx
@@ -1,3 +1,5 @@
+import Utils from 'web3-utils'
+
 export default async (req, res) => {
   const response = await fetch(
     `https://${
@@ -7,5 +9,5 @@ export default async (req, res) => {
     }`,
   )
   const { result: totalTokenSupply } = await response.json()
-  res.end(totalTokenSupply)
+  res.end(Utils.fromWei(totalTokenSupply))
 }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds an api endpoint for requesting *only* the total token supply value, as requested by CMC. The endpoint can be reached at `/api/totalTokenSupply` and is displayed in LPTU.

@dob does CMC need this returned as LPTU or LPT?