### PR TITLE
remove unnecessary contract call from reward handler

### DIFF
--- a/packages/subgraph/src/mappings/pollTallyHandlers.ts
+++ b/packages/subgraph/src/mappings/pollTallyHandlers.ts
@@ -179,7 +179,7 @@ export function updatePollTallyOnEarningsClaimed(
 
   // Return if the voter doesn't share the same delegate as the delegator that claimed earnings
   if (
-    delegator == null &&
+    delegator == null ||
     delegator.delegate != event.params.delegate.toHex()
   ) {
     return

--- a/packages/subgraph/src/mappings/pollTallyHandlers.ts
+++ b/packages/subgraph/src/mappings/pollTallyHandlers.ts
@@ -40,7 +40,7 @@ export function updatePollTallyOnReward(event: RewardEvent): void {
   let transcoder = Transcoder.load(event.params.transcoder.toHex())
 
   // update vote stakes
-  if (transcoder.status == 'Registered') {
+  if (voterAddress == event.params.transcoder.toHex()) {
     vote.voteStake = transcoder.totalStake
   } else {
     let bondingManager = BondingManager.bind(event.address)

--- a/packages/subgraph/src/mappings/pollTallyHandlers.ts
+++ b/packages/subgraph/src/mappings/pollTallyHandlers.ts
@@ -20,7 +20,7 @@ export function updatePollTallyOnReward(event: RewardEvent): void {
 
   // Return if transcoder that called reward isn't voter's delegate
   if (
-    delegator == null &&
+    delegator == null ||
     delegator.delegate != event.params.transcoder.toHex()
   ) {
     return
@@ -40,7 +40,7 @@ export function updatePollTallyOnReward(event: RewardEvent): void {
   let transcoder = Transcoder.load(event.params.transcoder.toHex())
 
   // update vote stakes
-  if (voterAddress == event.params.transcoder.toHex()) {
+  if (transcoder.status == 'Registered') {
     vote.voteStake = transcoder.totalStake
   } else {
     let bondingManager = BondingManager.bind(event.address)

--- a/packages/subgraph/test/integration/test.js
+++ b/packages/subgraph/test/integration/test.js
@@ -422,12 +422,6 @@ contract('Subgraph Integration Tests', accounts => {
     await tallyPollAndCheckResult()
   })
 
-  it('correctly tallies poll after transcoder 1 claims earnings', async () => {
-    await BondingManager.methods.reward().send({ from: transcoder1 })
-    await waitForSubgraphToBeSynced()
-    await tallyPollAndCheckResult()
-  })
-
   it('correctly tallies poll after transcoder 2 calls reward', async () => {
     await BondingManager.methods.reward().send({ from: transcoder2 })
     await waitForSubgraphToBeSynced()
@@ -589,14 +583,14 @@ contract('Subgraph Integration Tests', accounts => {
     await tallyPollAndCheckResult()
   })
 
-  it('correctly tallies poll after delegator 3 claims earnings', async () => {
+  it('correctly tallies poll after delegator 5 claims earnings', async () => {
     await mineAndInitializeRound(roundLength)
-    await BondingManager.methods.reward().send({ from: transcoder1 })
+    await BondingManager.methods.reward().send({ from: delegator2 })
     const currentRound = await RoundsManager.methods.currentRound().call()
 
     await BondingManager.methods
       .claimEarnings(currentRound)
-      .send({ from: delegator3 })
+      .send({ from: delegator5 })
 
     await waitForSubgraphToBeSynced()
     await tallyPollAndCheckResult()

--- a/packages/subgraph/test/integration/test.js
+++ b/packages/subgraph/test/integration/test.js
@@ -116,6 +116,7 @@ contract('Subgraph Integration Tests', accounts => {
   const voteMap = ['Yes', 'No']
 
   let transcoder1
+  let transcoder2
   let delegator1
   let delegator2
   let delegator3
@@ -414,9 +415,21 @@ contract('Subgraph Integration Tests', accounts => {
     }
   })
 
-  it('correctly tallies poll after reward', async () => {
+  it('correctly tallies poll after transcoder 1 calls reward', async () => {
     await mineAndInitializeRound(roundLength)
     await BondingManager.methods.reward().send({ from: transcoder1 })
+    await waitForSubgraphToBeSynced()
+    await tallyPollAndCheckResult()
+  })
+
+  it('correctly tallies poll after transcoder 1 claims earnings', async () => {
+    await BondingManager.methods.reward().send({ from: transcoder1 })
+    await waitForSubgraphToBeSynced()
+    await tallyPollAndCheckResult()
+  })
+
+  it('correctly tallies poll after transcoder 2 calls reward', async () => {
+    await BondingManager.methods.reward().send({ from: transcoder2 })
     await waitForSubgraphToBeSynced()
     await tallyPollAndCheckResult()
   })
@@ -572,6 +585,19 @@ contract('Subgraph Integration Tests', accounts => {
       overrides: [],
     }
     voters[delegator2].overrides.push(delegator5)
+    await waitForSubgraphToBeSynced()
+    await tallyPollAndCheckResult()
+  })
+
+  it('correctly tallies poll after delegator 3 claims earnings', async () => {
+    await mineAndInitializeRound(roundLength)
+    await BondingManager.methods.reward().send({ from: transcoder1 })
+    const currentRound = await RoundsManager.methods.currentRound().call()
+
+    await BondingManager.methods
+      .claimEarnings(currentRound)
+      .send({ from: delegator3 })
+
     await waitForSubgraphToBeSynced()
     await tallyPollAndCheckResult()
   })

--- a/packages/subgraph/test/integration/test.js
+++ b/packages/subgraph/test/integration/test.js
@@ -537,7 +537,7 @@ contract('Subgraph Integration Tests', accounts => {
   })
 
   it('correctly tallies poll after delegator 5 bonds with unregistered transcoder (delegate 2)', async () => {
-    let bondAmount = new BN(1000).times(TOKEN_UNIT)
+    let bondAmount = 1000
     await Token.methods.approve(bondingManagerAddress, bondAmount).send({
       from: delegator5,
     })
@@ -585,6 +585,7 @@ contract('Subgraph Integration Tests', accounts => {
 
   it('correctly tallies poll after delegator 5 claims earnings', async () => {
     await mineAndInitializeRound(roundLength)
+    await BondingManager.methods.reward().send({ from: transcoder1 })
     await BondingManager.methods.reward().send({ from: delegator2 })
     const currentRound = await RoundsManager.methods.currentRound().call()
 

--- a/packages/subgraph/test/integration/test.js
+++ b/packages/subgraph/test/integration/test.js
@@ -537,7 +537,7 @@ contract('Subgraph Integration Tests', accounts => {
   })
 
   it('correctly tallies poll after delegator 5 bonds with unregistered transcoder (delegate 2)', async () => {
-    let bondAmount = 1000
+    let bondAmount = new BN(1000).times(TOKEN_UNIT)
     await Token.methods.approve(bondingManagerAddress, bondAmount).send({
       from: delegator5,
     })


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR removes an unnecessary `getDelegator()` contract call from the subgraph's reward handler
