### PR TITLE
start and stop polling based on page visibility

### DIFF
--- a/packages/explorer-2.0/components/HistoryView/index.tsx
+++ b/packages/explorer-2.0/components/HistoryView/index.tsx
@@ -13,9 +13,9 @@ import Approve from '../../public/img/approve.svg'
 import Play from '../../public/img/play.svg'
 import moment from 'moment'
 import InfiniteScroll from 'react-infinite-scroll-component'
+import historyQuery from '../../queries/historyView.gql'
 
 export default () => {
-  const historyQuery = require('../../queries/historyView.gql')
   const router = useRouter()
   const query = router.query
   const account = query.account as string

--- a/packages/explorer-2.0/components/RoundStatus/index.tsx
+++ b/packages/explorer-2.0/components/RoundStatus/index.tsx
@@ -18,7 +18,12 @@ const GET_ROUND_MODAL_STATUS = gql`
 
 export default () => {
   const { data: modalData } = useQuery(GET_ROUND_MODAL_STATUS)
-  const { data: protocolData, loading: protocolDataloading } = useQuery(
+  const {
+    data: protocolData,
+    loading: protocolDataloading,
+    startPolling: startPollingProtocol,
+    stopPolling: stopPollingProtocol,
+  } = useQuery(
     gql`
       {
         protocol(id: "0") {
@@ -35,7 +40,12 @@ export default () => {
       pollInterval: 60000,
     },
   )
-  const { data: blockData, loading: blockDataLoading } = useQuery(
+  const {
+    data: blockData,
+    loading: blockDataLoading,
+    startPolling: startPollingBlock,
+    stopPolling: stopPollingBlock,
+  } = useQuery(
     gql`
       {
         block
@@ -181,9 +191,7 @@ export default () => {
             </strong>{' '}
             and approximately{' '}
             <strong sx={{ borderBottom: '1px dashed', borderColor: 'text' }}>
-              {moment()
-                .add(timeRemaining, 'seconds')
-                .fromNow(true)}
+              {moment().add(timeRemaining, 'seconds').fromNow(true)}
             </strong>{' '}
             remaining until the current round ends and round{' '}
             <strong sx={{ borderBottom: '1px dashed', borderColor: 'text' }}>

--- a/packages/explorer-2.0/components/RoundStatus/index.tsx
+++ b/packages/explorer-2.0/components/RoundStatus/index.tsx
@@ -9,6 +9,8 @@ import { useThemeUI } from 'theme-ui'
 import { buildStyles } from 'react-circular-progressbar'
 import { MdCheck, MdClose } from 'react-icons/md'
 import moment from 'moment'
+import { useEffect } from 'react'
+import { usePageVisibility } from '../../hooks'
 
 const GET_ROUND_MODAL_STATUS = gql`
   {
@@ -17,7 +19,9 @@ const GET_ROUND_MODAL_STATUS = gql`
 `
 
 export default () => {
+  const isVisible = usePageVisibility()
   const { data: modalData } = useQuery(GET_ROUND_MODAL_STATUS)
+  const pollInterval = 60000
   const {
     data: protocolData,
     loading: protocolDataloading,
@@ -37,7 +41,7 @@ export default () => {
       }
     `,
     {
-      pollInterval: 60000,
+      pollInterval,
     },
   )
   const {
@@ -52,12 +56,23 @@ export default () => {
       }
     `,
     {
-      pollInterval: 60000,
+      pollInterval,
     },
   )
 
   const { theme } = useThemeUI()
   const client = useApolloClient()
+
+  useEffect(() => {
+    if (!isVisible) {
+      stopPollingProtocol()
+      stopPollingBlock()
+    } else {
+      startPollingProtocol(pollInterval)
+      startPollingBlock(pollInterval)
+    }
+  }, [isVisible])
+
   const close = () => {
     client.writeData({
       data: {

--- a/packages/explorer-2.0/components/StakingGuide/Step4.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/Step4.tsx
@@ -7,9 +7,9 @@ import Button from '../Button'
 import Utils from 'web3-utils'
 import { useWeb3React } from '@web3-react/core'
 import { useApolloClient, useQuery } from '@apollo/react-hooks'
+import accountQuery from '../../queries/account.gql'
 
 export default ({ goTo, nextStep }) => {
-  const accountQuery = require('../../queries/account.gql')
   const client = useApolloClient()
   const context = useWeb3React()
   const [copied, setCopied] = useState(false)

--- a/packages/explorer-2.0/components/StakingGuide/Step5.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/Step5.tsx
@@ -1,19 +1,18 @@
 import { useEffect, useContext } from 'react'
 import { Styled } from 'theme-ui'
 import Button from '../Button'
-import { useWeb3Mutation } from '../../hooks'
-import Spinner from '../Spinner'
-import { Flex } from 'theme-ui'
+import { usePageVisibility, useWeb3Mutation } from '../../hooks'
 import Router from 'next/router'
-import gql from 'graphql-tag'
 import { MAXIUMUM_VALUE_UINT256 } from '../../lib/utils'
 import { useWeb3React } from '@web3-react/core'
 import { MutationsContext } from '../../contexts'
 import { useQuery } from '@apollo/react-hooks'
+import accountQuery from '../../queries/account.gql'
 
 export default ({ goTo, nextStep }) => {
-  const accountQuery = require('../../queries/account.gql')
   const context = useWeb3React()
+  const isVisible = usePageVisibility()
+  const pollInterval = 20000
   const { approve }: any = useContext(MutationsContext)
   const { data: dataMyAccount, startPolling, stopPolling } = useQuery(
     accountQuery,
@@ -21,11 +20,19 @@ export default ({ goTo, nextStep }) => {
       variables: {
         account: context?.account?.toLowerCase(),
       },
-      pollInterval: 20000,
+      pollInterval,
       skip: !context.active, // skip this query if wallet not connected
       ssr: false,
     },
   )
+
+  useEffect(() => {
+    if (!isVisible) {
+      stopPolling()
+    } else {
+      startPolling(pollInterval)
+    }
+  }, [isVisible])
 
   useEffect(() => {
     async function goToNextStep() {

--- a/packages/explorer-2.0/components/StakingGuide/Step5.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/Step5.tsx
@@ -15,14 +15,17 @@ export default ({ goTo, nextStep }) => {
   const accountQuery = require('../../queries/account.gql')
   const context = useWeb3React()
   const { approve }: any = useContext(MutationsContext)
-  const { data: dataMyAccount } = useQuery(accountQuery, {
-    variables: {
-      account: context?.account?.toLowerCase(),
+  const { data: dataMyAccount, startPolling, stopPolling } = useQuery(
+    accountQuery,
+    {
+      variables: {
+        account: context?.account?.toLowerCase(),
+      },
+      pollInterval: 20000,
+      skip: !context.active, // skip this query if wallet not connected
+      ssr: false,
     },
-    pollInterval: 20000,
-    skip: !context.active, // skip this query if wallet not connected
-    ssr: false,
-  })
+  )
 
   useEffect(() => {
     async function goToNextStep() {

--- a/packages/explorer-2.0/components/StakingGuide/index.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/index.tsx
@@ -14,9 +14,9 @@ import Step6 from './Step6'
 import Step7 from './Step7'
 import gql from 'graphql-tag'
 import { Box } from 'theme-ui'
+import accountQuery from '../../queries/account.gql'
 
 const Tour: any = dynamic(() => import('reactour'), { ssr: false })
-
 const GET_TOUR_OPEN = gql`
   {
     tourOpen @client
@@ -24,7 +24,6 @@ const GET_TOUR_OPEN = gql`
 `
 
 export default ({ children, ...props }) => {
-  const accountQuery = require('../../queries/account.gql')
   const client = useApolloClient()
   const [open, setOpen] = useState(false)
   const [tourKey, setTourKey] = useState(0)
@@ -90,7 +89,7 @@ export default ({ children, ...props }) => {
         },
       },
       {
-        action: node => node.focus(),
+        action: (node) => node.focus(),
         selector: '.tour-step-6',
         content: ({ goTo }) => {
           return <Step6 goTo={goTo} nextStep={nextStep} />
@@ -98,7 +97,7 @@ export default ({ children, ...props }) => {
         style: tourStyles,
       },
       {
-        action: node => node.focus(),
+        action: (node) => node.focus(),
         selector: '.tour-step-7',
         content: () => {
           return <Step7 />
@@ -139,7 +138,7 @@ export default ({ children, ...props }) => {
           })
           setTourKey(tourKey + 1)
         }}
-        getCurrentStep={curr => {
+        getCurrentStep={(curr) => {
           setNextStep(curr + 1)
         }}
         steps={steps}

--- a/packages/explorer-2.0/components/TokenholdersView/index.tsx
+++ b/packages/explorer-2.0/components/TokenholdersView/index.tsx
@@ -5,6 +5,8 @@ import gql from 'graphql-tag'
 import Spinner from '../Spinner'
 import Tokenholders from '../Tokenholders'
 import InfiniteScroll from 'react-infinite-scroll-component'
+import { useEffect } from 'react'
+import { usePageVisibility } from '../../hooks'
 
 const GET_DATA = gql`
   query($account: ID!, $first: Int!, $skip: Int!) {
@@ -37,31 +39,32 @@ const GET_DATA = gql`
 
 export default () => {
   const router = useRouter()
+  const isVisible = usePageVisibility()
   const query = router.query
   const account = query.account as string
-
-  const {
-    data,
-    loading,
-    error,
-    fetchMore,
-    startPolling,
-    stopPolling,
-  } = useQuery(GET_DATA, {
-    variables: {
-      account: account.toLowerCase(),
-      address: account.toLowerCase(),
-      first: 10,
-      skip: 0,
+  const pollInterval = 20000
+  const { data, loading, fetchMore, startPolling, stopPolling } = useQuery(
+    GET_DATA,
+    {
+      variables: {
+        account: account.toLowerCase(),
+        address: account.toLowerCase(),
+        first: 10,
+        skip: 0,
+      },
+      ssr: false,
+      pollInterval,
+      notifyOnNetworkStatusChange: true,
     },
-    ssr: false,
-    pollInterval: 20000,
-    notifyOnNetworkStatusChange: true,
-  })
+  )
 
-  if (error) {
-    console.error(error)
-  }
+  useEffect(() => {
+    if (!isVisible) {
+      stopPolling()
+    } else {
+      startPolling(pollInterval)
+    }
+  }, [isVisible])
 
   if (loading && !data) {
     return (

--- a/packages/explorer-2.0/components/TokenholdersView/index.tsx
+++ b/packages/explorer-2.0/components/TokenholdersView/index.tsx
@@ -40,7 +40,14 @@ export default () => {
   const query = router.query
   const account = query.account as string
 
-  const { data, loading, error, fetchMore, stopPolling } = useQuery(GET_DATA, {
+  const {
+    data,
+    loading,
+    error,
+    fetchMore,
+    startPolling,
+    stopPolling,
+  } = useQuery(GET_DATA, {
     variables: {
       account: account.toLowerCase(),
       address: account.toLowerCase(),

--- a/packages/explorer-2.0/hooks/index.tsx
+++ b/packages/explorer-2.0/hooks/index.tsx
@@ -4,6 +4,7 @@ import gql from 'graphql-tag'
 import { useWeb3React } from '@web3-react/core'
 import { Injected } from '../lib/connectors'
 import { isMobile } from 'react-device-detect'
+import submittedTxsQuery from '../queries/transactions.gql'
 
 export function useWeb3Mutation(mutation, options) {
   const client = useApolloClient()
@@ -70,8 +71,7 @@ export function useWeb3Mutation(mutation, options) {
     },
   )
 
-  const GET_SUBMITTED_TXS = require('../queries/transactions.gql')
-  const { data: transactionsData } = useQuery(GET_SUBMITTED_TXS)
+  const { data: transactionsData } = useQuery(submittedTxsQuery)
 
   useEffect(() => {
     if (data) {

--- a/packages/explorer-2.0/hooks/index.tsx
+++ b/packages/explorer-2.0/hooks/index.tsx
@@ -78,7 +78,7 @@ export function useWeb3Mutation(mutation, options) {
       client.writeData({
         data: {
           txs: [
-            ...transactionsData.txs.filter(t => t.txHash !== data.tx.txHash),
+            ...transactionsData.txs.filter((t) => t.txHash !== data.tx.txHash),
             {
               __typename: mutation.definitions[0].name.value,
               txHash: data.tx.txHash,
@@ -168,7 +168,7 @@ export function useInactiveListener(suppress = false) {
         activate(Injected, undefined, true).catch(() => {})
       }
 
-      const handleAccountsChanged = accounts => {
+      const handleAccountsChanged = (accounts) => {
         if (accounts.length > 0) {
           // eat errors
           activate(Injected, undefined, true).catch(() => {})
@@ -201,7 +201,7 @@ export function useMutations() {
   const mutations = require('../mutations').default
   const context = useWeb3React()
   let mutationsObj: any = {}
-  Object.keys(mutations).map(key => {
+  Object.keys(mutations).map((key) => {
     const { mutate } = useWeb3Mutation(mutations[key], {
       context: {
         library: context?.library,
@@ -241,4 +241,41 @@ export function useTimeEstimate({ startTime, estimate }) {
   }, [timeLeft])
 
   return { timeLeft }
+}
+
+export function getBrowserVisibilityProp() {
+  if (typeof document.hidden !== 'undefined') {
+    // Opera 12.10 and Firefox 18 and later support
+    return 'visibilitychange'
+  } else if (typeof document['msHidden'] !== 'undefined') {
+    return 'msvisibilitychange'
+  } else if (typeof document['webkitHidden'] !== 'undefined') {
+    return 'webkitvisibilitychange'
+  }
+}
+export function getBrowserDocumentHiddenProp() {
+  if (typeof document.hidden !== 'undefined') {
+    return 'hidden'
+  } else if (typeof document['msHidden'] !== 'undefined') {
+    return 'msHidden'
+  } else if (typeof document['webkitHidden'] !== 'undefined') {
+    return 'webkitHidden'
+  }
+}
+
+export function getIsDocumentVisible() {
+  return !process.browser || !document[getBrowserDocumentHiddenProp()]
+}
+
+export function usePageVisibility() {
+  const [isVisible, setIsVisible] = useState(getIsDocumentVisible())
+  const onVisibilityChange = () => setIsVisible(getIsDocumentVisible())
+  useEffect(() => {
+    const visibilityChange = getBrowserVisibilityProp()
+    document.addEventListener(visibilityChange, onVisibilityChange, false)
+    return () => {
+      document.removeEventListener(visibilityChange, onVisibilityChange)
+    }
+  })
+  return isVisible
 }

--- a/packages/explorer-2.0/lib/utils.tsx
+++ b/packages/explorer-2.0/lib/utils.tsx
@@ -1,5 +1,7 @@
 import { Delegator, Round, UnbondingLock } from '../@types'
 import Utils from 'web3-utils'
+import url from 'url'
+import parseDomain from 'parse-domain'
 
 export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
 
@@ -115,10 +117,7 @@ export const textTruncate = (str, length, ending) => {
   }
 }
 
-const url = require('url')
-const parseDomain = require('parse-domain')
-
-const networksTypes = {
+export const networksTypes = {
   1: 'mainnet',
   2: 'morden',
   3: 'ropsten',

--- a/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
+++ b/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
@@ -30,7 +30,13 @@ const Account = () => {
   const { query, asPath } = router
   const slug = query.slug
 
-  const { data, loading, refetch } = useQuery(accountViewQuery, {
+  const {
+    data,
+    loading,
+    refetch,
+    startPolling: startPollingAccount,
+    stopPolling: stopPollingAccount,
+  } = useQuery(accountViewQuery, {
     variables: {
       account: query.account.toString().toLowerCase(),
     },
@@ -38,7 +44,12 @@ const Account = () => {
     ssr: false,
   })
 
-  const { data: dataTranscoders, loading: loadingTranscoders } = useQuery(
+  const {
+    data: dataTranscoders,
+    loading: loadingTranscoders,
+    startPolling: startPollingOrchestrators,
+    stopPolling: stopPollingOrchestrators,
+  } = useQuery(
     gql`
       {
         transcoders(
@@ -57,17 +68,19 @@ const Account = () => {
     },
   )
 
-  const { data: dataMyAccount, loading: loadingMyAccount } = useQuery(
-    accountQuery,
-    {
-      variables: {
-        account: context?.account?.toLowerCase(),
-      },
-      pollInterval: 20000,
-      skip: !context.active, // skip this query if wallet not connected
-      ssr: false,
+  const {
+    data: dataMyAccount,
+    loading: loadingMyAccount,
+    startPolling: startPollingMyAccount,
+    stopPolling: stopPollingMyAccount,
+  } = useQuery(accountQuery, {
+    variables: {
+      account: context?.account?.toLowerCase(),
     },
-  )
+    pollInterval: 20000,
+    skip: !context.active, // skip this query if wallet not connected
+    ssr: false,
+  })
 
   const SELECTED_STAKING_ACTION = gql`
     {

--- a/packages/explorer-2.0/pages/index.tsx
+++ b/packages/explorer-2.0/pages/index.tsx
@@ -11,11 +11,16 @@ import ClaimBanner from '../components/ClaimBanner'
 import { Box } from 'theme-ui'
 import Approve from '../components/Approve'
 import Utils from 'web3-utils'
+import { useEffect } from 'react'
+import { usePageVisibility } from '../hooks'
+import orchestratorsViewQuery from '../queries/orchestratorsView.gql'
+import accountQuery from '../queries/account.gql'
 
 const Home = () => {
-  const orchestratorsViewQuery = require('../queries/orchestratorsView.gql')
-  const accountQuery = require('../queries/account.gql')
   const context = useWeb3React()
+  const isVisible = usePageVisibility()
+  const pollInterval = 20000
+
   const variables = {
     orderBy: 'totalStake',
     orderDirection: 'desc',
@@ -27,11 +32,11 @@ const Home = () => {
     data,
     loading,
     startPolling: startPollingOrchestrators,
-    stopPolling: stopPollingOrchesetrators,
+    stopPolling: stopPollingOrchestrators,
   } = useQuery(orchestratorsViewQuery, {
     variables,
     ssr: false,
-    pollInterval: 20000,
+    pollInterval,
   })
   const {
     data: dataMyAccount,
@@ -42,10 +47,20 @@ const Home = () => {
     variables: {
       account: context?.account?.toLowerCase(),
     },
-    pollInterval: 20000,
+    pollInterval,
     skip: !context.active,
     ssr: false,
   })
+
+  useEffect(() => {
+    if (!isVisible) {
+      stopPollingOrchestrators()
+      stopPollingMyAccount()
+    } else {
+      startPollingOrchestrators(pollInterval)
+      startPollingMyAccount(pollInterval)
+    }
+  }, [isVisible])
 
   return (
     <>

--- a/packages/explorer-2.0/pages/index.tsx
+++ b/packages/explorer-2.0/pages/index.tsx
@@ -23,22 +23,29 @@ const Home = () => {
       status: 'Registered',
     },
   }
-  const { data, loading } = useQuery(orchestratorsViewQuery, {
+  const {
+    data,
+    loading,
+    startPolling: startPollingOrchestrators,
+    stopPolling: stopPollingOrchesetrators,
+  } = useQuery(orchestratorsViewQuery, {
     variables,
     ssr: false,
     pollInterval: 20000,
   })
-  const { data: dataMyAccount, loading: loadingMyAccount } = useQuery(
-    accountQuery,
-    {
-      variables: {
-        account: context?.account?.toLowerCase(),
-      },
-      pollInterval: 20000,
-      skip: !context.active,
-      ssr: false,
+  const {
+    data: dataMyAccount,
+    loading: loadingMyAccount,
+    startPolling: startPollingMyAccount,
+    stopPolling: stopPollingMyAccount,
+  } = useQuery(accountQuery, {
+    variables: {
+      account: context?.account?.toLowerCase(),
     },
-  )
+    pollInterval: 20000,
+    skip: !context.active,
+    ssr: false,
+  })
 
   return (
     <>

--- a/packages/explorer-2.0/pages/voting/[poll].tsx
+++ b/packages/explorer-2.0/pages/voting/[poll].tsx
@@ -34,7 +34,11 @@ const Poll = () => {
   const [pollData, setPollData] = useState(null)
   const { query } = router
   const pollId = query.poll.toString().toLowerCase()
-  const { data } = useQuery(pollQuery, {
+  const {
+    data,
+    startPolling: startPollingPoll,
+    stopPolling: stopPollingPoll,
+  } = useQuery(pollQuery, {
     variables: {
       id: pollId,
     },
@@ -42,7 +46,11 @@ const Poll = () => {
     ssr: false,
   })
 
-  const { data: myAccountData } = useQuery(accountQuery, {
+  const {
+    data: myAccountData,
+    startPolling: startPollingMyAccount,
+    stopPolling: stopPollingMyAccount,
+  } = useQuery(accountQuery, {
     variables: {
       account: context?.account?.toLowerCase(),
     },
@@ -50,7 +58,11 @@ const Poll = () => {
     skip: !context.active,
   })
 
-  const { data: voteData } = useQuery(voteQuery, {
+  const {
+    data: voteData,
+    startPolling: startPollingVote,
+    stopPolling: stopPollingVote,
+  } = useQuery(voteQuery, {
     variables: {
       id: `${context?.account?.toLowerCase()}-${pollId}`,
     },
@@ -58,7 +70,11 @@ const Poll = () => {
     skip: !context.active,
   })
 
-  const { data: delegateVoteData } = useQuery(voteQuery, {
+  const {
+    data: delegateVoteData,
+    startPolling: startPollingDelegate,
+    stopPolling: stopPollingDelegate,
+  } = useQuery(voteQuery, {
     variables: {
       id: `${myAccountData?.delegator?.delegate?.id.toLowerCase()}-${pollId}`,
     },

--- a/packages/explorer-2.0/pages/voting/create-poll.tsx
+++ b/packages/explorer-2.0/pages/voting/create-poll.tsx
@@ -17,10 +17,12 @@ import { useApolloClient } from '@apollo/react-hooks'
 import { MutationsContext } from '../../contexts'
 import Utils from 'web3-utils'
 import Head from 'next/head'
+import { usePageVisibility } from '../../hooks'
 
 const CreatePoll = ({ projectOwner, projectName, gitCommitHash, lips }) => {
   const context = useWeb3React()
   const client = useApolloClient()
+  const isVisible = usePageVisibility()
   const [sufficientAllowance, setSufficientAllowance] = useState(false)
   const [sufficientBalance, setSufficientBalance] = useState(false)
   const ipfs = new IPFS({
@@ -28,6 +30,7 @@ const CreatePoll = ({ projectOwner, projectName, gitCommitHash, lips }) => {
     port: 5001,
     protocol: 'https',
   })
+  const pollInterval = 20000
 
   const accountQuery = gql`
     query($account: ID!) {
@@ -42,12 +45,20 @@ const CreatePoll = ({ projectOwner, projectName, gitCommitHash, lips }) => {
     variables: {
       account: context.account,
     },
-    pollInterval: 10000,
+    pollInterval,
     context: {
       library: context.library,
     },
     skip: !context.account,
   })
+
+  useEffect(() => {
+    if (!isVisible) {
+      stopPolling()
+    } else {
+      startPolling(pollInterval)
+    }
+  }, [isVisible])
 
   useEffect(() => {
     if (data) {

--- a/packages/explorer-2.0/pages/voting/create-poll.tsx
+++ b/packages/explorer-2.0/pages/voting/create-poll.tsx
@@ -38,7 +38,7 @@ const CreatePoll = ({ projectOwner, projectName, gitCommitHash, lips }) => {
     }
   `
 
-  const { data } = useQuery(accountQuery, {
+  const { data, startPolling, stopPolling } = useQuery(accountQuery, {
     variables: {
       account: context.account,
     },

--- a/packages/explorer-2.0/pages/voting/index.tsx
+++ b/packages/explorer-2.0/pages/voting/index.tsx
@@ -13,21 +13,31 @@ import fm from 'front-matter'
 import { useEffect, useState } from 'react'
 import moment from 'moment'
 import Link from 'next/link'
-import gql from 'graphql-tag'
 import Head from 'next/head'
+import { usePageVisibility } from '../../hooks'
+import allPollsQuery from '../../queries/allPolls.gql'
 
 const Voting = () => {
+  const isVisible = usePageVisibility()
+  const pollInterval = 20000
   const ipfs = new IPFS({
     host: 'ipfs.infura.io',
     port: 5001,
     protocol: 'https',
   })
-  const allPollsQuery = require('../../queries/allPolls.gql')
   const [polls, setPolls] = useState([])
   const [loading, setLoading] = useState(true)
   const { data, startPolling, stopPolling } = useQuery(allPollsQuery, {
-    pollInterval: 20000,
+    pollInterval,
   })
+
+  useEffect(() => {
+    if (!isVisible) {
+      stopPolling()
+    } else {
+      startPolling(pollInterval)
+    }
+  }, [isVisible])
 
   useEffect(() => {
     if (data) {

--- a/packages/explorer-2.0/pages/voting/index.tsx
+++ b/packages/explorer-2.0/pages/voting/index.tsx
@@ -25,7 +25,7 @@ const Voting = () => {
   const allPollsQuery = require('../../queries/allPolls.gql')
   const [polls, setPolls] = useState([])
   const [loading, setLoading] = useState(true)
-  const { data } = useQuery(allPollsQuery, {
+  const { data, startPolling, stopPolling } = useQuery(allPollsQuery, {
     pollInterval: 20000,
   })
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
In an effort to reduce Infura usage, this PR uses the browser's page visibility API and Apollo's `stopPolling()` and `startPolling()` methods to poll data *only* when the page is visible (when the browser tab is active).