### PR TITLE
Add support for calling staking functions with hints

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged --staged"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged --staged"
     }
   },
   "lint-staged": {

--- a/packages/explorer-2.0/apollo/resolvers/Mutation.tsx
+++ b/packages/explorer-2.0/apollo/resolvers/Mutation.tsx
@@ -1,4 +1,4 @@
-import { MAX_BATCH_CLAIM_ROUNDS, EMPTY_ADDRESS, getHint } from '../../lib/utils'
+import { MAX_BATCH_CLAIM_ROUNDS } from '../../lib/utils'
 
 /**
  * Approve an amount for an ERC20 token transfer

--- a/packages/explorer-2.0/apollo/resolvers/Mutation.tsx
+++ b/packages/explorer-2.0/apollo/resolvers/Mutation.tsx
@@ -59,49 +59,45 @@ export async function approve(_obj, _args, _ctx) {
  * @return {Promise}
  */
 export async function bond(_obj, _args, _ctx) {
-  try {
-    const {
+  const {
+    amount,
+    to,
+    oldDelegateNewPosPrev,
+    oldDelegateNewPosNext,
+    currDelegateNewPosPrev,
+    currDelegateNewPosNext,
+  } = _args
+  const gas = await _ctx.livepeer.rpc.estimateGas(
+    'BondingManager',
+    'bondWithHint',
+    [
       amount,
       to,
       oldDelegateNewPosPrev,
       oldDelegateNewPosNext,
       currDelegateNewPosPrev,
       currDelegateNewPosNext,
-    } = _args
-    const gas = await _ctx.livepeer.rpc.estimateGas(
-      'BondingManager',
-      'bondWithHint',
-      [
-        amount,
-        to,
-        oldDelegateNewPosPrev,
-        oldDelegateNewPosNext,
-        currDelegateNewPosPrev,
-        currDelegateNewPosNext,
-      ],
-    )
-    const txHash = await _ctx.livepeer.rpc.bondWithHint(
-      amount,
-      to,
-      oldDelegateNewPosPrev,
-      oldDelegateNewPosNext,
-      currDelegateNewPosPrev,
-      currDelegateNewPosNext,
-      {
-        gas: gas,
-        returnTxHash: true,
-      },
-    )
+    ],
+  )
+  const txHash = await _ctx.livepeer.rpc.bondWithHint(
+    amount,
+    to,
+    oldDelegateNewPosPrev,
+    oldDelegateNewPosNext,
+    currDelegateNewPosPrev,
+    currDelegateNewPosNext,
+    {
+      gas: gas,
+      returnTxHash: true,
+    },
+  )
 
-    return {
-      gas,
-      txHash,
-      inputData: {
-        ..._args,
-      },
-    }
-  } catch (e) {
-    console.log(e)
+  return {
+    gas,
+    txHash,
+    inputData: {
+      ..._args,
+    },
   }
 }
 
@@ -187,34 +183,30 @@ export async function batchClaimEarnings(_obj, _args, _ctx) {
  * @return {Promise}
  */
 export async function unbond(_obj, _args, _ctx) {
-  try {
-    const { amount, newPosPrev, newPosNext } = _args
-    const gas = await _ctx.livepeer.rpc.estimateGas(
-      'BondingManager',
-      'unbondWithHint',
-      [amount, newPosPrev, newPosNext],
-    )
+  const { amount, newPosPrev, newPosNext } = _args
+  const gas = await _ctx.livepeer.rpc.estimateGas(
+    'BondingManager',
+    'unbondWithHint',
+    [amount, newPosPrev, newPosNext],
+  )
 
-    const txHash = await _ctx.livepeer.rpc.unbondWithHint(
-      amount,
-      newPosPrev,
-      newPosNext,
-      {
-        ..._ctx.livepeer.config.defaultTx,
-        gas,
-        returnTxHash: true,
-      },
-    )
-
-    return {
+  const txHash = await _ctx.livepeer.rpc.unbondWithHint(
+    amount,
+    newPosPrev,
+    newPosNext,
+    {
+      ..._ctx.livepeer.config.defaultTx,
       gas,
-      txHash,
-      inputData: {
-        ..._args,
-      },
-    }
-  } catch (e) {
-    console.log(e)
+      returnTxHash: true,
+    },
+  )
+
+  return {
+    gas,
+    txHash,
+    inputData: {
+      ..._args,
+    },
   }
 }
 

--- a/packages/explorer-2.0/apollo/types/Mutation.tsx
+++ b/packages/explorer-2.0/apollo/types/Mutation.tsx
@@ -9,13 +9,13 @@ type Mutation {
   approve(type: String!, amount: String!): JSON
   
   "Submits a bond transaction for a previously approved amount"
-  bond(to: String!, amount: String!): JSON
+  bond(amount: String!, to: String!, oldDelegateNewPosPrev: String!, oldDelegateNewPosNext: String!, currDelegateNewPosPrev: String!, currDelegateNewPosNext: String!): JSON
   
   "Claims earnings from your last claim round through specified round"
   batchClaimEarnings(lastClaimRound: String!, endRound: String!): JSON
   
   "Submits a bond transaction for a previously approved amount"
-  unbond(amount: String!): JSON
+  unbond(amount: String!, newPosPrev: String!, newPosNext: String!): JSON
   
   "Withdraws unbonded stake into account wallet"
   withdrawStake(unbondingLockId: Int!): JSON
@@ -24,10 +24,10 @@ type Mutation {
   withdrawFees: JSON
   
   "Rebond tokens for an unbonding lock to a delegator's current delegate while a delegator is in the Bonded or Pending states"
-  rebond(unbondingLockId: Int!): JSON
+  rebond(unbondingLockId: Int!, newPosPrev: String!, newPosNext: String!): JSON
   
   "Rebond tokens for an unbonding lock to a delegate while a delegator is in the Unbonded state "
-  rebondFromUnbonded(delegate: String!, unbondingLockId: Int!): JSON
+  rebondFromUnbonded(delegate: String!, unbondingLockId: Int!, newPosPrev: String!, newPosNext: String!): JSON
   
   "Submits a round initialization transaction"
   initializeRound: JSON

--- a/packages/explorer-2.0/components/Restake/index.tsx
+++ b/packages/explorer-2.0/components/Restake/index.tsx
@@ -4,7 +4,7 @@ import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 import { initTransaction } from '../../lib/utils'
 
-export default ({ lock }) => {
+export default ({ unbondingLockId, newPosPrev, newPosNext }) => {
   const client = useApolloClient()
   const { rebond }: any = useContext(MutationsContext)
 
@@ -15,7 +15,9 @@ export default ({ lock }) => {
           initTransaction(client, async () => {
             await rebond({
               variables: {
-                unbondingLockId: lock.unbondingLockId,
+                unbondingLockId,
+                newPosPrev,
+                newPosNext,
               },
             })
           })

--- a/packages/explorer-2.0/components/RestakeFromUnstaked/index.tsx
+++ b/packages/explorer-2.0/components/RestakeFromUnstaked/index.tsx
@@ -5,7 +5,7 @@ import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 import { initTransaction } from '../../lib/utils'
 
-export default ({ lock }) => {
+export default ({ unbondingLockId, delegate, newPosPrev, newPosNext }) => {
   const context = useWeb3React()
   const client = useApolloClient()
 
@@ -22,8 +22,10 @@ export default ({ lock }) => {
           initTransaction(client, async () => {
             await rebondFromUnbonded({
               variables: {
-                unbondingLockId: lock.unbondingLockId,
-                delegate: lock.delegate.id,
+                unbondingLockId,
+                delegate,
+                newPosPrev,
+                newPosNext,
               },
             })
           })

--- a/packages/explorer-2.0/components/StakeTransactions/index.tsx
+++ b/packages/explorer-2.0/components/StakeTransactions/index.tsx
@@ -1,7 +1,7 @@
 import { Flex, Styled } from 'theme-ui'
 import Utils from 'web3-utils'
 import Unlink from '../../public/img/unlink.svg'
-import { abbreviateNumber } from '../../lib/utils'
+import { abbreviateNumber, getHint } from '../../lib/utils'
 import { UnbondingLock } from '../../@types'
 import List from '../List'
 import ListItem from '../ListItem'
@@ -9,7 +9,7 @@ import Restake from '../Restake'
 import RestakeFromUnstaked from '../RestakeFromUnstaked'
 import WithdrawStake from '../WithdrawStake'
 
-export default ({ delegator, currentRound, isMyAccount }) => {
+export default ({ delegator, transcoders, currentRound, isMyAccount }) => {
   const pendingStakeTransactions: Array<UnbondingLock> = delegator.unbondingLocks.filter(
     (item: UnbondingLock) =>
       item.withdrawRound && item.withdrawRound > parseInt(currentRound.id, 10),
@@ -27,94 +27,127 @@ export default ({ delegator, currentRound, isMyAccount }) => {
           sx={{ mb: 6 }}
           header={<Styled.h4>Pending Transactions</Styled.h4>}
         >
-          {pendingStakeTransactions.map((lock) => (
-            <ListItem
-              key={lock.id}
-              avatar={<Unlink sx={{ color: 'primary', mr: 2 }} />}
-            >
-              <Flex
-                sx={{
-                  width: '100%',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                }}
+          {pendingStakeTransactions.map((lock) => {
+            const { newPosPrev, newPosNext } = getHint(
+              isBonded ? delegator.delegate.id : lock.delegate.id,
+              transcoders,
+            )
+            return (
+              <ListItem
+                key={lock.id}
+                avatar={<Unlink sx={{ color: 'primary', mr: 2 }} />}
               >
-                <div>
-                  <div sx={{ mb: '2px' }}>
-                    Unstaking from{' '}
+                <Flex
+                  sx={{
+                    width: '100%',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                  }}
+                >
+                  <div>
+                    <div sx={{ mb: '2px' }}>
+                      Unstaking from{' '}
+                      {lock.delegate.id.replace(
+                        lock.delegate.id.slice(7, 37),
+                        '…',
+                      )}
+                    </div>
+                    <div sx={{ color: 'muted', fontSize: 0 }}>
+                      Tokens will be available for withdrawal in approximately{' '}
+                      {lock.withdrawRound - parseInt(currentRound.id, 10)} days.
+                    </div>
+                  </div>
+                  <Flex sx={{ alignItems: 'center' }}>
+                    {isMyAccount &&
+                      (isBonded ? (
+                        <Restake
+                          unbondingLockId={lock.unbondingLockId}
+                          newPosPrev={newPosPrev}
+                          newPosNext={newPosNext}
+                        />
+                      ) : (
+                        <RestakeFromUnstaked
+                          unbondingLockId={lock.unbondingLockId}
+                          delegate={lock.delegate.id}
+                          newPosPrev={newPosPrev}
+                          newPosNext={newPosNext}
+                        />
+                      ))}
+                    <div sx={{ ml: 3 }}>
+                      {' '}
+                      -
+                      <span sx={{ fontFamily: 'monospace' }}>
+                        {abbreviateNumber(Utils.fromWei(lock.amount), 4)}
+                      </span>{' '}
+                      LPT
+                    </div>
+                  </Flex>
+                </Flex>
+              </ListItem>
+            )
+          })}
+        </List>
+      )}
+      {!!completedStakeTransactions.length && (
+        <List header={<Styled.h4>Available for Withdrawal</Styled.h4>}>
+          {completedStakeTransactions.map((lock) => {
+            const { newPosPrev, newPosNext } = getHint(
+              isBonded ? delegator.delegate.id : lock.delegate.id,
+              transcoders,
+            )
+            return (
+              <ListItem
+                key={lock.id}
+                avatar={<Unlink sx={{ color: 'primary', mr: 2 }} />}
+              >
+                <Flex
+                  sx={{
+                    width: '100%',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                  }}
+                >
+                  <div>
+                    Unstaked from{' '}
                     {lock.delegate.id.replace(
                       lock.delegate.id.slice(7, 37),
                       '…',
                     )}
                   </div>
-                  <div sx={{ color: 'muted', fontSize: 0 }}>
-                    Tokens will be available for withdrawal in approximately{' '}
-                    {lock.withdrawRound - parseInt(currentRound.id, 10)} days.
-                  </div>
-                </div>
-                <Flex sx={{ alignItems: 'center' }}>
-                  {isMyAccount &&
-                    (isBonded ? (
-                      <Restake lock={lock} />
-                    ) : (
-                      <RestakeFromUnstaked lock={lock} />
-                    ))}
-                  <div sx={{ ml: 3 }}>
-                    {' '}
-                    -
-                    <span sx={{ fontFamily: 'monospace' }}>
-                      {abbreviateNumber(Utils.fromWei(lock.amount), 4)}
-                    </span>{' '}
-                    LPT
-                  </div>
-                </Flex>
-              </Flex>
-            </ListItem>
-          ))}
-        </List>
-      )}
-      {!!completedStakeTransactions.length && (
-        <List header={<Styled.h4>Available for Withdrawal</Styled.h4>}>
-          {completedStakeTransactions.map((lock) => (
-            <ListItem
-              key={lock.id}
-              avatar={<Unlink sx={{ color: 'primary', mr: 2 }} />}
-            >
-              <Flex
-                sx={{
-                  width: '100%',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                }}
-              >
-                <div>
-                  Unstaked from{' '}
-                  {lock.delegate.id.replace(lock.delegate.id.slice(7, 37), '…')}
-                </div>
 
-                <Flex sx={{ alignItems: 'center' }}>
-                  {isMyAccount && (
-                    <>
-                      {isBonded ? (
-                        <Restake lock={lock} />
-                      ) : (
-                        <RestakeFromUnstaked lock={lock} />
-                      )}
-                      <WithdrawStake lock={lock} />
-                    </>
-                  )}
-                  <div sx={{ ml: 3 }}>
-                    {' '}
-                    -
-                    <span sx={{ fontFamily: 'monospace' }}>
-                      {abbreviateNumber(Utils.fromWei(lock.amount), 3)}
-                    </span>{' '}
-                    LPT
-                  </div>
+                  <Flex sx={{ alignItems: 'center' }}>
+                    {isMyAccount && (
+                      <>
+                        {isBonded ? (
+                          <Restake
+                            unbondingLockId={lock.unbondingLockId}
+                            newPosPrev={newPosPrev}
+                            newPosNext={newPosNext}
+                          />
+                        ) : (
+                          <RestakeFromUnstaked
+                            unbondingLockId={lock.unbondingLockId}
+                            delegate={lock.delegate.id}
+                            newPosPrev={newPosPrev}
+                            newPosNext={newPosNext}
+                          />
+                        )}
+                        <WithdrawStake unbondingLockId={lock.unbondingLockId} />
+                      </>
+                    )}
+                    <div sx={{ ml: 3 }}>
+                      {' '}
+                      -
+                      <span sx={{ fontFamily: 'monospace' }}>
+                        {abbreviateNumber(Utils.fromWei(lock.amount), 3)}
+                      </span>{' '}
+                      LPT
+                    </div>
+                  </Flex>
                 </Flex>
-              </Flex>
-            </ListItem>
-          ))}
+              </ListItem>
+            )
+          })}
         </List>
       )}
     </>

--- a/packages/explorer-2.0/components/StakeTransactions/index.tsx
+++ b/packages/explorer-2.0/components/StakeTransactions/index.tsx
@@ -1,7 +1,11 @@
 import { Flex, Styled } from 'theme-ui'
 import Utils from 'web3-utils'
 import Unlink from '../../public/img/unlink.svg'
-import { abbreviateNumber, getHint } from '../../lib/utils'
+import {
+  abbreviateNumber,
+  getHint,
+  simulateNewActiveSetOrder,
+} from '../../lib/utils'
 import { UnbondingLock } from '../../@types'
 import List from '../List'
 import ListItem from '../ListItem'
@@ -28,9 +32,15 @@ export default ({ delegator, transcoders, currentRound, isMyAccount }) => {
           header={<Styled.h4>Pending Transactions</Styled.h4>}
         >
           {pendingStakeTransactions.map((lock) => {
+            const newActiveSetOrder = simulateNewActiveSetOrder({
+              action: 'stake',
+              transcoders: JSON.parse(JSON.stringify(transcoders)),
+              amount: Utils.toWei(lock.amount),
+              newDelegate: isBonded ? delegator.delegate.id : lock.delegate.id,
+            })
             const { newPosPrev, newPosNext } = getHint(
               isBonded ? delegator.delegate.id : lock.delegate.id,
-              transcoders,
+              newActiveSetOrder,
             )
             return (
               <ListItem
@@ -91,9 +101,15 @@ export default ({ delegator, transcoders, currentRound, isMyAccount }) => {
       {!!completedStakeTransactions.length && (
         <List header={<Styled.h4>Available for Withdrawal</Styled.h4>}>
           {completedStakeTransactions.map((lock) => {
+            const newActiveSetOrder = simulateNewActiveSetOrder({
+              action: 'stake',
+              transcoders: JSON.parse(JSON.stringify(transcoders)),
+              amount: Utils.toWei(lock.amount),
+              newDelegate: isBonded ? delegator.delegate.id : lock.delegate.id,
+            })
             const { newPosPrev, newPosNext } = getHint(
               isBonded ? delegator.delegate.id : lock.delegate.id,
-              transcoders,
+              newActiveSetOrder,
             )
             return (
               <ListItem

--- a/packages/explorer-2.0/components/StakingView/index.tsx
+++ b/packages/explorer-2.0/components/StakingView/index.tsx
@@ -10,7 +10,7 @@ import ReactTooltip from 'react-tooltip'
 import Help from '../../public/img/help.svg'
 import Button from '../Button'
 
-export default ({ delegator, protocol, currentRound }) => {
+export default ({ delegator, transcoders, protocol, currentRound }) => {
   const router = useRouter()
   const query = router.query
   const context = useWeb3React()
@@ -374,6 +374,7 @@ export default ({ delegator, protocol, currentRound }) => {
         )}
       </Box>
       <StakeTransactions
+        transcoders={transcoders}
         delegator={delegator}
         currentRound={currentRound}
         isMyAccount={isMyAccount}

--- a/packages/explorer-2.0/components/StakingWidget/Footer.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/Footer.tsx
@@ -3,7 +3,12 @@ import Stake from './Stake'
 import Unstake from './Unstake'
 import { Account, Delegator, Transcoder, Round } from '../../@types'
 import Utils from 'web3-utils'
-import { getDelegatorStatus, MAX_EARNINGS_CLAIMS_ROUNDS } from '../../lib/utils'
+import {
+  getDelegatorStatus,
+  MAX_EARNINGS_CLAIMS_ROUNDS,
+  EMPTY_ADDRESS,
+  getHint,
+} from '../../lib/utils'
 import { useWeb3React } from '@web3-react/core'
 import Warning from './Warning'
 import Approve from '../Approve'
@@ -12,6 +17,7 @@ import Help from '../../public/img/help.svg'
 import { useApolloClient } from '@apollo/react-hooks'
 
 interface Props {
+  transcoders: [Transcoder]
   action: string
   amount: string
   transcoder: Transcoder
@@ -21,6 +27,7 @@ interface Props {
 }
 
 export default ({
+  transcoders,
   delegator,
   transcoder,
   action,
@@ -90,10 +97,28 @@ export default ({
     roundsSinceLastClaim <= MAX_EARNINGS_CLAIMS_ROUNDS &&
     parseFloat(amount) > 0
 
+  const { newPosPrev, newPosNext } = getHint(
+    delegator?.delegate?.id,
+    transcoders,
+  )
+
+  const {
+    newPosPrev: currDelegateNewPosPrev,
+    newPosNext: currDelegateNewPosNext,
+  } = getHint(transcoder.id, transcoders)
+
   if (action == 'stake') {
     return (
       <>
-        <Stake disabled={!canStake} transcoder={transcoder} amount={amount} />
+        <Stake
+          disabled={!canStake}
+          to={transcoder.id}
+          amount={amount}
+          oldDelegateNewPosPrev={newPosPrev}
+          oldDelegateNewPosNext={newPosNext}
+          currDelegateNewPosPrev={currDelegateNewPosPrev}
+          currDelegateNewPosNext={currDelegateNewPosNext}
+        />
         {renderStakeWarnings(
           roundsSinceLastClaim,
           amount,
@@ -109,7 +134,12 @@ export default ({
   }
   return (
     <>
-      <Unstake disabled={!canUnstake} amount={amount} />
+      <Unstake
+        amount={amount}
+        newPosPrev={newPosPrev}
+        newPosNext={newPosNext}
+        disabled={!canUnstake}
+      />
       {renderUnstakeWarnings(
         roundsSinceLastClaim,
         amount,

--- a/packages/explorer-2.0/components/StakingWidget/Footer.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/Footer.tsx
@@ -6,8 +6,8 @@ import Utils from 'web3-utils'
 import {
   getDelegatorStatus,
   MAX_EARNINGS_CLAIMS_ROUNDS,
-  EMPTY_ADDRESS,
   getHint,
+  simulateNewActiveSetOrder,
 } from '../../lib/utils'
 import { useWeb3React } from '@web3-react/core'
 import Warning from './Warning'
@@ -97,15 +97,23 @@ export default ({
     roundsSinceLastClaim <= MAX_EARNINGS_CLAIMS_ROUNDS &&
     parseFloat(amount) > 0
 
+  const newActiveSetOrder = simulateNewActiveSetOrder({
+    action,
+    transcoders: JSON.parse(JSON.stringify(transcoders)),
+    amount: Utils.toWei(amount ? amount.toString() : '0'),
+    newDelegate: transcoder.id,
+    oldDelegate: delegator?.delegate?.id,
+  })
+
   const { newPosPrev, newPosNext } = getHint(
     delegator?.delegate?.id,
-    transcoders,
+    newActiveSetOrder,
   )
 
   const {
     newPosPrev: currDelegateNewPosPrev,
     newPosNext: currDelegateNewPosNext,
-  } = getHint(transcoder.id, transcoders)
+  } = getHint(transcoder.id, newActiveSetOrder)
 
   if (action == 'stake') {
     return (

--- a/packages/explorer-2.0/components/StakingWidget/Stake.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/Stake.tsx
@@ -6,7 +6,15 @@ import { useWeb3React } from '@web3-react/core'
 import { MutationsContext } from '../../contexts'
 import { initTransaction } from '../../lib/utils'
 
-export default ({ transcoder, amount, disabled }) => {
+export default ({
+  to,
+  amount,
+  oldDelegateNewPosPrev,
+  oldDelegateNewPosNext,
+  currDelegateNewPosPrev,
+  currDelegateNewPosNext,
+  disabled,
+}) => {
   const client = useApolloClient()
   const context = useWeb3React()
   const { bond }: any = useContext(MutationsContext)
@@ -23,8 +31,12 @@ export default ({ transcoder, amount, disabled }) => {
           initTransaction(client, async () => {
             await bond({
               variables: {
-                to: transcoder.id,
                 amount: Utils.toWei(amount ? amount.toString() : '0'),
+                to,
+                oldDelegateNewPosPrev,
+                oldDelegateNewPosNext,
+                currDelegateNewPosPrev,
+                currDelegateNewPosNext,
               },
             })
             // If user staked inside tour, close tour after staking

--- a/packages/explorer-2.0/components/StakingWidget/Unstake.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/Unstake.tsx
@@ -6,7 +6,7 @@ import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 import { initTransaction } from '../../lib/utils'
 
-export default ({ amount, disabled }) => {
+export default ({ amount, newPosPrev, newPosNext, disabled }) => {
   const context = useWeb3React()
   const client = useApolloClient()
 
@@ -26,6 +26,8 @@ export default ({ amount, disabled }) => {
             await unbond({
               variables: {
                 amount: Utils.toWei(amount ? amount.toString() : '0'),
+                newPosPrev,
+                newPosNext,
               },
             })
           })

--- a/packages/explorer-2.0/components/StakingWidget/index.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/index.tsx
@@ -10,6 +10,7 @@ import InputBox from './InputBox'
 import { Flex } from 'theme-ui'
 
 interface Props {
+  transcoders: [Transcoder]
   transcoder: Transcoder
   delegator?: Delegator
   protocol: Protocol
@@ -19,6 +20,7 @@ interface Props {
 }
 
 export default ({
+  transcoders,
   delegator,
   account,
   transcoder,
@@ -74,6 +76,7 @@ export default ({
           </Flex>
           <ProjectionBox action={action} />
           <Footer
+            transcoders={transcoders}
             currentRound={currentRound}
             account={account}
             delegator={delegator}

--- a/packages/explorer-2.0/components/WithdrawStake/index.tsx
+++ b/packages/explorer-2.0/components/WithdrawStake/index.tsx
@@ -5,7 +5,7 @@ import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 import { initTransaction } from '../../lib/utils'
 
-export default ({ lock }) => {
+export default ({ unbondingLockId }) => {
   const context = useWeb3React()
   const client = useApolloClient()
 
@@ -22,7 +22,7 @@ export default ({ lock }) => {
           initTransaction(client, async () => {
             await withdrawStake({
               variables: {
-                unbondingLockId: lock.unbondingLockId,
+                unbondingLockId,
               },
             })
           })

--- a/packages/explorer-2.0/lib/connectors.tsx
+++ b/packages/explorer-2.0/lib/connectors.tsx
@@ -4,16 +4,14 @@ import { NetworkConnector } from '@web3-react/network-connector'
 import { FortmaticConnector } from '@web3-react/fortmatic-connector'
 import { WalletLinkConnector } from '@web3-react/walletlink-connector'
 
-const POLLING_INTERVAL = 12000
 const RPC_URLS: { [chainId: number]: string } = {
-  1: process.env.RPC_URL_1 as string,
-  4: process.env.RPC_URL_4 as string,
+  1: `https://eth-mainnet.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY}` as string,
+  4: `https://eth-rinkeby.alchemyapi.io/v2/${process.env.ALCHEMY_API_KEY}` as string,
 }
 
 export const Network = new NetworkConnector({
   defaultChainId: process.env.NETWORK === 'rinkeby' ? 4 : 1,
   urls: RPC_URLS,
-  pollingInterval: POLLING_INTERVAL * 3,
 })
 
 export const Injected = new InjectedConnector({

--- a/packages/explorer-2.0/lib/utils.tsx
+++ b/packages/explorer-2.0/lib/utils.tsx
@@ -1,6 +1,8 @@
 import { Delegator, Round, UnbondingLock } from '../@types'
 import Utils from 'web3-utils'
 
+export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
+
 export const abbreviateNumber = (value, precision = 3) => {
   let newValue = value
   const suffixes = ['', 'K', 'M', 'B', 'T']
@@ -318,4 +320,28 @@ export const mergeObjectsInUnique = (array, property) => {
   })
 
   return Array.from(newArray.values())
+}
+
+export const getHint = (id, transcoders) => {
+  let hint = {
+    newPosPrev: EMPTY_ADDRESS,
+    newPosNext: EMPTY_ADDRESS,
+  }
+
+  const index = transcoders.indexOf(id.toLowerCase())
+
+  // if transcoder is not in active set return
+  if (index < 0) {
+    return hint
+  } else if (index === 0) {
+    // if transcoder is the first in the active set, only set posNex
+    hint.newPosNext = transcoders[index + 1]
+  } else if (index === transcoders.length) {
+    // if transcoder is the last in the active set, only set posPrev
+    hint.newPosPrev = transcoders[index - 1]
+  } else {
+    hint.newPosNext = transcoders[index + 1]
+    hint.newPosPrev = transcoders[index - 1]
+  }
+  return hint
 }

--- a/packages/explorer-2.0/lib/utils.tsx
+++ b/packages/explorer-2.0/lib/utils.tsx
@@ -388,6 +388,6 @@ export const simulateNewActiveSetOrder = ({
 
   // reorder transcoders array
   return transcoders.sort((a, b) =>
-    +Utils.fromWei(a.totalStake) > +Utils.fromWei(b.totalStake) ? 1 : -1,
+    +Utils.fromWei(a.totalStake) < +Utils.fromWei(b.totalStake) ? 1 : -1,
   )
 }

--- a/packages/explorer-2.0/lib/utils.tsx
+++ b/packages/explorer-2.0/lib/utils.tsx
@@ -362,7 +362,6 @@ export const simulateNewActiveSetOrder = ({
   }
 
   if (action === 'stake') {
-    console.log(transcoders[index])
     transcoders[index].totalStake = Utils.toBN(transcoders[index].totalStake)
       .add(Utils.toBN(amount))
       .toString()

--- a/packages/explorer-2.0/lib/utils.tsx
+++ b/packages/explorer-2.0/lib/utils.tsx
@@ -388,6 +388,6 @@ export const simulateNewActiveSetOrder = ({
 
   // reorder transcoders array
   return transcoders.sort((a, b) =>
-    +Utils.fromWei(a.totalStake) < +Utils.fromWei(b.totalStake) ? 1 : -1,
+    Utils.toBN(b.totalStake).cmp(Utils.toBN(a.totalStake)),
   )
 }

--- a/packages/explorer-2.0/lib/utils.tsx
+++ b/packages/explorer-2.0/lib/utils.tsx
@@ -362,6 +362,7 @@ export const simulateNewActiveSetOrder = ({
   }
 
   if (action === 'stake') {
+    console.log(transcoders[index])
     transcoders[index].totalStake = Utils.toBN(transcoders[index].totalStake)
       .add(Utils.toBN(amount))
       .toString()

--- a/packages/explorer-2.0/lib/utils.tsx
+++ b/packages/explorer-2.0/lib/utils.tsx
@@ -327,9 +327,9 @@ export const getHint = (id, transcoders) => {
     newPosPrev: EMPTY_ADDRESS,
     newPosNext: EMPTY_ADDRESS,
   }
-
-  const index = transcoders.indexOf(id.toLowerCase())
-
+  const index = transcoders.findIndex(
+    (t) => t.id.toLowerCase() === id.toLowerCase(),
+  )
   // if transcoder is not in active set return
   if (index < 0) {
     return hint
@@ -344,4 +344,50 @@ export const getHint = (id, transcoders) => {
     hint.newPosPrev = transcoders[index - 1]
   }
   return hint
+}
+
+export const simulateNewActiveSetOrder = ({
+  action,
+  transcoders,
+  amount,
+  newDelegate,
+  oldDelegate = EMPTY_ADDRESS,
+}) => {
+  const index = transcoders.findIndex(
+    (t) => t.id.toLowerCase() === newDelegate.toLowerCase(),
+  )
+
+  if (index < 0) {
+    return transcoders
+  }
+
+  if (action === 'stake') {
+    transcoders[index].totalStake = Utils.toBN(transcoders[index].totalStake)
+      .add(Utils.toBN(amount))
+      .toString()
+
+    // if delegator is moving stake, subtract amount from old delegate
+    if (
+      oldDelegate.toLowerCase() != newDelegate.toLowerCase() &&
+      oldDelegate.toLowerCase() != EMPTY_ADDRESS
+    ) {
+      const oldDelegateIndex = transcoders.findIndex(
+        (t) => t.id.toLowerCase() === oldDelegate.toLowerCase(),
+      )
+      transcoders[oldDelegateIndex].totalStake = Utils.toBN(
+        transcoders[oldDelegateIndex].totalStake,
+      )
+        .sub(Utils.toBN(amount))
+        .toString()
+    }
+  } else {
+    transcoders[index].totalStake = Utils.toBN(transcoders[index].totalStake)
+      .sub(Utils.toBN(amount))
+      .toString()
+  }
+
+  // reorder transcoders array
+  return transcoders.sort((a, b) =>
+    +Utils.fromWei(a.totalStake) > +Utils.fromWei(b.totalStake) ? 1 : -1,
+  )
 }

--- a/packages/explorer-2.0/mutations/bond.gql
+++ b/packages/explorer-2.0/mutations/bond.gql
@@ -1,3 +1,17 @@
-mutation bond($to: String!, $amount: String!) {
-  tx: bond(to: $to, amount: $amount)
+mutation bond(
+  $amount: String!
+  $to: String!
+  $oldDelegateNewPosPrev: String!
+  $oldDelegateNewPosNext: String!
+  $currDelegateNewPosPrev: String!
+  $currDelegateNewPosNext: String!
+) {
+  tx: bond(
+    amount: $amount
+    to: $to
+    oldDelegateNewPosPrev: $oldDelegateNewPosPrev
+    oldDelegateNewPosNext: $oldDelegateNewPosNext
+    currDelegateNewPosPrev: $currDelegateNewPosPrev
+    currDelegateNewPosNext: $currDelegateNewPosNext
+  )
 }

--- a/packages/explorer-2.0/mutations/rebond.gql
+++ b/packages/explorer-2.0/mutations/rebond.gql
@@ -1,3 +1,11 @@
-mutation rebond($unbondingLockId: Int!) {
-  tx: rebond(unbondingLockId: $unbondingLockId)
+mutation rebond(
+  $unbondingLockId: Int!
+  $newPosPrev: String!
+  $newPosNext: String!
+) {
+  tx: rebond(
+    unbondingLockId: $unbondingLockId
+    newPosPrev: $newPosPrev
+    newPosNext: $newPosNext
+  )
 }

--- a/packages/explorer-2.0/mutations/rebondFromUnbonded.gql
+++ b/packages/explorer-2.0/mutations/rebondFromUnbonded.gql
@@ -1,3 +1,13 @@
-mutation rebondFromUnbonded($unbondingLockId: Int!, $delegate: String!) {
-  tx: rebondFromUnbonded(unbondingLockId: $unbondingLockId, delegate: $delegate)
+mutation rebondFromUnbonded(
+  $unbondingLockId: Int!
+  $delegate: String!
+  $newPosPrev: String!
+  $newPosNext: String!
+) {
+  tx: rebondFromUnbonded(
+    unbondingLockId: $unbondingLockId
+    delegate: $delegate
+    newPosPrev: $newPosPrev
+    newPosNext: $newPosNext
+  )
 }

--- a/packages/explorer-2.0/mutations/unbond.gql
+++ b/packages/explorer-2.0/mutations/unbond.gql
@@ -1,3 +1,3 @@
-mutation unbond($amount: String!) {
-  tx: unbond(amount: $amount)
+mutation unbond($amount: String!, $newPosPrev: String!, $newPosNext: String!) {
+  tx: unbond(amount: $amount, newPosPrev: $newPosPrev, newPosNext: $newPosNext)
 }

--- a/packages/explorer-2.0/package.json
+++ b/packages/explorer-2.0/package.json
@@ -34,7 +34,7 @@
     "@apollo/react-ssr": "^3.1.3",
     "@babel/core": "^7.5.5",
     "@emotion/core": "^10.0.17",
-    "@livepeer/sdk": "1.0.0-alpha.17",
+    "@livepeer/sdk": "1.0.0-alpha.19",
     "@material-ui/core": "^4.8.0",
     "@mdx-js/loader": "^1.5.5",
     "@mdx-js/react": "^1.4.5",

--- a/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
+++ b/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
@@ -38,6 +38,20 @@ const Account = () => {
     ssr: false,
   })
 
+  const { data: dataTranscoders, loading: loadingTranscoders } = useQuery(
+    gql`
+      {
+        transcoders(
+          orderDirection: desc
+          orderBy: totalStake
+          where: { active: true }
+        ) {
+          id
+        }
+      }
+    `,
+  )
+
   const { data: dataMyAccount, loading: loadingMyAccount } = useQuery(
     accountQuery,
     {
@@ -57,7 +71,7 @@ const Account = () => {
   `
   const { data: selectedStakingAction } = useQuery(SELECTED_STAKING_ACTION)
 
-  if (loading || loadingMyAccount) {
+  if (loading || loadingMyAccount || loadingTranscoders) {
     return (
       <Flex
         sx={{
@@ -81,7 +95,7 @@ const Account = () => {
     context?.account,
     query.account.toString(),
   )
-  const isStaked = !!data.delegator?.delegate
+  const isStaked = !!data?.delegator?.delegate
   const hasLivepeerToken =
     data.account && parseFloat(Utils.fromWei(data.account.tokenBalance)) > 0
   let role: string
@@ -103,13 +117,6 @@ const Account = () => {
     asPath,
     isMyDelegate,
   )
-
-  const headerTitle =
-    process.env.THREEBOX_ENABLED && data?.threeBoxSpace?.name
-      ? data.threeBoxSpace.name
-      : query.account
-          .toString()
-          .replace(query.account.toString().slice(5, 39), '…')
 
   return (
     <>
@@ -172,6 +179,7 @@ const Account = () => {
         {slug == 'tokenholders' && <TokenholdersView />}
         {slug == 'staking' && (
           <StakingView
+            transcoders={dataTranscoders.transcoders}
             delegator={data.delegator}
             protocol={data.protocol}
             currentRound={data.currentRound[0]}
@@ -192,6 +200,7 @@ const Account = () => {
           >
             <StakingWidget
               currentRound={data.currentRound[0]}
+              transcoders={dataTranscoders.transcoders}
               delegator={dataMyAccount?.delegator}
               account={dataMyAccount?.account}
               transcoder={data.transcoder}
@@ -201,6 +210,7 @@ const Account = () => {
         ) : (
           <BottomDrawer>
             <StakingWidget
+              transcoders={dataTranscoders.transcoders}
               selectedAction={selectedStakingAction?.selectedStakingAction}
               currentRound={data.currentRound[0]}
               delegator={dataMyAccount?.delegator}

--- a/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
+++ b/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
@@ -47,6 +47,7 @@ const Account = () => {
           where: { active: true }
         ) {
           id
+          totalStake
         }
       }
     `,

--- a/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
+++ b/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
@@ -50,6 +50,10 @@ const Account = () => {
         }
       }
     `,
+    {
+      pollInterval: 20000,
+      ssr: false,
+    },
   )
 
   const { data: dataMyAccount, loading: loadingMyAccount } = useQuery(

--- a/packages/explorer-2.0/pages/index.tsx
+++ b/packages/explorer-2.0/pages/index.tsx
@@ -114,6 +114,7 @@ const Home = () => {
             }}
           >
             <StakingWidget
+              transcoders={data.transcoders}
               delegator={dataMyAccount?.delegator}
               currentRound={data.protocol.currentRound}
               account={dataMyAccount?.account}

--- a/packages/explorer-2.0/pages/index.tsx
+++ b/packages/explorer-2.0/pages/index.tsx
@@ -27,6 +27,7 @@ const Home = () => {
   const { data, loading } = useQuery(orchestratorsViewQuery, {
     variables,
     ssr: false,
+    pollInterval: 20000,
   })
   const { data: dataMyAccount, loading: loadingMyAccount } = useQuery(
     accountQuery,

--- a/packages/explorer-2.0/pages/index.tsx
+++ b/packages/explorer-2.0/pages/index.tsx
@@ -114,7 +114,7 @@ const Home = () => {
             }}
           >
             <StakingWidget
-              transcoders={data.transcoders}
+              transcoders={data.transcoders.filter((t) => t.active)}
               delegator={dataMyAccount?.delegator}
               currentRound={data.protocol.currentRound}
               account={dataMyAccount?.account}

--- a/packages/explorer-2.0/queries/orchestratorsView.gql
+++ b/packages/explorer-2.0/queries/orchestratorsView.gql
@@ -20,6 +20,7 @@ query(
     rewardCut
     totalStake
     price
+    active
     threeBoxSpace {
       __typename
       did

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -88,124 +88,148 @@ The following section details the rpc API's function signatures and typedefs.
         -   [Examples](#examples-5)
     -   [getUnbondingPeriod](#getunbondingperiod)
         -   [Examples](#examples-6)
-    -   [getUnbondingPeriod](#getunbondingperiod-1)
-        -   [Examples](#examples-7)
     -   [getNumActiveTranscoders](#getnumactivetranscoders)
-        -   [Examples](#examples-8)
-    -   [getNumActiveTranscoders](#getnumactivetranscoders-1)
-        -   [Examples](#examples-9)
+        -   [Examples](#examples-7)
     -   [getMaxEarningsClaimsRounds](#getmaxearningsclaimsrounds)
-        -   [Examples](#examples-10)
-    -   [getMaxEarningsClaimsRounds](#getmaxearningsclaimsrounds-1)
-        -   [Examples](#examples-11)
+        -   [Examples](#examples-8)
     -   [getTotalBonded](#gettotalbonded)
-        -   [Examples](#examples-12)
+        -   [Examples](#examples-9)
     -   [getTokenTotalSupply](#gettokentotalsupply)
-        -   [Examples](#examples-13)
+        -   [Examples](#examples-10)
     -   [getTokenBalance](#gettokenbalance)
         -   [Parameters](#parameters-5)
-        -   [Examples](#examples-14)
+        -   [Examples](#examples-11)
     -   [getTokenInfo](#gettokeninfo)
         -   [Parameters](#parameters-6)
-        -   [Examples](#examples-15)
+        -   [Examples](#examples-12)
     -   [transferToken](#transfertoken)
         -   [Parameters](#parameters-7)
-        -   [Examples](#examples-16)
+        -   [Examples](#examples-13)
     -   [getFaucetAmount](#getfaucetamount)
-        -   [Examples](#examples-17)
+        -   [Examples](#examples-14)
     -   [getFaucetWait](#getfaucetwait)
-        -   [Examples](#examples-18)
+        -   [Examples](#examples-15)
     -   [getFaucetNext](#getfaucetnext)
         -   [Parameters](#parameters-8)
-        -   [Examples](#examples-19)
+        -   [Examples](#examples-16)
     -   [getFaucetInfo](#getfaucetinfo)
         -   [Parameters](#parameters-9)
-        -   [Examples](#examples-20)
+        -   [Examples](#examples-17)
     -   [getInflation](#getinflation)
-        -   [Examples](#examples-21)
+        -   [Examples](#examples-18)
     -   [getInflationChange](#getinflationchange)
-        -   [Examples](#examples-22)
+        -   [Examples](#examples-19)
     -   [getDelegatorStatus](#getdelegatorstatus)
         -   [Parameters](#parameters-10)
-        -   [Examples](#examples-23)
+        -   [Examples](#examples-20)
     -   [getDelegator](#getdelegator)
         -   [Parameters](#parameters-11)
-        -   [Examples](#examples-24)
+        -   [Examples](#examples-21)
     -   [rebond](#rebond)
         -   [Parameters](#parameters-12)
-        -   [Examples](#examples-25)
-    -   [rebondFromUnbonded](#rebondfromunbonded)
+        -   [Examples](#examples-22)
+    -   [rebondWithHint](#rebondwithhint)
         -   [Parameters](#parameters-13)
-        -   [Examples](#examples-26)
-    -   [getTranscoderIsActive](#gettranscoderisactive)
+        -   [Examples](#examples-23)
+    -   [rebondFromUnbonded](#rebondfromunbonded)
         -   [Parameters](#parameters-14)
-        -   [Examples](#examples-27)
-    -   [getTranscoderStatus](#gettranscoderstatus)
+        -   [Examples](#examples-24)
+    -   [rebondFromUnbondedWithHint](#rebondfromunbondedwithhint)
         -   [Parameters](#parameters-15)
-        -   [Examples](#examples-28)
-    -   [getTranscoderTotalStake](#gettranscodertotalstake)
+        -   [Examples](#examples-25)
+    -   [getPendingStake](#getpendingstake)
         -   [Parameters](#parameters-16)
-        -   [Examples](#examples-29)
-    -   [getTranscoderPoolMaxSize](#gettranscoderpoolmaxsize)
-        -   [Examples](#examples-30)
-    -   [getTranscoder](#gettranscoder)
+        -   [Examples](#examples-26)
+    -   [getPendingFees](#getpendingfees)
         -   [Parameters](#parameters-17)
-        -   [Examples](#examples-31)
-    -   [getTranscoders](#gettranscoders)
-        -   [Examples](#examples-32)
-    -   [getProtocolPaused](#getprotocolpaused)
-        -   [Examples](#examples-33)
-    -   [getProtocol](#getprotocol)
-        -   [Examples](#examples-34)
-    -   [getRoundLength](#getroundlength)
-        -   [Examples](#examples-35)
-    -   [getRoundsPerYear](#getroundsperyear)
-        -   [Examples](#examples-36)
-    -   [getCurrentRound](#getcurrentround)
-        -   [Examples](#examples-37)
-    -   [getCurrentRoundIsInitialized](#getcurrentroundisinitialized)
-        -   [Examples](#examples-38)
-    -   [getCurrentRoundStartBlock](#getcurrentroundstartblock)
-        -   [Examples](#examples-39)
-    -   [getLastInitializedRound](#getlastinitializedround)
-        -   [Examples](#examples-40)
-    -   [getCurrentRoundInfo](#getcurrentroundinfo)
-        -   [Examples](#examples-41)
-    -   [tapFaucet](#tapfaucet)
+        -   [Examples](#examples-27)
+    -   [getTranscoderIsActive](#gettranscoderisactive)
         -   [Parameters](#parameters-18)
-        -   [Examples](#examples-42)
-    -   [initializeRound](#initializeround)
+        -   [Examples](#examples-28)
+    -   [getTranscoderStatus](#gettranscoderstatus)
         -   [Parameters](#parameters-19)
-        -   [Examples](#examples-43)
-    -   [claimEarnings](#claimearnings)
+        -   [Examples](#examples-29)
+    -   [getTranscoderTotalStake](#gettranscodertotalstake)
         -   [Parameters](#parameters-20)
-        -   [Examples](#examples-44)
-    -   [estimateGas](#estimategas)
+        -   [Examples](#examples-30)
+    -   [getTranscoderPoolMaxSize](#gettranscoderpoolmaxsize)
+        -   [Examples](#examples-31)
+    -   [getTranscoder](#gettranscoder)
         -   [Parameters](#parameters-21)
-        -   [Examples](#examples-45)
-    -   [unbond](#unbond)
+        -   [Examples](#examples-32)
+    -   [getTranscoders](#gettranscoders)
+        -   [Examples](#examples-33)
+    -   [getProtocolPaused](#getprotocolpaused)
+        -   [Examples](#examples-34)
+    -   [getProtocol](#getprotocol)
+        -   [Examples](#examples-35)
+    -   [getRoundLength](#getroundlength)
+        -   [Examples](#examples-36)
+    -   [getRoundsPerYear](#getroundsperyear)
+        -   [Examples](#examples-37)
+    -   [getCurrentRound](#getcurrentround)
+        -   [Examples](#examples-38)
+    -   [getCurrentRoundIsInitialized](#getcurrentroundisinitialized)
+        -   [Examples](#examples-39)
+    -   [getCurrentRoundStartBlock](#getcurrentroundstartblock)
+        -   [Examples](#examples-40)
+    -   [getLastInitializedRound](#getlastinitializedround)
+        -   [Examples](#examples-41)
+    -   [getCurrentRoundInfo](#getcurrentroundinfo)
+        -   [Examples](#examples-42)
+    -   [tapFaucet](#tapfaucet)
         -   [Parameters](#parameters-22)
-        -   [Examples](#examples-46)
-    -   [setupTranscoder](#setuptranscoder)
+        -   [Examples](#examples-43)
+    -   [initializeRound](#initializeround)
         -   [Parameters](#parameters-23)
-        -   [Examples](#examples-47)
-    -   [getTargetBondingRate](#gettargetbondingrate)
-        -   [Examples](#examples-48)
-    -   [withdrawStake](#withdrawstake)
+        -   [Examples](#examples-44)
+    -   [createPoll](#createpoll)
         -   [Parameters](#parameters-24)
-        -   [Examples](#examples-49)
-    -   [withdrawStakeWithUnbondLock](#withdrawstakewithunbondlock)
+        -   [Examples](#examples-45)
+    -   [getPollCreatorAllowance](#getpollcreatorallowance)
         -   [Parameters](#parameters-25)
-        -   [Examples](#examples-50)
-    -   [withdrawFees](#withdrawfees)
+        -   [Examples](#examples-46)
+    -   [getBondingManagerAllowance](#getbondingmanagerallowance)
         -   [Parameters](#parameters-26)
+        -   [Examples](#examples-47)
+    -   [vote](#vote)
+        -   [Parameters](#parameters-27)
+        -   [Examples](#examples-48)
+    -   [claimEarnings](#claimearnings)
+        -   [Parameters](#parameters-28)
+        -   [Examples](#examples-49)
+    -   [bondWithHint](#bondwithhint)
+        -   [Parameters](#parameters-29)
+        -   [Examples](#examples-50)
+    -   [estimateGas](#estimategas)
+        -   [Parameters](#parameters-30)
         -   [Examples](#examples-51)
+    -   [unbond](#unbond)
+        -   [Parameters](#parameters-31)
+        -   [Examples](#examples-52)
+    -   [unbondWithHint](#unbondwithhint)
+        -   [Parameters](#parameters-32)
+        -   [Examples](#examples-53)
+    -   [setupTranscoder](#setuptranscoder)
+        -   [Parameters](#parameters-33)
+        -   [Examples](#examples-54)
+    -   [getTargetBondingRate](#gettargetbondingrate)
+        -   [Examples](#examples-55)
+    -   [withdrawStake](#withdrawstake)
+        -   [Parameters](#parameters-34)
+        -   [Examples](#examples-56)
+    -   [withdrawStakeWithUnbondLock](#withdrawstakewithunbondlock)
+        -   [Parameters](#parameters-35)
+        -   [Examples](#examples-57)
+    -   [withdrawFees](#withdrawfees)
+        -   [Parameters](#parameters-36)
+        -   [Examples](#examples-58)
 -   [getDelegatorUnbondingLocks](#getdelegatorunbondinglocks)
-    -   [Parameters](#parameters-27)
-    -   [Examples](#examples-52)
+    -   [Parameters](#parameters-37)
+    -   [Examples](#examples-59)
 -   [getDelegatorUnbondingLock](#getdelegatorunbondinglock)
-    -   [Parameters](#parameters-28)
-    -   [Examples](#examples-53)
+    -   [Parameters](#parameters-38)
+    -   [Examples](#examples-60)
 -   [ABIPropDescriptor](#abipropdescriptor)
     -   [Properties](#properties)
 -   [ContractArtifact](#contractartifact)
@@ -216,9 +240,9 @@ The following section details the rpc API's function signatures and typedefs.
     -   [Properties](#properties-3)
 -   [TokenInfo](#tokeninfo)
     -   [Properties](#properties-4)
--   [TxConfig](#txconfig)
-    -   [Properties](#properties-5)
 -   [Protocol](#protocol)
+    -   [Properties](#properties-5)
+-   [TxReceipt](#txreceipt)
     -   [Properties](#properties-6)
 -   [Log](#log)
     -   [Properties](#properties-7)
@@ -236,7 +260,7 @@ The following section details the rpc API's function signatures and typedefs.
     -   [Properties](#properties-13)
 -   [Block](#block)
     -   [Properties](#properties-14)
--   [TxReceipt](#txreceipt)
+-   [TxConfig](#txconfig)
     -   [Properties](#properties-15)
 
 ### module~exports
@@ -389,19 +413,6 @@ await rpc.getUnbondingPeriod()
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
 
-#### getUnbondingPeriod
-
-Gets the unbonding period for transcoders
-
-##### Examples
-
-```javascript
-await rpc.getUnbondingPeriod()
-// => string
-```
-
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
-
 #### getNumActiveTranscoders
 
 Gets the number of active transcoders
@@ -410,32 +421,6 @@ Gets the number of active transcoders
 
 ```javascript
 await rpc.getNumActiveTranscoders()
-// => string
-```
-
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
-
-#### getNumActiveTranscoders
-
-Gets the number of active transcoders
-
-##### Examples
-
-```javascript
-await rpc.getNumActiveTranscoders()
-// => string
-```
-
-Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
-
-#### getMaxEarningsClaimsRounds
-
-Gets the maximum earnings for claims rounds
-
-##### Examples
-
-```javascript
-await rpc.getMaxEarningsClaimsRounds()
 // => string
 ```
 
@@ -695,7 +680,7 @@ Rebonds LPT from an address
 
 ##### Parameters
 
--   `unbondingLockId` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `unbondingLockId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 -   `tx` **[TxConfig](#txconfig)** an object specifying the `from` and `gas` values of the transaction (optional, default `config.defaultTx`)
 
 ##### Examples
@@ -725,13 +710,51 @@ await rpc.rebond(0)
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[TxReceipt](#txreceipt)>** 
 
+#### rebondWithHint
+
+Rebonds LPT from an address with hint
+
+##### Parameters
+
+-   `unbondingLockId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+-   `newPosPrev` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `newPosNext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `tx` **[TxConfig](#txconfig)** an object specifying the `from` and `gas` values of the transaction (optional, default `config.defaultTx`)
+
+##### Examples
+
+```javascript
+await rpc.rebondWithHint(0, "0x", "0x")
+// => TxReceipt {
+//   transactionHash: string,
+//   transactionIndex": BN,
+//   blockHash: string,
+//   blockNumber: BN,
+//   cumulativeGasUsed: BN,
+//   gasUsed: BN,
+//   contractAddress: string,
+//   logs: Array<Log {
+//     logIndex: BN,
+//     blockNumber: BN,
+//     blockHash: string,
+//     transactionHash: string,
+//     transactionIndex: string,
+//     address: string,
+//     data: string,
+//     topics: Array<string>
+//   }>
+// }
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[TxReceipt](#txreceipt)>** 
+
 #### rebondFromUnbonded
 
 Rebonds LPT from an address
 
 ##### Parameters
 
--   `addr` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `to` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
 -   `unbondingLockId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
 -   `tx` **[TxConfig](#txconfig)** an object specifying the `from` and `gas` values of the transaction (optional, default `config.defaultTx`)
 
@@ -761,6 +784,81 @@ await rpc.rebondFromUnbonded("0x", 1)
 ```
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[TxReceipt](#txreceipt)>** 
+
+#### rebondFromUnbondedWithHint
+
+Rebonds LPT from an address with hint
+
+##### Parameters
+
+-   `to` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `unbondingLockId` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** 
+-   `newPosPrev` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `newPosNext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `tx` **[TxConfig](#txconfig)** an object specifying the `from` and `gas` values of the transaction (optional, default `config.defaultTx`)
+
+##### Examples
+
+```javascript
+await rpc.rebondFromUnbondedWithHint("0x", 1, "0x", "0x")
+// => TxReceipt {
+//   transactionHash: string,
+//   transactionIndex": BN,
+//   blockHash: string,
+//   blockNumber: BN,
+//   cumulativeGasUsed: BN,
+//   gasUsed: BN,
+//   contractAddress: string,
+//   logs: Array<Log {
+//     logIndex: BN,
+//     blockNumber: BN,
+//     blockHash: string,
+//     transactionHash: string,
+//     transactionIndex: string,
+//     address: string,
+//     data: string,
+//     topics: Array<string>
+//   }>
+// }
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[TxReceipt](#txreceipt)>** 
+
+#### getPendingStake
+
+Get a delegator's pending stake
+
+##### Parameters
+
+-   `addr` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** user's ETH address
+-   `endRound` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The last round to compute pending stake from
+
+##### Examples
+
+```javascript
+await rpc.getPendingStake('0xf00...')
+// => string
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
+
+#### getPendingFees
+
+Get a delegator's pending fees
+
+##### Parameters
+
+-   `addr` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** user's ETH address
+-   `endRound` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The last round to compute pending fees from
+
+##### Examples
+
+```javascript
+await rpc.getPendingFees('0xf00...')
+// => string
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)>** 
 
 #### getTranscoderIsActive
 
@@ -1068,6 +1166,151 @@ await rpc.initializeRound()
 
 Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[TxReceipt](#txreceipt)>** 
 
+#### createPoll
+
+Creates a poll
+
+##### Parameters
+
+-   `proposal` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The IPFS multihash for the proposal
+-   `tx` **[TxConfig](#txconfig)** an object specifying the `from` and `gas` values of the transaction (optional, default `config.defaultTx`)
+
+##### Examples
+
+```javascript
+await rpc.createPoll('Qm...')
+// => TxReceipt {
+//   transactionHash: string,
+//   transactionIndex": BN,
+//   blockHash: string,
+//   blockNumber: BN,
+//   cumulativeGasUsed: BN,
+//   gasUsed: BN,
+//   contractAddress: string,
+//   logs: Array<Log {
+//     logIndex: BN,
+//     blockNumber: BN,
+//     blockHash: string,
+//     transactionHash: string,
+//     transactionIndex: string,
+//     address: string,
+//     data: string,
+//     topics: Array<string>
+//   }>
+// }
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[TxReceipt](#txreceipt)>** 
+
+#### getPollCreatorAllowance
+
+Get PollCreator transfer allowance
+
+##### Parameters
+
+-   `addr` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** user's ETH address
+-   `tx` **[TxConfig](#txconfig)** an object specifying the `from` and `gas` values of the transaction (optional, default `config.defaultTx`)
+
+##### Examples
+
+```javascript
+await rpc.getPollCreatorAllowance('0x...')
+// => TxReceipt {
+//   transactionHash: string,
+//   transactionIndex": BN,
+//   blockHash: string,
+//   blockNumber: BN,
+//   cumulativeGasUsed: BN,
+//   gasUsed: BN,
+//   contractAddress: string,
+//   logs: Array<Log {
+//     logIndex: BN,
+//     blockNumber: BN,
+//     blockHash: string,
+//     transactionHash: string,
+//     transactionIndex: string,
+//     address: string,
+//     data: string,
+//     topics: Array<string>
+//   }>
+// }
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[TxReceipt](#txreceipt)>** 
+
+#### getBondingManagerAllowance
+
+Get BondingManager transfer allowance
+
+##### Parameters
+
+-   `addr` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** user's ETH address
+-   `tx` **[TxConfig](#txconfig)** an object specifying the `from` and `gas` values of the transaction (optional, default `config.defaultTx`)
+
+##### Examples
+
+```javascript
+await rpc.getBondingManagerAllowance('0x...')
+// => TxReceipt {
+//   transactionHash: string,
+//   transactionIndex": BN,
+//   blockHash: string,
+//   blockNumber: BN,
+//   cumulativeGasUsed: BN,
+//   gasUsed: BN,
+//   contractAddress: string,
+//   logs: Array<Log {
+//     logIndex: BN,
+//     blockNumber: BN,
+//     blockHash: string,
+//     transactionHash: string,
+//     transactionIndex: string,
+//     address: string,
+//     data: string,
+//     topics: Array<string>
+//   }>
+// }
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[TxReceipt](#txreceipt)>** 
+
+#### vote
+
+Creates a poll
+
+##### Parameters
+
+-   `pollAddress` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** poll contract address
+-   `choiceId` **int** vote (0 = yes, 1 = no)
+-   `tx` **[TxConfig](#txconfig)** an object specifying the `from` and `gas` values of the transaction (optional, default `config.defaultTx`)
+
+##### Examples
+
+```javascript
+await rpc.initializeRound()
+// => TxReceipt {
+//   transactionHash: string,
+//   transactionIndex": BN,
+//   blockHash: string,
+//   blockNumber: BN,
+//   cumulativeGasUsed: BN,
+//   gasUsed: BN,
+//   contractAddress: string,
+//   logs: Array<Log {
+//     logIndex: BN,
+//     blockNumber: BN,
+//     blockHash: string,
+//     transactionHash: string,
+//     transactionIndex: string,
+//     address: string,
+//     data: string,
+//     topics: Array<string>
+//   }>
+// }
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[TxReceipt](#txreceipt)>** 
+
 #### claimEarnings
 
 Claims token and eth earnings from the sender's `lastClaimRound + 1` through a given `endRound`
@@ -1085,6 +1328,47 @@ await rpc.claimEarnings()
 ```
 
 Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+
+#### bondWithHint
+
+Bonds to a transcoder with hint
+
+##### Parameters
+
+-   `amount` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `to` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `oldDelegateNewPosPrev` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `oldDelegateNewPosNext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `currDelegateNewPosPrev` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `currDelegateNewPosNext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `tx` **[TxConfig](#txconfig)** an object specifying the `from` and `gas` values of the transaction (optional, default `config.defaultTx`)
+
+##### Examples
+
+```javascript
+await rpc.bondWithHint("100", "0x", "0x", "0x", "0x", "0x")
+// => TxReceipt {
+//   transactionHash: string,
+//   transactionIndex": BN,
+//   blockHash: string,
+//   blockNumber: BN,
+//   cumulativeGasUsed: BN,
+//   gasUsed: BN,
+//   contractAddress: string,
+//   logs: Array<Log {
+//     logIndex: BN,
+//     blockNumber: BN,
+//     blockHash: string,
+//     transactionHash: string,
+//     transactionIndex: string,
+//     address: string,
+//     data: string,
+//     topics: Array<string>
+//   }>
+// }
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[TxReceipt](#txreceipt)>** 
 
 #### estimateGas
 
@@ -1131,6 +1415,44 @@ Unbonds LPT from an address
 
 ```javascript
 await rpc.unbond(amount)
+// => TxReceipt {
+//   transactionHash: string,
+//   transactionIndex": BN,
+//   blockHash: string,
+//   blockNumber: BN,
+//   cumulativeGasUsed: BN,
+//   gasUsed: BN,
+//   contractAddress: string,
+//   logs: Array<Log {
+//     logIndex: BN,
+//     blockNumber: BN,
+//     blockHash: string,
+//     transactionHash: string,
+//     transactionIndex: string,
+//     address: string,
+//     data: string,
+//     topics: Array<string>
+//   }>
+// }
+```
+
+Returns **[Promise](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)&lt;[TxReceipt](#txreceipt)>** 
+
+#### unbondWithHint
+
+Unbonds LPT from an address with hint
+
+##### Parameters
+
+-   `amount` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `newPosPrev` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `newPosNext` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `tx` **[TxConfig](#txconfig)** an object specifying the `from` and `gas` values of the transaction (optional, default `config.defaultTx`)
+
+##### Examples
+
+```javascript
+await rpc.unbondWithHint("100", "0x", "0x")
 // => TxReceipt {
 //   transactionHash: string,
 //   transactionIndex": BN,
@@ -1424,17 +1746,6 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 -   `totalSupply` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** total supply of token available in the protocol (LPTU)
 -   `balance` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** user's token balance (LPTU)
 
-### TxConfig
-
-Transaction config object
-
-Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)
-
-#### Properties
-
--   `from` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the ETH account address to sign the transaction from
--   `gas` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the amount of gas to include in the transaction
-
 ### Protocol
 
 A Protocol struct
@@ -1448,6 +1759,23 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 -   `totalBondedToken` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** total bonded token for protocol
 -   `targetBondingRate` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** target bonding rate for protocol
 -   `transcoderPoolMaxSize` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** transcoder pool max size
+
+### TxReceipt
+
+Transaction receipt
+
+Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)
+
+#### Properties
+
+-   `transactionHash` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the transaction hash
+-   `transactionIndex` **BN** the transaction index
+-   `blockHash` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the transaction block hash
+-   `blockNumber` **BN** the transaction block number
+-   `cumulativeGasUsed` **BN** the cumulative gas used in the transaction
+-   `gasUsed` **BN** the gas used in the transaction
+-   `contractAddress` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the contract address of the transaction method
+-   `logs` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Log](#log)>** an object containing logs that were fired during the transaction
 
 ### Log
 
@@ -1592,19 +1920,13 @@ Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Globa
 -   `transactionsRoot` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** root transaction hash
 -   `uncles` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;Uncle>** block uncles
 
-### TxReceipt
+### TxConfig
 
-Transaction receipt
+Transaction config object
 
 Type: [Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)
 
 #### Properties
 
--   `transactionHash` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the transaction hash
--   `transactionIndex` **BN** the transaction index
--   `blockHash` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the transaction block hash
--   `blockNumber` **BN** the transaction block number
--   `cumulativeGasUsed` **BN** the cumulative gas used in the transaction
--   `gasUsed` **BN** the gas used in the transaction
--   `contractAddress` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the contract address of the transaction method
--   `logs` **[Array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array)&lt;[Log](#log)>** an object containing logs that were fired during the transaction
+-   `from` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the ETH account address to sign the transaction from
+-   `gas` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the amount of gas to include in the transaction

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@livepeer/sdk",
   "description": "A module for interacting with Livepeer's smart contracts. The SDK is a core dependency of most LivepeerJS packages.",
-  "version": "1.0.0-alpha.18",
+  "version": "1.0.0-alpha.19",
   "license": "MIT",
   "main": "main/index.js",
   "module": "lib/index.js",

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -695,48 +695,6 @@ export async function createLivepeerSDK(
     },
 
     /**
-     * Gets the unbonding period for transcoders
-     * @memberof livepeer~rpc
-     * @return {Promise<string>}
-     *
-     * @example
-     *
-     * await rpc.getUnbondingPeriod()
-     * // => string
-     */
-    async getUnbondingPeriod(): Promise<string> {
-      return headToString(await BondingManager.unbondingPeriod())
-    },
-
-    /**
-     * Gets the number of active transcoders
-     * @memberof livepeer~rpc
-     * @return {Promise<string>}
-     *
-     * @example
-     *
-     * await rpc.getNumActiveTranscoders()
-     * // => string
-     */
-    async getNumActiveTranscoders(): Promise<string> {
-      return headToString(await BondingManager.numActiveTranscoders())
-    },
-
-    /**
-     * Gets the maximum earnings for claims rounds
-     * @memberof livepeer~rpc
-     * @return {Promise<string>}
-     *
-     * @example
-     *
-     * await rpc.getMaxEarningsClaimsRounds()
-     * // => string
-     */
-    async getMaxEarningsClaimsRounds(): Promise<string> {
-      return headToString(await BondingManager.maxEarningsClaimsRounds())
-    },
-
-    /**
      * Gets the total amount of bonded tokens
      * @memberof livepeer~rpc
      * @return {Promise<string}

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1098,6 +1098,7 @@ export async function createLivepeerSDK(
     /**
      * Rebonds LPT from an address
      * @memberof livepeer~rpc
+     * @param {number} unbondingLockId
      * @param {TxConfig} [tx = config.defaultTx] - an object specifying the `from` and `gas` values of the transaction
      * @return {Promise<TxReceipt>}
      *
@@ -1125,7 +1126,7 @@ export async function createLivepeerSDK(
      * // }
      */
     async rebond(
-      unbondingLockId: string,
+      unbondingLockId: number,
       tx = config.defaultTx,
     ): Promise<TxReceipt> {
       const txHash = await BondingManager.rebond(unbondingLockId, {
@@ -1140,8 +1141,64 @@ export async function createLivepeerSDK(
     },
 
     /**
+     * Rebonds LPT from an address with hint
+     * @memberof livepeer~rpc
+     * @param {number} unbondingLockId
+     * @param {string} newPosPrev
+     * @param {string} newPosNext
+     * @param {TxConfig} [tx = config.defaultTx] - an object specifying the `from` and `gas` values of the transaction
+     * @return {Promise<TxReceipt>}
+     *
+     * @example
+     *
+     * await rpc.rebondWithHint(0, "0x", "0x")
+     * // => TxReceipt {
+     * //   transactionHash: string,
+     * //   transactionIndex": BN,
+     * //   blockHash: string,
+     * //   blockNumber: BN,
+     * //   cumulativeGasUsed: BN,
+     * //   gasUsed: BN,
+     * //   contractAddress: string,
+     * //   logs: Array<Log {
+     * //     logIndex: BN,
+     * //     blockNumber: BN,
+     * //     blockHash: string,
+     * //     transactionHash: string,
+     * //     transactionIndex: string,
+     * //     address: string,
+     * //     data: string,
+     * //     topics: Array<string>
+     * //   }>
+     * // }
+     */
+    async rebondWithHint(
+      unbondingLockId: number,
+      newPosPrev: string,
+      newPosNext: string,
+      tx: TxObject,
+    ): Promise<TxReceipt> {
+      const txHash = await BondingManager.rebondWithHint(
+        unbondingLockId,
+        newPosPrev,
+        newPosNext,
+        {
+          ...config.defaultTx,
+          ...tx,
+        },
+      )
+      if (tx.returnTxHash) {
+        return txHash
+      }
+
+      return await utils.getTxReceipt(txHash, config.eth)
+    },
+
+    /**
      * Rebonds LPT from an address
      * @memberof livepeer~rpc
+     * @param {string} to
+     * @param {number} unbondingLockId
      * @param {TxConfig} [tx = config.defaultTx] - an object specifying the `from` and `gas` values of the transaction
      * @return {Promise<TxReceipt>}
      *
@@ -1169,13 +1226,71 @@ export async function createLivepeerSDK(
      * // }
      */
     async rebondFromUnbonded(
-      addr: string,
+      to: string,
       unbondingLockId: number,
       tx = config.defaultTx,
     ): Promise<TxReceipt> {
       const txHash = await BondingManager.rebondFromUnbonded(
-        addr,
+        to,
         unbondingLockId,
+        {
+          ...config.defaultTx,
+          ...tx,
+        },
+      )
+
+      if (tx.returnTxHash) {
+        return txHash
+      }
+
+      return await utils.getTxReceipt(txHash, config.eth)
+    },
+
+    /**
+     * Rebonds LPT from an address with hint
+     * @memberof livepeer~rpc
+     * @param {string} to
+     * @param {number} unbondingLockId
+     * @param {string} newPosPrev
+     * @param {string} newPosNext
+     * @param {TxConfig} [tx = config.defaultTx] - an object specifying the `from` and `gas` values of the transaction
+     * @return {Promise<TxReceipt>}
+     *
+     * @example
+     *
+     * await rpc.rebondFromUnbondedWithHint("0x", 1, "0x", "0x")
+     * // => TxReceipt {
+     * //   transactionHash: string,
+     * //   transactionIndex": BN,
+     * //   blockHash: string,
+     * //   blockNumber: BN,
+     * //   cumulativeGasUsed: BN,
+     * //   gasUsed: BN,
+     * //   contractAddress: string,
+     * //   logs: Array<Log {
+     * //     logIndex: BN,
+     * //     blockNumber: BN,
+     * //     blockHash: string,
+     * //     transactionHash: string,
+     * //     transactionIndex: string,
+     * //     address: string,
+     * //     data: string,
+     * //     topics: Array<string>
+     * //   }>
+     * // }
+     */
+    async rebondFromUnbondedWithHint(
+      to: string,
+      unbondingLockId: number,
+      newPosPrev: string,
+      newPosNext: string,
+      tx = config.defaultTx,
+    ): Promise<TxReceipt> {
+      const txHash = await BondingManager.rebondFromUnbondedWithHint(
+        to,
+        unbondingLockId,
+        newPosPrev,
+        newPosNext,
         {
           ...config.defaultTx,
           ...tx,
@@ -1192,8 +1307,8 @@ export async function createLivepeerSDK(
     /**
      * Get a delegator's pending stake
      * @memberof livepeer~rpc
-     * @param  {string} addr - user's ETH address
-     * @param  {string} endRound The last round to compute pending stake from
+     * @param {string} addr - user's ETH address
+     * @param {string} endRound The last round to compute pending stake from
      * @return {Promise<string>}
      *
      * @example
@@ -1901,6 +2016,71 @@ export async function createLivepeerSDK(
     },
 
     /**
+     * Bonds to a transcoder with hint
+     * @memberof livepeer~rpc
+     * @param {string} amount
+     * @param {string} to
+     * @param {string} oldDelegateNewPosPrev
+     * @param {string} oldDelegateNewPosNext
+     * @param {string} currDelegateNewPosPrev
+     * @param {string} currDelegateNewPosNext
+     * @param {TxConfig} [tx = config.defaultTx] - an object specifying the `from` and `gas` values of the transaction
+     * @return {Promise<TxReceipt>}
+     *
+     * @example
+     *
+     * await rpc.bondWithHint("100", "0x", "0x", "0x", "0x", "0x")
+     * // => TxReceipt {
+     * //   transactionHash: string,
+     * //   transactionIndex": BN,
+     * //   blockHash: string,
+     * //   blockNumber: BN,
+     * //   cumulativeGasUsed: BN,
+     * //   gasUsed: BN,
+     * //   contractAddress: string,
+     * //   logs: Array<Log {
+     * //     logIndex: BN,
+     * //     blockNumber: BN,
+     * //     blockHash: string,
+     * //     transactionHash: string,
+     * //     transactionIndex: string,
+     * //     address: string,
+     * //     data: string,
+     * //     topics: Array<string>
+     * //   }>
+     * // }
+     */
+    async bondWithHint(
+      amount: string,
+      to: string,
+      oldDelegateNewPosPrev: string,
+      oldDelegateNewPosNext: string,
+      currDelegateNewPosPrev: string,
+      currDelegateNewPosNext: string,
+      tx: TxObject,
+    ): Promise<TxReceipt> {
+      const token = toBN(amount)
+      const txHash = await BondingManager.bondWithHint(
+        token,
+        await resolveAddress(rpc.getENSAddress, to),
+        oldDelegateNewPosPrev,
+        oldDelegateNewPosNext,
+        currDelegateNewPosPrev,
+        currDelegateNewPosNext,
+        {
+          ...config.defaultTx,
+          ...tx,
+        },
+      )
+
+      if (tx.returnTxHash) {
+        return txHash
+      }
+
+      return await utils.getTxReceipt(txHash, config.eth)
+    },
+
+    /**
      * Gets the estimated amount of gas to be used by a smart contract
      * method.
      * @memberof livepeer~rpc
@@ -1982,6 +2162,61 @@ export async function createLivepeerSDK(
         ...config.defaultTx,
         ...tx,
       })
+
+      if (tx.returnTxHash) {
+        return txHash
+      }
+
+      return await utils.getTxReceipt(txHash, config.eth)
+    },
+
+    /**
+     * Unbonds LPT from an address with hint
+     * @memberof livepeer~rpc
+     * @param {string} amount
+     * @param {string} newPosPrev
+     * @param {string} newPosNext
+     * @param {TxConfig} [tx = config.defaultTx] - an object specifying the `from` and `gas` values of the transaction
+     * @return {Promise<TxReceipt>}
+     *
+     * @example
+     *
+     * await rpc.unbondWithHint("100", "0x", "0x")
+     * // => TxReceipt {
+     * //   transactionHash: string,
+     * //   transactionIndex": BN,
+     * //   blockHash: string,
+     * //   blockNumber: BN,
+     * //   cumulativeGasUsed: BN,
+     * //   gasUsed: BN,
+     * //   contractAddress: string,
+     * //   logs: Array<Log {
+     * //     logIndex: BN,
+     * //     blockNumber: BN,
+     * //     blockHash: string,
+     * //     transactionHash: string,
+     * //     transactionIndex: string,
+     * //     address: string,
+     * //     data: string,
+     * //     topics: Array<string>
+     * //   }>
+     * // }
+     */
+    async unbondWithHint(
+      amount: string,
+      newPosPrev: string,
+      newPosNext: string,
+      tx = config.defaultTx,
+    ): Promise<TxReceipt> {
+      const txHash = await BondingManager.unbondWithHint(
+        amount,
+        newPosPrev,
+        newPosNext,
+        {
+          ...config.defaultTx,
+          ...tx,
+        },
+      )
 
       if (tx.returnTxHash) {
         return txHash


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds support for calling all staking functions with hints in an effort to reduce the gas costs associated with these functions.

**Specific updates (required)**
- Adds `bondWithHint`, `unbondWithHint`, `rebondWithHint`, and `rebondFromUnbondedWithHint` methods to the sdk
- Updates the apollo mutations in the explorer to use these new methods

**Does this pull request close any open issues?**
Closes #742
