### PR TITLE
add new minter address to subgraph manifest

### DIFF
--- a/packages/subgraph/abis/Minter.json
+++ b/packages/subgraph/abis/Minter.json
@@ -1,184 +1,9 @@
 [
   {
-    "constant": true,
-    "inputs": [],
-    "name": "currentMintedTokens",
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "targetBondingRate",
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "constant": false,
     "inputs": [
       {
-        "name": "_controller",
-        "type": "address"
-      }
-    ],
-    "name": "setController",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "currentMintableTokens",
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "inflationChange",
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "inflation",
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "controller",
-    "outputs": [
-      {
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "name": "_controller",
-        "type": "address"
-      },
-      {
-        "name": "_inflation",
-        "type": "uint256"
-      },
-      {
-        "name": "_inflationChange",
-        "type": "uint256"
-      },
-      {
-        "name": "_targetBondingRate",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "name": "currentMintableTokens",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "name": "currentInflation",
-        "type": "uint256"
-      }
-    ],
-    "name": "SetCurrentRewardTokens",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "name": "controller",
-        "type": "address"
-      }
-    ],
-    "name": "SetController",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "name": "param",
-        "type": "string"
-      }
-    ],
-    "name": "ParameterUpdate",
-    "type": "event"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
-        "name": "_targetBondingRate",
-        "type": "uint256"
-      }
-    ],
-    "name": "setTargetBondingRate",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
+        "internalType": "uint256",
         "name": "_inflationChange",
         "type": "uint256"
       }
@@ -193,6 +18,7 @@
     "constant": false,
     "inputs": [
       {
+        "internalType": "contract IMinter",
         "name": "_newMinter",
         "type": "address"
       }
@@ -206,39 +32,45 @@
   {
     "constant": false,
     "inputs": [
-      {
-        "name": "_fracNum",
-        "type": "uint256"
-      },
-      {
-        "name": "_fracDenom",
-        "type": "uint256"
-      }
+      { "internalType": "address payable", "name": "_to", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
     ],
-    "name": "createReward",
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "name": "trustedWithdrawETH",
+    "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "currentMintedTokens",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getController",
+    "outputs": [
+      { "internalType": "contract IController", "name": "", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
     "type": "function"
   },
   {
     "constant": false,
     "inputs": [
       {
-        "name": "_to",
-        "type": "address"
-      },
-      {
-        "name": "_amount",
+        "internalType": "uint256",
+        "name": "_targetBondingRate",
         "type": "uint256"
       }
     ],
-    "name": "trustedTransferTokens",
+    "name": "setTargetBondingRate",
     "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",
@@ -247,10 +79,66 @@
   {
     "constant": false,
     "inputs": [
-      {
-        "name": "_amount",
-        "type": "uint256"
-      }
+      { "internalType": "uint256", "name": "_fracNum", "type": "uint256" },
+      { "internalType": "uint256", "name": "_fracDenom", "type": "uint256" }
+    ],
+    "name": "createReward",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "targetBondingRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "_controller", "type": "address" }
+    ],
+    "name": "setController",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "currentMintableTokens",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "inflationChange",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "inflation",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
     ],
     "name": "trustedBurnTokens",
     "outputs": [],
@@ -261,33 +149,13 @@
   {
     "constant": false,
     "inputs": [
-      {
-        "name": "_to",
-        "type": "address"
-      },
-      {
-        "name": "_amount",
-        "type": "uint256"
-      }
+      { "internalType": "address", "name": "_to", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
     ],
-    "name": "trustedWithdrawETH",
+    "name": "trustedTransferTokens",
     "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [],
-    "name": "depositETH",
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "payable": true,
-    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -300,17 +168,87 @@
     "type": "function"
   },
   {
+    "constant": false,
+    "inputs": [],
+    "name": "depositETH",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
     "constant": true,
     "inputs": [],
-    "name": "getController",
+    "name": "controller",
     "outputs": [
-      {
-        "name": "",
-        "type": "address"
-      }
+      { "internalType": "contract IController", "name": "", "type": "address" }
     ],
     "payable": false,
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_controller", "type": "address" },
+      { "internalType": "uint256", "name": "_inflation", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "_inflationChange",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_targetBondingRate",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "currentMintableTokens",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "currentInflation",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetCurrentRewardTokens",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "controller",
+        "type": "address"
+      }
+    ],
+    "name": "SetController",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "param",
+        "type": "string"
+      }
+    ],
+    "name": "ParameterUpdate",
+    "type": "event"
   }
 ]

--- a/packages/subgraph/networks.yaml
+++ b/packages/subgraph/networks.yaml
@@ -24,6 +24,9 @@ mainnet:
     minter:
       address: '8573f2f5a3bd960eee3d998473e50c75cdbe6828'
       startBlock: 5533913
+    minter_LIP40:
+      address: '505F8c2ee81f1C6fa0D88e918eF0491222E05818'
+      startBlock: 10686186
     ticketBroker:
       address: '5b1ce829384eebfa30286f12d1e7a695ca45f5d2'
       startBlock: 9274420

--- a/packages/subgraph/networks.yaml
+++ b/packages/subgraph/networks.yaml
@@ -60,6 +60,9 @@ rinkeby:
     minter:
       address: 'e5056d1fE48F562dd8AcB1BBFFa147223d448C1B'
       startBlock: 5325851
+    minter_LIP40:
+      address: '63B12E71F9c620BeAdf53b0e95189a16A2Af8Ed2'
+      startBlock: 7041202
     ticketBroker:
       address: '40897Ff6e44Ca2e145A691701897844669Bf7cee'
       startBlock: 5325857
@@ -91,6 +94,9 @@ development:
       address: 'D833215cBcc3f914bD1C9ece3EE7BF8B14f841bb'
       startBlock: 0
     minter:
+      address: 'e982E462b094850F12AF94d21D470e21bE9D0E9C'
+      startBlock: 0
+    minter_LIP40:
       address: 'e982E462b094850F12AF94d21D470e21bE9D0E9C'
       startBlock: 0
     ticketBroker:

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -207,6 +207,31 @@ dataSources:
         - event: ParameterUpdate(string)
           handler: parameterUpdate
   - kind: ethereum/contract
+    name: Minter_LIP40
+    network: {{networkName}}
+    source:
+      startBlock: {{contracts.minter_LIP40.startBlock}}
+      address: {{contracts.minter_LIP40.address}}
+      abi: Minter
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/minter.ts
+      entities:
+        - Round
+        - Protocol
+        - ParameterUpdate
+        - SetCurrentRewardTokens
+      abis:
+        - name: Minter
+          file: ./abis/Minter.json
+      eventHandlers:
+        - event: SetCurrentRewardTokens(uint256,uint256)
+          handler: setCurrentRewardTokens
+        - event: ParameterUpdate(string)
+          handler: parameterUpdate
+  - kind: ethereum/contract
     name: TicketBroker
     network: {{networkName}}
     source:


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds the new minter contract address to the subgraph manifest so the new inflation change is up to date.

**Does this pull request close any open issues?**
- Closes #823 