### PR TITLE
add checks to getHint() and simulateNewActiveSetOrder() methods

### DIFF
--- a/packages/explorer-2.0/lib/utils.tsx
+++ b/packages/explorer-2.0/lib/utils.tsx
@@ -327,9 +327,15 @@ export const getHint = (id, transcoders) => {
     newPosPrev: EMPTY_ADDRESS,
     newPosNext: EMPTY_ADDRESS,
   }
+
+  if (!transcoders.length || !id) {
+    return hint
+  }
+
   const index = transcoders.findIndex(
     (t) => t.id.toLowerCase() === id.toLowerCase(),
   )
+
   // if transcoder is not in active set return
   if (index < 0) {
     return hint
@@ -368,6 +374,7 @@ export const simulateNewActiveSetOrder = ({
 
     // if delegator is moving stake, subtract amount from old delegate
     if (
+      oldDelegate &&
       oldDelegate.toLowerCase() != newDelegate.toLowerCase() &&
       oldDelegate.toLowerCase() != EMPTY_ADDRESS
     ) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes an error thrown in the explorer for users who have connected their wallets but have never staked before. This causes `newDelegate` param in the `getHint()` method to be `undefined` causing the method to throw an error.

