### PR TITLE
api: add --api-region and corresponding proxy

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -82,6 +82,7 @@
     "node-jose": "^1.1.4",
     "nodemon": "^1.19.0",
     "pg": "^7.10.0",
+    "promise.any": "^2.0.1",
     "request-ip": "^2.1.3",
     "string-template": "^1.0.0",
     "uuid": "^3.3.2",

--- a/packages/api/src/controllers/api-proxy.js
+++ b/packages/api/src/controllers/api-proxy.js
@@ -1,0 +1,52 @@
+/**
+ * Special controller for forwarding all incoming requests to a geolocated API region
+ */
+
+import Router from 'express/lib/router'
+import geolocateMiddleware from '../middleware/geolocate'
+import fetch from 'isomorphic-fetch'
+import path from 'path'
+
+const app = Router()
+
+app.use(geolocateMiddleware({ region: 'api-region' }), async (req, res) => {
+  const upstreamUrl = new URL(req.region.chosenServer)
+  upstreamUrl.pathname = req.originalUrl
+  const upstreamUrlString = upstreamUrl.toString()
+  console.log(upstreamUrlString)
+  const upstreamHeaders = {
+    ...req.headers,
+    host: upstreamUrl.hostname,
+  }
+  delete upstreamHeaders['content-length']
+  let body = undefined
+  if (req.body) {
+    body = JSON.stringify(req.body)
+  }
+  console.log('doing fetch', {
+    method: req.method,
+    body,
+    headers: upstreamHeaders,
+  })
+  let upstreamRes
+  try {
+    upstreamRes = await fetch(upstreamUrl.toString(), {
+      method: req.method,
+      body: body,
+      headers: upstreamHeaders,
+    })
+  } catch (e) {
+    console.log(e)
+  }
+  console.log('back from fetch')
+  res.status(upstreamRes.status)
+  if (res.status === 204) {
+    return res.end()
+  }
+  console.log('doing body')
+  const resBody = await upstreamRes.json()
+  console.log('back from body')
+  res.json(resBody)
+})
+
+export default app

--- a/packages/api/src/middleware/geolocate.js
+++ b/packages/api/src/middleware/geolocate.js
@@ -35,9 +35,12 @@ function geoLocateFactory({ first = true, region = 'region' }) {
     const errors = []
     const promises = servers.map(async (server) => {
       const start = Date.now()
-      const res = await fetch(`${server}/geolocate`)
+      const upstreamUrl = `${server}/api/geolocate`
+      const res = await fetch(upstreamUrl)
       if (res.status !== 200) {
-        const err = new Error(`HTTP ${res.status}: ${await res.text()}`)
+        const err = new Error(
+          `${upstreamUrl} HTTP ${res.status}: ${await res.text()}`,
+        )
         errors.push(err)
         throw err
       }

--- a/packages/api/src/parse-cli.js
+++ b/packages/api/src/parse-cli.js
@@ -195,6 +195,13 @@ export default function parseCli(argv) {
           default: [],
           coerce: coerceArr,
         },
+        'api-region': {
+          describe:
+            'list of api endpoints to forward on incoming API requests. defining this delegates all non-geolocation tasks to the upstream servers',
+          type: 'array',
+          default: [],
+          coerce: coerceArr,
+        },
       })
       .help()
       .parse(argv)

--- a/yarn.lock
+++ b/yarn.lock
@@ -16729,6 +16729,17 @@ es-abstract@^1.17.0, es-abstract@^1.17.0-next.0, es-abstract@^1.17.0-next.1, es-
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
 
+es-aggregate-error@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/es-aggregate-error/-/es-aggregate-error-1.0.3.tgz#01296b119dc81356dabca1d85a85e5eece413a97"
+  integrity sha512-MUB3fHZI0fVJsbtkhR2rw7REEZBlWg6MpIRtW5Pr7r5mLc6TVMdLhagnclYFqdiRd6L/lLt5N9sqploNLrLd+Q==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
+    function-bind "^1.1.1"
+    functions-have-names "^1.2.1"
+    globalthis "^1.0.1"
+
 es-array-method-boxes-properly@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
@@ -19454,7 +19465,7 @@ functional-red-black-tree@^1.0.1, functional-red-black-tree@~1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-functions-have-names@^1.2.0:
+functions-have-names@^1.2.0, functions-have-names@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.1.tgz#a981ac397fa0c9964551402cdc5533d7a4d52f91"
   integrity sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==
@@ -20063,7 +20074,7 @@ globals@^9.18.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
-globalthis@^1.0.0:
+globalthis@^1.0.0, globalthis@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.1.tgz#40116f5d9c071f9e8fb0037654df1ab3a83b7ef9"
   integrity sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==
@@ -24408,7 +24419,7 @@ iterate-iterator@^1.0.1:
   resolved "https://registry.yarnpkg.com/iterate-iterator/-/iterate-iterator-1.0.1.tgz#1693a768c1ddd79c969051459453f082fe82e9f6"
   integrity sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==
 
-iterate-value@^1.0.0:
+iterate-value@^1.0.0, iterate-value@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/iterate-value/-/iterate-value-1.0.2.tgz#935115bd37d006a52046535ebc8d07e9c9337f57"
   integrity sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==
@@ -34167,6 +34178,18 @@ promise.allsettled@^1.0.0:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     iterate-value "^1.0.0"
+
+promise.any@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/promise.any/-/promise.any-2.0.1.tgz#381c8f31b5312865c6c2a8104ff501f7f847e66d"
+  integrity sha512-3amHUuhVhkhFVw8mAM33pyt1zBoYK9O9SorjWbE+E3zSTb4AUpJmK5+rt5g6OCtZpgBlT1cTxF/bp/SNeMQSUQ==
+  dependencies:
+    array.prototype.map "^1.0.1"
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
+    es-aggregate-error "^1.0.2"
+    function-bind "^1.1.1"
+    iterate-value "^1.0.1"
 
 promise.prototype.finally@^3.1.0:
   version "3.1.2"


### PR DESCRIPTION
Works around the "too many subrequests" message, though we should also optimize some of those queries. Already tested in .monster by manually building and deploying the worker.

This also improves the geolocation logic a bit so it won't fail if the first region returns an error message.