### PR TITLE
fix pagination

### DIFF
--- a/packages/explorer-2.0/lib/createSchema.tsx
+++ b/packages/explorer-2.0/lib/createSchema.tsx
@@ -262,15 +262,16 @@ export default async () => {
           `https://livepeer-pricing-tool.com/orchestratorStats`,
         )
         let transcodersWithPrice = await response.json()
-        transcodersWithPrice = transcodersWithPrice.map((t) => ({
-          id: t.Address,
-          price: t.PricePerPixel,
-        }))
-        const merged = mergeObjectsInUnique(
-          [...transcoders, ...transcodersWithPrice],
-          'id',
-        )
-        return merged
+        let arr = []
+        transcodersWithPrice.map((t) => {
+          if (transcoders.filter((a) => a.id === t.Address).length > 0) {
+            arr.push({
+              id: t.Address,
+              price: t.PricePerPixel,
+            })
+          }
+        })
+        return mergeObjectsInUnique([...transcoders, ...arr], 'id')
       },
     },
   }

--- a/packages/explorer-2.0/pages/index.tsx
+++ b/packages/explorer-2.0/pages/index.tsx
@@ -21,7 +21,6 @@ const Home = () => {
     orderDirection: 'desc',
     where: {
       status: 'Registered',
-      id_not: '0x0000000000000000000000000000000000000000', // subgraph indexes this as a transcoder for some reason so need to filter it out
     },
   }
   const { data, loading } = useQuery(orchestratorsViewQuery, {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes a bug in the the orchestrator pagination component caused by [the pricing api returning unregistered orchestrators](https://github.com/buidl-labs/livepeer-pricing-tool/issues/20). Until a fixed is deployed to that API, this PR discards those invalid orchestrators.

Closes #820 
