### PR TITLE
throw 404 if page doesn't exist

### DIFF
--- a/packages/explorer-2.0/.gitignore
+++ b/packages/explorer-2.0/.gitignore
@@ -36,7 +36,14 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 .next
+.now
+.vercel
+
+# local env files
 .env
 .env.build
 .env.rinkeby
-.now
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/packages/explorer-2.0/lib/utils.tsx
+++ b/packages/explorer-2.0/lib/utils.tsx
@@ -2,6 +2,7 @@ import { Delegator, Round, UnbondingLock } from '../@types'
 import Utils from 'web3-utils'
 import url from 'url'
 import parseDomain from 'parse-domain'
+import { ethers } from 'ethers'
 
 export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
 
@@ -182,6 +183,9 @@ export const detectNetwork = async (provider) => {
 }
 
 export const checkAddressEquality = (address1, address2) => {
+  if (!isAddress(address1) || !isAddress(address2)) {
+    return false
+  }
   return Utils.toChecksumAddress(address1) === Utils.toChecksumAddress(address2)
 }
 
@@ -396,4 +400,13 @@ export const simulateNewActiveSetOrder = ({
   return transcoders.sort((a, b) =>
     Utils.toBN(b.totalStake).cmp(Utils.toBN(a.totalStake)),
   )
+}
+
+export function isAddress(address) {
+  try {
+    ethers.utils.getAddress(address)
+  } catch (e) {
+    return false
+  }
+  return true
 }

--- a/packages/explorer-2.0/pages/404.tsx
+++ b/packages/explorer-2.0/pages/404.tsx
@@ -1,0 +1,29 @@
+import { Flex, Box } from '@theme-ui/components'
+
+function Error() {
+  return (
+    <Flex
+      sx={{
+        width: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+        bg: 'background',
+      }}
+    >
+      <Box
+        sx={{
+          fontSize: 5,
+          pr: 3,
+          mr: 3,
+          borderRight: '1px solid',
+          borderColor: 'white',
+        }}
+      >
+        404
+      </Box>
+      <p>This page could not be found</p>
+    </Flex>
+  )
+}
+
+export default Error

--- a/packages/explorer-2.0/pages/_error.tsx
+++ b/packages/explorer-2.0/pages/_error.tsx
@@ -1,0 +1,40 @@
+import { Flex, Box } from '@theme-ui/components'
+
+const statusCodes: { [code: number]: string } = {
+  400: 'Bad Request',
+  405: 'Method Not Allowed',
+  500: 'Internal Server Error',
+}
+
+function Error({ statusCode }) {
+  return (
+    <Flex
+      sx={{
+        width: '100%',
+        alignItems: 'center',
+        justifyContent: 'center',
+        bg: 'background',
+      }}
+    >
+      <Box
+        sx={{
+          fontSize: 5,
+          pr: 3,
+          mr: 3,
+          borderRight: '1px solid',
+          borderColor: 'white',
+        }}
+      >
+        {statusCode}
+      </Box>
+      <p>{statusCodes[statusCode]}</p>
+    </Flex>
+  )
+}
+
+Error.getInitialProps = ({ res, err }) => {
+  const statusCode = res ? res.statusCode : err ? err.statusCode : 404
+  return { statusCode }
+}
+
+export default Error

--- a/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
+++ b/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
@@ -12,7 +12,11 @@ import StakingView from '../../../components/StakingView'
 import Spinner from '../../../components/Spinner'
 import Utils from 'web3-utils'
 import { useWeb3React } from '@web3-react/core'
-import { getDelegatorStatus, checkAddressEquality } from '../../../lib/utils'
+import {
+  isAddress,
+  getDelegatorStatus,
+  checkAddressEquality,
+} from '../../../lib/utils'
 import HistoryView from '../../../components/HistoryView'
 import { withApollo } from '../../../lib/apollo'
 import BottomDrawer from '../../../components/BottomDrawer'
@@ -24,6 +28,7 @@ import { usePageVisibility } from '../../../hooks'
 import { useEffect } from 'react'
 import accountViewQuery from '../../../queries/accountView.gql'
 import accountQuery from '../../../queries/account.gql'
+import FourZeroFour from '../../404'
 
 const Account = () => {
   const router = useRouter()
@@ -34,6 +39,10 @@ const Account = () => {
   const slug = query.slug
   const pollInterval = 20000
 
+  if (!query?.account || !isAddress(query?.account.toString())) {
+    return <FourZeroFour />
+  }
+
   const {
     data,
     loading,
@@ -42,7 +51,7 @@ const Account = () => {
     stopPolling: stopPollingAccount,
   } = useQuery(accountViewQuery, {
     variables: {
-      account: query.account.toString().toLowerCase(),
+      account: query?.account.toString().toLowerCase(),
     },
     pollInterval,
     ssr: false,
@@ -127,7 +136,7 @@ const Account = () => {
 
   const isMyAccount = checkAddressEquality(
     context?.account,
-    query.account.toString(),
+    query?.account.toString(),
   )
   const isStaked = !!data?.delegator?.delegate
   const hasLivepeerToken =
@@ -143,11 +152,11 @@ const Account = () => {
   }
 
   const isMyDelegate =
-    query.account.toString() === dataMyAccount?.delegator?.delegate?.id
+    query?.account.toString() === dataMyAccount?.delegator?.delegate?.id
 
   const tabs: Array<TabType> = getTabs(
     role,
-    query.account.toString(),
+    query?.account.toString(),
     asPath,
     isMyDelegate,
   )
@@ -184,7 +193,7 @@ const Account = () => {
           />
         )}
         <Profile
-          account={query.account.toString()}
+          account={query?.account.toString()}
           delegator={data.delegator}
           threeBoxSpace={data.threeBoxSpace}
           hasLivepeerToken={hasLivepeerToken}

--- a/packages/explorer-2.0/pages/voting/[poll].tsx
+++ b/packages/explorer-2.0/pages/voting/[poll].tsx
@@ -26,6 +26,7 @@ import { usePageVisibility } from '../../hooks'
 import pollQuery from '../../queries/poll.gql'
 import accountQuery from '../../queries/account.gql'
 import voteQuery from '../../queries/vote.gql'
+import FourZeroFour from '../404'
 
 const Poll = () => {
   const router = useRouter()
@@ -35,6 +36,11 @@ const Poll = () => {
   const isVisible = usePageVisibility()
   const [pollData, setPollData] = useState(null)
   const { query } = router
+
+  if (!query?.poll) {
+    return <FourZeroFour />
+  }
+
   const pollId = query.poll.toString().toLowerCase()
   const pollInterval = 20000
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR throws a 404 on the `/[account]` and `/[poll]` routes if the page doesn't exist.

**How did you test each of these updates (required)**
Visited the endpoint `/accounts/%5Baccount%5D/%5Bslug%5D` and `/voting/%5Bpoll%5D` and confirmed seeing a 404 page.

**Screenshots**
![image](https://user-images.githubusercontent.com/555740/92526765-ffd94f00-f1f3-11ea-9fdf-c0ae793f4c63.png)
