### PR TITLE
fix docs links/tweak MistServer GOP param

### DIFF
--- a/packages/api/src/controllers/stream.js
+++ b/packages/api/src/controllers/stream.js
@@ -22,11 +22,14 @@ const hackMistSettings = (req, profiles) => {
   }
   profiles = profiles || []
   return profiles.map((profile) => {
-    return {
+    profile = {
       ...profile,
       fps: 0,
-      gop: '2.0',
     }
+    if (typeof profile.gop === 'undefined') {
+      profile.gop = '2.0'
+    }
+    return profile
   })
 }
 

--- a/packages/livepeer.com/www/lib/markdown-provider.tsx
+++ b/packages/livepeer.com/www/lib/markdown-provider.tsx
@@ -12,20 +12,27 @@ const StyledA = ({ href, children }) => {
   if (router.pathname === href) {
     opacity = 1;
   }
-  return (
-    <Link href={href}>
-      <a
-        sx={{
-          textDecoration: "none",
-          cursor: "pointer",
-          opacity: opacity,
-          "&:hover": { opacity: 1 },
-        }}
-      >
-        {children}
-      </a>
-    </Link>
+  const isInternal = href.startsWith("/");
+  const internalA = (
+    <a
+      href={href}
+      target={isInternal ? undefined : "_blank"}
+      sx={{
+        textDecoration: "none",
+        cursor: "pointer",
+        opacity: opacity,
+        "&:hover": { opacity: 1 },
+      }}
+    >
+      {children}
+    </a>
   );
+
+  if (!isInternal) {
+    return internalA;
+  }
+
+  return <Link href={href}>{internalA}</Link>;
 };
 
 const components = {

--- a/packages/livepeer.com/www/pages/docs/api-keys/create-an-api-key.mdx
+++ b/packages/livepeer.com/www/pages/docs/api-keys/create-an-api-key.mdx
@@ -4,7 +4,7 @@ import DocsLayout from "../../../components/DocsLayout";
 
 ### How to create an API key
 
-1. Open your Livepeer account and navigate to the **API key list page**, https://livepeer.com/app/user/keys
+1. Open your Livepeer account and navigate to the **API key list page**, [https://livepeer.com/app/user/keys](/app/user/keys)
 1. Click the button to create a new key.
 1. Input a name for your key and **create** the key. 
 1. When prompted, **copy** and **secure** the API key. This key is a secret, and for your security Livepeer will not show it to you again.

--- a/packages/livepeer.com/www/pages/docs/api-keys/delete-an-api-key.mdx
+++ b/packages/livepeer.com/www/pages/docs/api-keys/delete-an-api-key.mdx
@@ -6,7 +6,7 @@ import DocsLayout from "../../../components/DocsLayout";
 
 <p><font color="red">Deleting an API key cannot be undone.</font></p>
 
-1. Open your Livepeer account and navigate to the **API key list page**, https://livepeer.com/app/user/keys
+1. Open your Livepeer account and navigate to the **API key list page**, [https://livepeer.com/app/user/keys](/app/user/keys)
 1. Click the radio button next to the API keys you want to delete
 1. Click the **delete** button and follow the prompt to confirm.
 

--- a/packages/livepeer.com/www/pages/docs/rtmp/create-a-stream.mdx
+++ b/packages/livepeer.com/www/pages/docs/rtmp/create-a-stream.mdx
@@ -6,7 +6,7 @@ import DocsLayout from "../../../components/DocsLayout";
 
 Before live streaming via the Livepeer API, you will need to create a Livepeer account and be able to create a RTMP stream. You do not need to create an API key.
 
-1. Open your Livepeer account and navigate to the **streams list page**, https://livepeer.com/app/user.
+1. Open your Livepeer account and navigate to the **streams list page**, [https://livepeer.com/app/user](/app/user).
 1. Click the button to create a new stream.
 1. On the **create a new stream page**, input a **stream name**.
     * Your stream name needs to be unique and include URL compatible characters only.

--- a/packages/livepeer.com/www/pages/docs/rtmp/stream-page-specifications.mdx
+++ b/packages/livepeer.com/www/pages/docs/rtmp/stream-page-specifications.mdx
@@ -4,7 +4,7 @@ import DocsLayout from "../../../components/DocsLayout";
 
 ### Understanding the stream page specifications
 
-Navigate to a stream page by clicking on a stream name on the **stream list page**, https://livepeer.com/app/user.
+Navigate to a stream page by clicking on a stream name on the **stream list page**, [https://livepeer.com/app/user](/app/user).
 
 The stream name is at the top of the stream page.
 


### PR DESCRIPTION
* Fixes some links on docs. External links work properly now.
* Also while I was thinking about it I'm allowing for MistServer to override its GOP parameter 