### PR TITLE
add redeemed ticket events to history view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ coverage
 .nyc_output
 yarn-error.log
 .env
+.env.local
+.env.rinkeby
 .env.build
 .poosh.cache
 

--- a/packages/explorer-2.0/components/HistoryView/index.tsx
+++ b/packages/explorer-2.0/components/HistoryView/index.tsx
@@ -9,6 +9,7 @@ import Unlink from '../../public/img/unlink.svg'
 import Link from '../../public/img/link.svg'
 import Claim from '../../public/img/claim.svg'
 import LPT from '../../public/img/lpt.svg'
+import ETH from '../../public/img/eth.svg'
 import Approve from '../../public/img/approve.svg'
 import Play from '../../public/img/play.svg'
 import moment from 'moment'
@@ -517,6 +518,48 @@ function renderSwitch(transaction: any, i: number) {
                 +{abbreviateNumber(Utils.fromWei(transaction.amount), 3)}
               </span>{' '}
               LPT
+            </div>
+          </Flex>
+        </ListItem>
+      )
+    case 'WinningTicketRedeemed':
+      return (
+        <ListItem
+          sx={{
+            cursor: 'pointer',
+            px: 2,
+            '&:hover': { backgroundColor: 'rgba(255, 255, 255, .04)' },
+          }}
+          onClick={() =>
+            window.open(`https://etherscan.io/tx/${transaction.hash}`, '_blank')
+          }
+          key={i}
+          avatar={
+            <ETH sx={{ width: 20, height: 20, color: 'primary', mr: 2 }} />
+          }
+        >
+          <Flex
+            sx={{
+              width: '100%',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Box>
+              <Box>Redeemed Winning Ticket</Box>
+              <Box sx={{ fontSize: 12, color: 'muted' }}>
+                {moment
+                  .unix(transaction.timestamp)
+                  .format('MM/DD/YYYY h:mm:ss a')}{' '}
+                -- Round #{transaction.round.id}
+              </Box>
+            </Box>
+            <div sx={{ fontSize: 1, ml: 3 }}>
+              {' '}
+              <span sx={{ fontFamily: 'monospace' }}>
+                +{abbreviateNumber(Utils.fromWei(transaction.faceValue), 3)}
+              </span>{' '}
+              ETH
             </div>
           </Flex>
         </ListItem>

--- a/packages/explorer-2.0/public/img/eth.svg
+++ b/packages/explorer-2.0/public/img/eth.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32px" height="48px" viewBox="0 0 32 48" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>eth</title>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="eth" transform="translate(2.000000, 1.000000)" stroke="currentColor" stroke-width="2">
+            <path d="M0,22 L14,0 L28,22 L14,30 L0,22 Z M14,30 L14,0" id="Shape"></path>
+            <path d="M0,27 L14,35 L28,27 L14,46 L0,27 Z M14,46 L14,35 M0,22 L14,16 L28,22" id="Shape"></path>
+        </g>
+    </g>
+</svg>

--- a/packages/explorer-2.0/queries/historyView.gql
+++ b/packages/explorer-2.0/queries/historyView.gql
@@ -100,5 +100,12 @@ query($account: String!, $first: Int!, $skip: Int!) {
         id
       }
     }
+    ... on WinningTicketRedeemed {
+      __typename
+      faceValue
+      round {
+        id
+      }
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -30291,7 +30291,7 @@ pull-window@^2.1.4:
   dependencies:
     looper "^2.0.0"
 
-"pull-ws@github:hugomrdias/pull-ws#fix/bundle-size":
+pull-ws@hugomrdias/pull-ws#fix/bundle-size:
   version "3.3.1"
   resolved "https://codeload.github.com/hugomrdias/pull-ws/tar.gz/8e2ce0bb3b1cd6804828316e937fff8e0bef6225"
   dependencies:


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds the `RedeemedWinningTicket` event to an account's history view.

**Does this pull request close any open issues?**
Closes #809 

**Screenshots (optional):**
<img width="788" alt="Screen Shot 2020-08-31 at 5 58 41 PM" src="https://user-images.githubusercontent.com/555740/91773028-f9bfee80-ebb3-11ea-951c-263a75fbb7dc.png">
