### PR TITLE
api: temporarily force mist to use passthrough fps

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -239,6 +239,20 @@ app.post('/', authMiddleware({}), validatePost('stream'), async (req, res) => {
     playbackId,
     createdByTokenName: req.tokenName,
   })
+
+  // FIXME: tempoarily, Mist can only make passthrough FPS streams
+  if (
+    req.headers['user-agent'] &&
+    req.headers['user-agent'].toLowerCase().includes('mistserver')
+  ) {
+    doc.profiles = (doc.profiles || []).map((profile) => {
+      return {
+        ...profile,
+        fps: 0,
+      }
+    })
+  }
+
   await Promise.all([
     req.store.create(doc),
     trackAction(


### PR DESCRIPTION
user-agent sniffing: the last resort of scoundrels

this will go away when it's possible and encouraged to select "passthrough" as the default in the MistServer interface