### PR TITLE
Name default components

### DIFF
--- a/packages/explorer-2.0/components/AccountCell/index.tsx
+++ b/packages/explorer-2.0/components/AccountCell/index.tsx
@@ -23,7 +23,7 @@ const ActiveCircle = ({ active }, props) => {
   )
 }
 
-export default ({ threeBoxSpace, active, address }) => {
+const Index = ({ threeBoxSpace, active, address }) => {
   return (
     <Flex sx={{ alignItems: 'center' }}>
       <Flex sx={{ minWidth: 40, minHeight: 40, position: 'relative', mr: 2 }}>
@@ -101,3 +101,5 @@ export default ({ threeBoxSpace, active, address }) => {
     </Flex>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Approve/index.tsx
+++ b/packages/explorer-2.0/components/Approve/index.tsx
@@ -8,7 +8,7 @@ import { useWeb3React } from '@web3-react/core'
 import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 
-export default ({ account, banner = true }) => {
+const Index = ({ account, banner = true }) => {
   const context = useWeb3React()
   const client = useApolloClient()
   const { approve }: any = useContext(MutationsContext)
@@ -72,3 +72,5 @@ export default ({ account, banner = true }) => {
 
   return element
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Banner/index.tsx
+++ b/packages/explorer-2.0/components/Banner/index.tsx
@@ -8,7 +8,7 @@ interface Props {
   sx?: object
 }
 
-export default ({ open = true, label, button, ...props }: Props) =>
+const Index = ({ open = true, label, button, ...props }: Props) =>
   !open ? null : (
     <Box
       sx={{
@@ -27,3 +27,5 @@ export default ({ open = true, label, button, ...props }: Props) =>
       </Box>
     </Box>
   )
+
+export default Index

--- a/packages/explorer-2.0/components/BottomDrawer/index.tsx
+++ b/packages/explorer-2.0/components/BottomDrawer/index.tsx
@@ -14,7 +14,8 @@ const slideUp = keyframes`
     transform: translate3d(0,0%,0);
   }
 `
-export default ({ children }) => {
+
+const Index = ({ children }) => {
   const client = useApolloClient()
   const { width } = useWindowSize()
 
@@ -67,3 +68,5 @@ export default ({ children }) => {
     </Box>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Button/index.tsx
+++ b/packages/explorer-2.0/components/Button/index.tsx
@@ -1,6 +1,6 @@
 import { Styled } from 'theme-ui'
 
-export default ({
+const Index = ({
   as = 'button',
   variant = 'primary',
   size = 'normal',
@@ -30,3 +30,5 @@ export default ({
     }}
   />
 )
+
+export default Index

--- a/packages/explorer-2.0/components/CampaignView/index.tsx
+++ b/packages/explorer-2.0/components/CampaignView/index.tsx
@@ -14,7 +14,7 @@ import {
   MenuItemRadio,
 } from '@modulz/radix/dist/index.es'
 
-export default ({ currentRound, transcoder }) => {
+const Index = ({ currentRound, transcoder }) => {
   const [isPriceSettingOpen, setIsPriceSettingOpen] = useState(false)
   const targetRef = useRef()
   const [priceSetting, setPriceSetting] = useState('1t pixels')
@@ -296,3 +296,5 @@ export default ({ currentRound, transcoder }) => {
     </Box>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Card/index.tsx
+++ b/packages/explorer-2.0/components/Card/index.tsx
@@ -1,6 +1,6 @@
 import { Flex } from 'theme-ui'
 
-export default ({
+const Index = ({
   title = null,
   subtitle = null,
   children = null,
@@ -29,3 +29,5 @@ export default ({
     </Flex>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Checkbox/index.tsx
+++ b/packages/explorer-2.0/components/Checkbox/index.tsx
@@ -1,6 +1,6 @@
 import Check from '../../public/img/check.svg'
 
-export default ({ isActive = false, ...props }) => (
+const Index = ({ isActive = false, ...props }) => (
   <div
     {...props}
     sx={{
@@ -19,3 +19,5 @@ export default ({ isActive = false, ...props }) => (
     {isActive && <Check sx={{ width: 16, height: 16 }} />}
   </div>
 )
+
+export default Index

--- a/packages/explorer-2.0/components/Chip/index.tsx
+++ b/packages/explorer-2.0/components/Chip/index.tsx
@@ -1,4 +1,4 @@
-export default ({ label, variant = 'primary', ...props }) => (
+const Index = ({ label, variant = 'primary', ...props }) => (
   <div
     sx={{
       borderRadius: 1000,
@@ -14,3 +14,5 @@ export default ({ label, variant = 'primary', ...props }) => (
     {label}
   </div>
 )
+
+export default Index

--- a/packages/explorer-2.0/components/CircularProgressBar/index.tsx
+++ b/packages/explorer-2.0/components/CircularProgressBar/index.tsx
@@ -2,7 +2,7 @@ import { CircularProgressbar } from 'react-circular-progressbar'
 import { Box } from 'theme-ui'
 import { Flex } from '@theme-ui/components'
 
-export default props => {
+const Index = (props) => {
   const { children, ...otherProps } = props
 
   return (
@@ -31,3 +31,5 @@ export default props => {
     </Box>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Drawer/index.tsx
+++ b/packages/explorer-2.0/components/Drawer/index.tsx
@@ -11,7 +11,7 @@ import RoundStatus from '../RoundStatus'
 import { useApolloClient } from '@apollo/react-hooks'
 import UniswapModal from '../UniswapModal'
 
-export default ({
+const Index = ({
   items = [],
   open,
   onDrawerOpen,
@@ -250,3 +250,5 @@ export default ({
     </>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/EditProfile/index.tsx
+++ b/packages/explorer-2.0/components/EditProfile/index.tsx
@@ -58,7 +58,7 @@ function hasExistingProfile(profile) {
   return profile.name || profile.website || profile.description || profile.image
 }
 
-export default ({ threeBoxSpace, refetch, account }: Props) => {
+const Index = ({ threeBoxSpace, refetch, account }: Props) => {
   const context = useWeb3React()
   const { register, handleSubmit, formState, watch } = useForm()
   const [previewImage, setPreviewImage] = useState(null)
@@ -117,7 +117,7 @@ export default ({ threeBoxSpace, refetch, account }: Props) => {
     })()
   }, [debouncedSignature, debouncedEthereumAccount, message])
 
-  reader.onload = function(e) {
+  reader.onload = function (e) {
     setPreviewImage(e.target.result)
   }
 
@@ -639,3 +639,5 @@ export default ({ threeBoxSpace, refetch, account }: Props) => {
     </>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/ExternalAccount/index.tsx
+++ b/packages/explorer-2.0/components/ExternalAccount/index.tsx
@@ -12,7 +12,7 @@ const REMOVE_ADDRESS_LINK = gql`
   }
 `
 
-export default ({ threeBoxSpace, refetch, children }) => {
+const Index = ({ threeBoxSpace, refetch, children }) => {
   const [open, setOpen] = useState(false)
   const context = useWeb3React()
   const [removeAddressLink] = useMutation(REMOVE_ADDRESS_LINK)
@@ -132,3 +132,5 @@ export default ({ threeBoxSpace, refetch, children }) => {
     </div>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/FeesView/index.tsx
+++ b/packages/explorer-2.0/components/FeesView/index.tsx
@@ -9,7 +9,7 @@ import Help from '../../public/img/help.svg'
 import Link from 'next/link'
 import WithdrawFees from '../WithdrawFees'
 
-export default ({ delegator, currentRound, isMyAccount }) => {
+const Index = ({ delegator, currentRound, isMyAccount }) => {
   if (!delegator?.bondedAmount) {
     if (isMyAccount) {
       return (
@@ -189,3 +189,5 @@ export default ({ delegator, currentRound, isMyAccount }) => {
     </Box>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Flow/index.tsx
+++ b/packages/explorer-2.0/components/Flow/index.tsx
@@ -11,7 +11,7 @@ interface Props {
   currencyType?: string
 }
 
-export default ({
+const Index = ({
   action = 'stake',
   reverse = false,
   amount = 0,
@@ -57,3 +57,5 @@ export default ({
     </Flex>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Hamburger/index.tsx
+++ b/packages/explorer-2.0/components/Hamburger/index.tsx
@@ -1,5 +1,6 @@
 import { Flex, Box } from 'theme-ui'
-export default ({ ...props }) => {
+
+const Index = ({ ...props }) => {
   return (
     <Flex
       sx={{
@@ -15,3 +16,5 @@ export default ({ ...props }) => {
     </Flex>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Header/index.tsx
+++ b/packages/explorer-2.0/components/Header/index.tsx
@@ -10,7 +10,7 @@ interface Props {
   title?: JSX.Element | string
 }
 
-export default ({ onDrawerOpen, title }: Props) => {
+const Index = ({ onDrawerOpen, title }: Props) => {
   const client = useApolloClient()
   const { active, account } = useWeb3React()
 
@@ -80,3 +80,5 @@ export default ({ onDrawerOpen, title }: Props) => {
     </Flex>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/HistoryView/index.tsx
+++ b/packages/explorer-2.0/components/HistoryView/index.tsx
@@ -16,7 +16,7 @@ import moment from 'moment'
 import InfiniteScroll from 'react-infinite-scroll-component'
 import historyQuery from '../../queries/historyView.gql'
 
-export default () => {
+const Index = () => {
   const router = useRouter()
   const query = router.query
   const account = query.account as string
@@ -114,6 +114,8 @@ export default () => {
     </InfiniteScroll>
   )
 }
+
+export default Index
 
 function renderSwitch(transaction: any, i: number) {
   switch (transaction.__typename) {

--- a/packages/explorer-2.0/components/Label/index.tsx
+++ b/packages/explorer-2.0/components/Label/index.tsx
@@ -1,4 +1,4 @@
-export default ({ children, ...props }) => (
+const Index = ({ children, ...props }) => (
   <div
     {...props}
     sx={{
@@ -13,3 +13,5 @@ export default ({ children, ...props }) => (
     {children}
   </div>
 )
+
+export default Index

--- a/packages/explorer-2.0/components/List/index.tsx
+++ b/packages/explorer-2.0/components/List/index.tsx
@@ -4,7 +4,7 @@ interface Props {
   children: JSX.Element[] | JSX.Element
 }
 
-export default ({ header = null, onScroll, children, ...props }: Props) => (
+const Index = ({ header = null, onScroll, children, ...props }: Props) => (
   <div onScroll={onScroll} sx={{ width: '100%' }} {...props}>
     {header && (
       <div sx={{ pb: 2, borderBottom: '1px solid', borderColor: 'border' }}>
@@ -14,3 +14,5 @@ export default ({ header = null, onScroll, children, ...props }: Props) => (
     <div>{children}</div>
   </div>
 )
+
+export default Index

--- a/packages/explorer-2.0/components/ListItem/index.tsx
+++ b/packages/explorer-2.0/components/ListItem/index.tsx
@@ -1,6 +1,6 @@
 import { Flex } from 'theme-ui'
 
-export default ({ avatar = null, children, ...props }) => {
+const Index = ({ avatar = null, children, ...props }) => {
   return (
     <Flex
       sx={{
@@ -23,3 +23,5 @@ export default ({ avatar = null, children, ...props }) => {
     </Flex>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Modal/index.tsx
+++ b/packages/explorer-2.0/components/Modal/index.tsx
@@ -16,7 +16,7 @@ interface Props {
   ref?: any
 }
 
-export default ({
+const Index = ({
   isOpen = false,
   setOpen,
   Icon,
@@ -89,3 +89,5 @@ export default ({
     </>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Orchestrators/index.tsx
+++ b/packages/explorer-2.0/components/Orchestrators/index.tsx
@@ -23,7 +23,7 @@ import {
 } from '@modulz/radix/dist/index.es'
 import Price from '../Price'
 
-export default ({ currentRound, transcoders }) => {
+const Index = ({ currentRound, transcoders }) => {
   const { width } = useWindowSize()
   const client = useApolloClient()
   const [isPriceSettingOpen, setIsPriceSettingOpen] = useState(false)
@@ -733,3 +733,5 @@ export default ({ currentRound, transcoders }) => {
     }
   }
 }
+
+export default Index

--- a/packages/explorer-2.0/components/PollCard/index.tsx
+++ b/packages/explorer-2.0/components/PollCard/index.tsx
@@ -1,7 +1,7 @@
 import { Flex } from 'theme-ui'
 import { Box } from 'theme-ui'
 
-export default ({ ...props }) => {
+const Index = ({ ...props }) => {
   return (
     <Flex
       sx={{
@@ -35,3 +35,5 @@ export default ({ ...props }) => {
     </Flex>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/PollTokenApproval/index.tsx
+++ b/packages/explorer-2.0/components/PollTokenApproval/index.tsx
@@ -4,7 +4,7 @@ import { useContext } from 'react'
 import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 
-export default () => {
+const Index = () => {
   const client = useApolloClient()
   const { approve }: any = useContext(MutationsContext)
 
@@ -24,3 +24,5 @@ export default () => {
     </>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Price/index.tsx
+++ b/packages/explorer-2.0/components/Price/index.tsx
@@ -1,7 +1,7 @@
 import { Box } from 'theme-ui'
 import Utils from 'web3-utils'
 
-export default ({ value, per, useEthSymbol = true }) => {
+const Index = ({ value, per, useEthSymbol = true }) => {
   if (per === '1m pixels') {
     return (
       <Box sx={{ fontFamily: 'monospace' }}>
@@ -38,3 +38,5 @@ export default ({ value, per, useEthSymbol = true }) => {
     )
   }
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Profile/index.tsx
+++ b/packages/explorer-2.0/components/Profile/index.tsx
@@ -30,7 +30,7 @@ interface Props {
   status: string
 }
 
-export default ({
+const Index = ({
   account,
   role = 'Orchestrator',
   hasLivepeerToken,
@@ -295,3 +295,5 @@ export default ({
     </Box>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/ProgressBar/index.tsx
+++ b/packages/explorer-2.0/components/ProgressBar/index.tsx
@@ -4,7 +4,7 @@ import moment from 'moment'
 import { useTimeEstimate } from '../../hooks'
 import { txMessages } from '../../lib/utils'
 
-export default ({ tx }) => {
+const Index = ({ tx }) => {
   if (!tx) {
     return null
   }
@@ -82,3 +82,5 @@ export default ({ tx }) => {
     </Box>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Restake/index.tsx
+++ b/packages/explorer-2.0/components/Restake/index.tsx
@@ -4,7 +4,7 @@ import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 import { initTransaction } from '../../lib/utils'
 
-export default ({ unbondingLockId, newPosPrev, newPosNext, delegator }) => {
+const Index = ({ unbondingLockId, newPosPrev, newPosNext, delegator }) => {
   const client = useApolloClient()
   const { rebond }: any = useContext(MutationsContext)
 
@@ -31,3 +31,5 @@ export default ({ unbondingLockId, newPosPrev, newPosNext, delegator }) => {
     </>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/RestakeFromUnstaked/index.tsx
+++ b/packages/explorer-2.0/components/RestakeFromUnstaked/index.tsx
@@ -5,7 +5,7 @@ import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 import { initTransaction } from '../../lib/utils'
 
-export default ({
+const Index = ({
   unbondingLockId,
   delegate,
   newPosPrev,
@@ -45,3 +45,5 @@ export default ({
     </>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/RoundStatus/index.tsx
+++ b/packages/explorer-2.0/components/RoundStatus/index.tsx
@@ -18,7 +18,7 @@ const GET_ROUND_MODAL_STATUS = gql`
   }
 `
 
-export default () => {
+const Index = () => {
   const isVisible = usePageVisibility()
   const { data: modalData } = useQuery(GET_ROUND_MODAL_STATUS)
   const pollInterval = 60000
@@ -219,3 +219,5 @@ export default () => {
     </Flex>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Snackbar/index.tsx
+++ b/packages/explorer-2.0/components/Snackbar/index.tsx
@@ -1,7 +1,7 @@
 import { Flex } from 'theme-ui'
 import Close from '../../public/img/close.svg'
 
-export default ({ children, onClose }) => (
+const Index = ({ children, onClose }) => (
   <div
     sx={{
       borderRadius: '3px',
@@ -26,3 +26,5 @@ export default ({ children, onClose }) => (
     </Flex>
   </div>
 )
+
+export default Index

--- a/packages/explorer-2.0/components/Spinner/index.tsx
+++ b/packages/explorer-2.0/components/Spinner/index.tsx
@@ -6,7 +6,7 @@ const rotate = keyframes`
   }
 `
 
-export default ({ speed = '1s', ...props }) => (
+const Index = ({ speed = '1s', ...props }) => (
   <div
     {...props}
     sx={{
@@ -23,3 +23,5 @@ export default ({ speed = '1s', ...props }) => (
     }}
   ></div>
 )
+
+export default Index

--- a/packages/explorer-2.0/components/StakeTransactions/index.tsx
+++ b/packages/explorer-2.0/components/StakeTransactions/index.tsx
@@ -13,7 +13,7 @@ import Restake from '../Restake'
 import RestakeFromUnstaked from '../RestakeFromUnstaked'
 import WithdrawStake from '../WithdrawStake'
 
-export default ({ delegator, transcoders, currentRound, isMyAccount }) => {
+const Index = ({ delegator, transcoders, currentRound, isMyAccount }) => {
   const pendingStakeTransactions: Array<UnbondingLock> = delegator.unbondingLocks.filter(
     (item: UnbondingLock) =>
       item.withdrawRound && item.withdrawRound > parseInt(currentRound.id, 10),
@@ -173,3 +173,5 @@ export default ({ delegator, transcoders, currentRound, isMyAccount }) => {
     </>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/StakingGuide/Step1.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/Step1.tsx
@@ -2,7 +2,7 @@ import { Styled } from 'theme-ui'
 import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 
-export default ({ goTo, nextStep }) => {
+const Step1 = ({ goTo, nextStep }) => {
   const GET_WALLET_MODAL_STATUS = gql`
     {
       walletModalOpen @client
@@ -21,3 +21,5 @@ export default ({ goTo, nextStep }) => {
     </div>
   )
 }
+
+export default Step1

--- a/packages/explorer-2.0/components/StakingGuide/Step2.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/Step2.tsx
@@ -2,7 +2,7 @@ import { Styled } from 'theme-ui'
 import { useWeb3React } from '@web3-react/core'
 import { useApolloClient } from '@apollo/react-hooks'
 
-export default ({ goTo, nextStep }) => {
+const Step2 = ({ goTo, nextStep }) => {
   const { active } = useWeb3React()
   const client = useApolloClient()
 
@@ -25,3 +25,5 @@ export default ({ goTo, nextStep }) => {
     </div>
   )
 }
+
+export default Step2

--- a/packages/explorer-2.0/components/StakingGuide/Step3.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/Step3.tsx
@@ -2,7 +2,7 @@ import { Styled } from 'theme-ui'
 import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 
-export default ({ goTo, nextStep }) => {
+const Step3 = ({ goTo, nextStep }) => {
   const GET_UNISWAP_MODAL_STATUS = gql`
     {
       uniswapModalOpen @client
@@ -23,3 +23,5 @@ export default ({ goTo, nextStep }) => {
     </div>
   )
 }
+
+export default Step3

--- a/packages/explorer-2.0/components/StakingGuide/Step4.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/Step4.tsx
@@ -9,7 +9,7 @@ import { useWeb3React } from '@web3-react/core'
 import { useApolloClient, useQuery } from '@apollo/react-hooks'
 import accountQuery from '../../queries/account.gql'
 
-export default ({ goTo, nextStep }) => {
+const Step4 = ({ goTo, nextStep }) => {
   const client = useApolloClient()
   const context = useWeb3React()
   const [copied, setCopied] = useState(false)
@@ -124,3 +124,5 @@ export default ({ goTo, nextStep }) => {
     </div>
   )
 }
+
+export default Step4

--- a/packages/explorer-2.0/components/StakingGuide/Step5.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/Step5.tsx
@@ -9,7 +9,7 @@ import { MutationsContext } from '../../contexts'
 import { useQuery } from '@apollo/react-hooks'
 import accountQuery from '../../queries/account.gql'
 
-export default ({ goTo, nextStep }) => {
+const Step5 = ({ goTo, nextStep }) => {
   const context = useWeb3React()
   const isVisible = usePageVisibility()
   const pollInterval = 20000
@@ -74,3 +74,5 @@ export default ({ goTo, nextStep }) => {
     </div>
   )
 }
+
+export default Step5

--- a/packages/explorer-2.0/components/StakingGuide/Step6.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/Step6.tsx
@@ -1,7 +1,7 @@
 import { Styled } from 'theme-ui'
 import Button from '../Button'
 
-export default ({ goTo, nextStep }) => {
+const Step6 = ({ goTo, nextStep }) => {
   return (
     <div sx={{ py: 1 }}>
       <Styled.h2 sx={{ mb: 2 }}>Choose Orchestrator</Styled.h2>
@@ -23,3 +23,5 @@ export default ({ goTo, nextStep }) => {
     </div>
   )
 }
+
+export default Step6

--- a/packages/explorer-2.0/components/StakingGuide/Step7.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/Step7.tsx
@@ -1,6 +1,6 @@
 import { Styled } from 'theme-ui'
 
-export default () => {
+const Step7 = () => {
   return (
     <div sx={{ py: 1 }}>
       <Styled.h2 sx={{ mb: 2 }}>Stake</Styled.h2>
@@ -11,3 +11,5 @@ export default () => {
     </div>
   )
 }
+
+export default Step7

--- a/packages/explorer-2.0/components/StakingGuide/index.tsx
+++ b/packages/explorer-2.0/components/StakingGuide/index.tsx
@@ -23,7 +23,7 @@ const GET_TOUR_OPEN = gql`
   }
 `
 
-export default ({ children, ...props }) => {
+const Index = ({ children, ...props }) => {
   const client = useApolloClient()
   const [open, setOpen] = useState(false)
   const [tourKey, setTourKey] = useState(0)
@@ -258,3 +258,5 @@ export default ({ children, ...props }) => {
     </Box>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/StakingView/index.tsx
+++ b/packages/explorer-2.0/components/StakingView/index.tsx
@@ -10,7 +10,7 @@ import ReactTooltip from 'react-tooltip'
 import Help from '../../public/img/help.svg'
 import Button from '../Button'
 
-export default ({ delegator, transcoders, protocol, currentRound }) => {
+const Index = ({ delegator, transcoders, protocol, currentRound }) => {
   const router = useRouter()
   const query = router.query
   const context = useWeb3React()
@@ -382,3 +382,5 @@ export default ({ delegator, transcoders, protocol, currentRound }) => {
     </Box>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/StakingWidget/Footer.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/Footer.tsx
@@ -25,7 +25,7 @@ interface Props {
   account: Account
 }
 
-export default ({
+const Footer = ({
   transcoders,
   delegator,
   transcoder,
@@ -75,19 +75,10 @@ export default ({
         ? parseFloat(Utils.fromWei(delegator.pendingStake))
         : 0,
     )
-
   const isMyTranscoder = delegator?.delegate?.id === transcoder?.id
   const sufficientStake = delegator && amount && parseFloat(amount) <= stake
-  const roundsSinceLastClaim =
-    currentRound &&
-    delegator &&
-    delegator.lastClaimRound &&
-    parseInt(currentRound.id, 10) - parseInt(delegator.lastClaimRound.id, 10)
-
   const canStake = sufficientBalance && approved && sufficientTransferAllowance
-
   const canUnstake = isMyTranscoder && isStaked && parseFloat(amount) > 0
-
   const newActiveSetOrder = simulateNewActiveSetOrder({
     action,
     transcoders: JSON.parse(JSON.stringify(transcoders)),
@@ -95,12 +86,10 @@ export default ({
     newDelegate: transcoder.id,
     oldDelegate: delegator?.delegate?.id,
   })
-
   const { newPosPrev, newPosNext } = getHint(
     delegator?.delegate?.id,
     newActiveSetOrder,
   )
-
   const {
     newPosPrev: currDelegateNewPosPrev,
     newPosNext: currDelegateNewPosNext,
@@ -156,6 +145,8 @@ export default ({
     </>
   )
 }
+
+export default Footer
 
 function renderStakeWarnings(
   amount,

--- a/packages/explorer-2.0/components/StakingWidget/Header.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/Header.tsx
@@ -1,7 +1,7 @@
 import { Styled, Flex } from 'theme-ui'
 import QRCode from 'qrcode.react'
 
-export default ({ transcoder }) => {
+const Header = ({ transcoder }) => {
   return (
     <Styled.h4
       as="h3"
@@ -58,3 +58,5 @@ export default ({ transcoder }) => {
     </Styled.h4>
   )
 }
+
+export default Header

--- a/packages/explorer-2.0/components/StakingWidget/Input.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/Input.tsx
@@ -6,7 +6,7 @@ let hoursPerYear = 8760
 let averageHoursPerRound = 21
 let roundsPerYear = hoursPerYear / averageHoursPerRound
 
-export default ({ transcoder, value = '', onChange, protocol, ...props }) => {
+const Input = ({ transcoder, value = '', onChange, protocol, ...props }) => {
   const client = useApolloClient()
   const { width } = useWindowSize()
   const totalSupply = Number(Utils.fromWei(protocol.totalTokenSupply))
@@ -76,6 +76,8 @@ export default ({ transcoder, value = '', onChange, protocol, ...props }) => {
     </div>
   )
 }
+
+export default Input
 
 function calculateAnnualROI({
   rewardCut,

--- a/packages/explorer-2.0/components/StakingWidget/InputBox.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/InputBox.tsx
@@ -4,7 +4,7 @@ import Input from './Input'
 import Utils from 'web3-utils'
 import ReactTooltip from 'react-tooltip'
 
-export default ({
+const InputBox = ({
   account,
   action,
   delegator,
@@ -102,3 +102,5 @@ export default ({
     </div>
   )
 }
+
+export default InputBox

--- a/packages/explorer-2.0/components/StakingWidget/ProjectionBox.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/ProjectionBox.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 import { abbreviateNumber } from '../../lib/utils'
 
-export default ({ action }) => {
+const ProjectionBox = ({ action }) => {
   const GET_ROI = gql`
     {
       roi @client
@@ -56,3 +56,5 @@ export default ({ action }) => {
     </div>
   )
 }
+
+export default ProjectionBox

--- a/packages/explorer-2.0/components/StakingWidget/Stake.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/Stake.tsx
@@ -6,7 +6,7 @@ import { useWeb3React } from '@web3-react/core'
 import { MutationsContext } from '../../contexts'
 import { initTransaction } from '../../lib/utils'
 
-export default ({
+const Stake = ({
   to,
   amount,
   oldDelegateNewPosPrev,
@@ -61,3 +61,5 @@ export default ({
     </>
   )
 }
+
+export default Stake

--- a/packages/explorer-2.0/components/StakingWidget/Unstake.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/Unstake.tsx
@@ -6,7 +6,7 @@ import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 import { initTransaction } from '../../lib/utils'
 
-export default ({ amount, newPosPrev, newPosNext, delegator, disabled }) => {
+const Unstake = ({ amount, newPosPrev, newPosNext, delegator, disabled }) => {
   const context = useWeb3React()
   const client = useApolloClient()
 
@@ -45,3 +45,5 @@ export default ({ amount, newPosPrev, newPosNext, delegator, disabled }) => {
     </>
   )
 }
+
+export default Unstake

--- a/packages/explorer-2.0/components/StakingWidget/Warning.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/Warning.tsx
@@ -1,4 +1,4 @@
-export default ({ children }) => {
+const Warning = ({ children }) => {
   return (
     <div
       sx={{
@@ -13,3 +13,5 @@ export default ({ children }) => {
     </div>
   )
 }
+
+export default Warning

--- a/packages/explorer-2.0/components/StakingWidget/index.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/index.tsx
@@ -19,7 +19,7 @@ interface Props {
   selectedAction?: string
 }
 
-export default ({
+const Index = ({
   transcoders,
   delegator,
   account,
@@ -89,3 +89,5 @@ export default ({
     </Box>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Tabs/index.tsx
+++ b/packages/explorer-2.0/components/Tabs/index.tsx
@@ -7,7 +7,7 @@ export interface TabType {
   isActive?: boolean
 }
 
-export default ({ tabs, variant = 'primary', ...props }) => {
+const Index = ({ tabs, variant = 'primary', ...props }) => {
   return (
     <div
       sx={{
@@ -40,3 +40,5 @@ export default ({ tabs, variant = 'primary', ...props }) => {
     </div>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/Textfield/index.tsx
+++ b/packages/explorer-2.0/components/Textfield/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Styled } from 'theme-ui'
 
-export default ({
+const Index = ({
   disabled = false,
   onFocus = null,
   onBlur = null,
@@ -118,7 +118,7 @@ export default ({
           required={required}
           defaultValue={defaultValue}
           value={value}
-          onChange={onChange ? onChange : e => setScopedValue(e.target.value)}
+          onChange={onChange ? onChange : (e) => setScopedValue(e.target.value)}
           ref={inputRef}
           name={name}
           sx={{
@@ -155,3 +155,5 @@ export default ({
     </div>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/ThreeBoxSteps/index.tsx
+++ b/packages/explorer-2.0/components/ThreeBoxSteps/index.tsx
@@ -45,7 +45,8 @@ function getStepContent(step) {
       return 'Unknown step'
   }
 }
-export default ({ hasProfile, activeStep }) => {
+
+const Index = ({ hasProfile, activeStep }) => {
   let steps = getSteps(hasProfile)
 
   return (
@@ -61,3 +62,5 @@ export default ({ hasProfile, activeStep }) => {
     </Stepper>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/ToggleCard/index.tsx
+++ b/packages/explorer-2.0/components/ToggleCard/index.tsx
@@ -2,7 +2,7 @@ import { Styled, Flex } from 'theme-ui'
 import Label from '../Label'
 import Checkbox from '../Checkbox'
 
-export default ({
+const Index = ({
   label = null,
   description,
   icon: Icon,
@@ -31,3 +31,5 @@ export default ({
     <Styled.p>{description}</Styled.p>
   </div>
 )
+
+export default Index

--- a/packages/explorer-2.0/components/Tokenholders/index.tsx
+++ b/packages/explorer-2.0/components/Tokenholders/index.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link'
 import Utils from 'web3-utils'
 import { abbreviateNumber } from '../../lib/utils'
 
-export default ({ protocol, delegators, ...props }) => {
+const Index = ({ protocol, delegators, ...props }) => {
   const columns: any = useMemo(
     () => [
       {
@@ -84,6 +84,8 @@ export default ({ protocol, delegators, ...props }) => {
     </table>
   )
 }
+
+export default Index
 
 function renderSwitch(cell, protocol) {
   switch (cell.column.Header) {

--- a/packages/explorer-2.0/components/TokenholdersView/index.tsx
+++ b/packages/explorer-2.0/components/TokenholdersView/index.tsx
@@ -37,7 +37,7 @@ const GET_DATA = gql`
   }
 `
 
-export default () => {
+const Index = () => {
   const router = useRouter()
   const isVisible = usePageVisibility()
   const query = router.query
@@ -138,3 +138,5 @@ export default () => {
     </InfiniteScroll>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/TxConfirmedDialog/index.tsx
+++ b/packages/explorer-2.0/components/TxConfirmedDialog/index.tsx
@@ -12,7 +12,7 @@ import Confetti from 'react-confetti'
 import Link from 'next/link'
 import Router from 'next/router'
 
-export default ({ tx, isOpen, onDismiss }) => {
+const Index = ({ tx, isOpen, onDismiss }) => {
   if (!isOpen) {
     return null
   }
@@ -40,6 +40,8 @@ export default ({ tx, isOpen, onDismiss }) => {
     </Modal>
   )
 }
+
+export default Index
 
 function renderSwitch({ tx, onDismiss }) {
   const { width, height } = useWindowSize()

--- a/packages/explorer-2.0/components/TxStartedDialog/index.tsx
+++ b/packages/explorer-2.0/components/TxStartedDialog/index.tsx
@@ -9,7 +9,7 @@ import Utils from 'web3-utils'
 import moment from 'moment'
 import { MdOpenInNew } from 'react-icons/md'
 
-export default ({ tx, isOpen, onDismiss }) => {
+const Index = ({ tx, isOpen, onDismiss }) => {
   if (!isOpen) {
     return null
   }
@@ -64,6 +64,8 @@ export default ({ tx, isOpen, onDismiss }) => {
     </Modal>
   )
 }
+
+export default Index
 
 function Table({ tx, timeLeft }) {
   return (

--- a/packages/explorer-2.0/components/TxSummaryDialog/index.tsx
+++ b/packages/explorer-2.0/components/TxSummaryDialog/index.tsx
@@ -6,7 +6,7 @@ import Modal from '../Modal'
 import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 
-export default ({ isOpen, onDismiss }) => {
+const Index = ({ isOpen, onDismiss }) => {
   if (!isOpen) {
     return null
   }
@@ -42,6 +42,8 @@ export default ({ isOpen, onDismiss }) => {
     </Modal>
   )
 }
+
+export default Index
 
 function Header({ data }) {
   return (

--- a/packages/explorer-2.0/components/UniswapModal/index.tsx
+++ b/packages/explorer-2.0/components/UniswapModal/index.tsx
@@ -3,7 +3,7 @@ import { useApolloClient, useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
 import CloseIcon from '../../public/img/close.svg'
 
-export default ({ children }) => {
+const Index = ({ children }) => {
   const client = useApolloClient()
   const GET_UNISWAP_MODAL_STATUS = gql`
     {
@@ -51,3 +51,5 @@ export default ({ children }) => {
     </DialogOverlay>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/VoteButton/index.tsx
+++ b/packages/explorer-2.0/components/VoteButton/index.tsx
@@ -5,7 +5,7 @@ import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 import { initTransaction } from '../../lib/utils'
 
-export default ({ pollAddress, choiceId, children, ...props }) => {
+const Index = ({ pollAddress, choiceId, children, ...props }) => {
   const context = useWeb3React()
   const client = useApolloClient()
 
@@ -28,3 +28,5 @@ export default ({ pollAddress, choiceId, children, ...props }) => {
     </Button>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/VotingWidget/index.tsx
+++ b/packages/explorer-2.0/components/VotingWidget/index.tsx
@@ -14,7 +14,7 @@ import Copy from '../../public/img/copy.svg'
 import { useState, useEffect } from 'react'
 import Modal from '../Modal'
 
-export default ({ data }) => {
+const Index = ({ data }) => {
   const context = useWeb3React()
   const client = useApolloClient()
   const [copied, setCopied] = useState(false)
@@ -356,6 +356,8 @@ export default ({ data }) => {
     </Box>
   )
 }
+
+export default Index
 
 function renderVoteButton(data) {
   switch (data?.vote?.choiceID) {

--- a/packages/explorer-2.0/components/WalletModal/AccountDetails.tsx
+++ b/packages/explorer-2.0/components/WalletModal/AccountDetails.tsx
@@ -7,7 +7,7 @@ import { Flex } from 'theme-ui'
 import Button from '../Button'
 import { SUPPORTED_WALLETS } from '../../lib/constants'
 
-export default ({ onClose, openOptions }) => {
+const AccountDetails = ({ onClose, openOptions }) => {
   const { account, connector } = useWeb3React()
 
   function formatConnectorName() {
@@ -15,11 +15,11 @@ export default ({ onClose, openOptions }) => {
       window['ethereum'] && window['ethereum'].isMetaMask ? true : false
     const name = Object.keys(SUPPORTED_WALLETS)
       .filter(
-        k =>
+        (k) =>
           SUPPORTED_WALLETS[k].connector === connector &&
           (connector !== Injected || isMetaMask === (k === 'METAMASK')),
       )
-      .map(k => SUPPORTED_WALLETS[k].name)[0]
+      .map((k) => SUPPORTED_WALLETS[k].name)[0]
     return <Box>{name}</Box>
   }
 
@@ -89,3 +89,5 @@ export default ({ onClose, openOptions }) => {
     </Box>
   )
 }
+
+export default AccountDetails

--- a/packages/explorer-2.0/components/WalletModal/Option.tsx
+++ b/packages/explorer-2.0/components/WalletModal/Option.tsx
@@ -1,6 +1,6 @@
 import { Flex, Box } from 'theme-ui'
 
-export default ({
+const Option = ({
   link = null,
   clickable = true,
   size = null,
@@ -47,3 +47,5 @@ export default ({
   }
   return content
 }
+
+export default Option

--- a/packages/explorer-2.0/components/WalletModal/PendingView.tsx
+++ b/packages/explorer-2.0/components/WalletModal/PendingView.tsx
@@ -4,7 +4,7 @@ import { SUPPORTED_WALLETS } from '../../lib/constants'
 import Option from './Option'
 import { Injected } from '../../lib/connectors'
 
-export default ({ connector }) => {
+const PendingView = ({ connector }) => {
   const isMetamask = window['ethereum'] && window['ethereum'].isMetaMask
   return (
     <>
@@ -22,7 +22,7 @@ export default ({ connector }) => {
         <Spinner speed="1.5s" sx={{ width: 20, height: 20, mr: 2 }} />
         Initializing
       </Flex>
-      {Object.keys(SUPPORTED_WALLETS).map(key => {
+      {Object.keys(SUPPORTED_WALLETS).map((key) => {
         const option = SUPPORTED_WALLETS[key]
         if (option.connector === connector) {
           if (option.connector === Injected) {
@@ -49,3 +49,5 @@ export default ({ connector }) => {
     </>
   )
 }
+
+export default PendingView

--- a/packages/explorer-2.0/components/WalletModal/index.tsx
+++ b/packages/explorer-2.0/components/WalletModal/index.tsx
@@ -21,8 +21,7 @@ const WALLET_VIEWS = {
   PENDING: 'pending',
 }
 
-// Borrowed from uniswap's WalletModal component implementation
-export default () => {
+const Index = () => {
   const { active, account, connector, activate, error } = useWeb3React()
   const [walletView, setWalletView] = useState(WALLET_VIEWS.ACCOUNT)
   const [pendingWallet, setPendingWallet] = useState()
@@ -238,3 +237,6 @@ export default () => {
     )
   )
 }
+
+// Borrowed from uniswap's WalletModal component implementation
+export default Index

--- a/packages/explorer-2.0/components/Web3ReactManager/index.tsx
+++ b/packages/explorer-2.0/components/Web3ReactManager/index.tsx
@@ -1,6 +1,6 @@
 import { useInactiveListener, useEagerConnect } from '../../hooks'
 
-export default function Web3ReactManager({ children }) {
+const Index = ({ children }) => {
   const triedEager = useEagerConnect()
 
   // when there's no account connected, react to logins (broadly speaking) on the injected provider, if it exists
@@ -8,3 +8,5 @@ export default function Web3ReactManager({ children }) {
 
   return children
 }
+
+export default Index

--- a/packages/explorer-2.0/components/WithdrawFees/index.tsx
+++ b/packages/explorer-2.0/components/WithdrawFees/index.tsx
@@ -5,7 +5,7 @@ import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 import { initTransaction } from '../../lib/utils'
 
-export default ({ delegator, ...props }) => {
+const Index = ({ delegator, ...props }) => {
   const context = useWeb3React()
   const client = useApolloClient()
 
@@ -35,3 +35,5 @@ export default ({ delegator, ...props }) => {
     </>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/components/WithdrawStake/index.tsx
+++ b/packages/explorer-2.0/components/WithdrawStake/index.tsx
@@ -5,7 +5,7 @@ import { MutationsContext } from '../../contexts'
 import { useApolloClient } from '@apollo/react-hooks'
 import { initTransaction } from '../../lib/utils'
 
-export default ({ unbondingLockId }) => {
+const Index = ({ unbondingLockId }) => {
   const context = useWeb3React()
   const client = useApolloClient()
 
@@ -34,3 +34,5 @@ export default ({ unbondingLockId }) => {
     </>
   )
 }
+
+export default Index

--- a/packages/explorer-2.0/package.json
+++ b/packages/explorer-2.0/package.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "run-p dev:next",
-    "dev:rinkeby": "dotenv -e .env.rinkeby next -- -p 3009",
-    "dev:next": "next -- -p 3009",
+    "dev:rinkeby": "dotenv -e .env.rinkeby next",
+    "dev:next": "next",
     "build": "next build",
     "start": "NODE_ENV=production next start",
     "storybook": "start-storybook"

--- a/packages/explorer-2.0/package.json
+++ b/packages/explorer-2.0/package.json
@@ -77,7 +77,7 @@
     "match-sorter": "^4.0.1",
     "micro-cors": "^0.1.1",
     "moment": "^2.24.0",
-    "next": "^9.5.2",
+    "next": "^10.0.0",
     "next-transpile-modules": "^4.1.0",
     "parse-domain": "^2.3.4",
     "qrcode.react": "^0.9.3",

--- a/packages/explorer-2.0/package.json
+++ b/packages/explorer-2.0/package.json
@@ -103,8 +103,8 @@
     "styled-components": "^4.4.0",
     "theme-ui": "^0.2.43",
     "use-debounce": "^3.3.0",
-    "web3": "^1.2.6",
-    "web3-utils": "1.2.1"
+    "web3": "^1.3.0",
+    "web3-utils": "^1.3.0"
   },
   "main": "package.json",
   "resolutions": {

--- a/packages/explorer-2.0/pages/styleguide/colors.tsx
+++ b/packages/explorer-2.0/pages/styleguide/colors.tsx
@@ -1,7 +1,7 @@
 import { Styled } from 'theme-ui'
 import { ColorPalette } from '@theme-ui/style-guide'
 
-export default () => {
+const Colors = () => {
   return (
     <section id="colors">
       <Styled.h2 sx={{ fontSize: 6 }}>Colors</Styled.h2>
@@ -9,3 +9,5 @@ export default () => {
     </section>
   )
 }
+
+export default Colors

--- a/packages/explorer-2.0/pages/styleguide/index.tsx
+++ b/packages/explorer-2.0/pages/styleguide/index.tsx
@@ -2,7 +2,7 @@ import { Styled, Box } from 'theme-ui'
 import Typography from './typography'
 import Colors from './colors'
 
-export default () => (
+const Index = () => (
   <Styled.root>
     <Box sx={{ m: 4 }}>
       <Styled.h1 sx={{ mb: 4, color: 'primary', fontSize: 8 }}>
@@ -13,3 +13,5 @@ export default () => (
     </Box>
   </Styled.root>
 )
+
+export default Index

--- a/packages/explorer-2.0/pages/styleguide/typography.tsx
+++ b/packages/explorer-2.0/pages/styleguide/typography.tsx
@@ -1,7 +1,7 @@
 import { Styled, useThemeUI } from 'theme-ui'
 import { TypeScale, TypeStyle } from '@theme-ui/style-guide'
 
-const Row = props => (
+const Row = (props) => (
   <div
     {...props}
     sx={{
@@ -17,7 +17,7 @@ const Row = props => (
   />
 )
 
-export default () => {
+const Typography = () => {
   const { theme } = useThemeUI()
   const { fonts, fontWeights, lineHeights } = theme
 
@@ -28,7 +28,7 @@ export default () => {
         <div>
           <Styled.h3 sx={{ mb: 3 }}>Font Families</Styled.h3>
           <Row>
-            {Object.keys(fonts).map(name => (
+            {Object.keys(fonts).map((name) => (
               <div key={name}>
                 <TypeStyle fontFamily={name} fontSize={6}>
                   Aa
@@ -45,7 +45,7 @@ export default () => {
         <div>
           <Styled.h3>Font Weights</Styled.h3>
           <Row>
-            {Object.keys(fontWeights).map(name => (
+            {Object.keys(fontWeights).map((name) => (
               <div key={name}>
                 <TypeStyle fontSize={6} fontWeight={name}>
                   {fontWeights[name]}
@@ -60,7 +60,7 @@ export default () => {
         <div>
           <Styled.h3>Line Heights</Styled.h3>
           <Row>
-            {Object.keys(lineHeights).map(name => (
+            {Object.keys(lineHeights).map((name) => (
               <div key={name}>
                 <TypeStyle fontSize={6} lineHeight={name}>
                   {lineHeights[name]}
@@ -74,3 +74,5 @@ export default () => {
     </section>
   )
 }
+
+export default Typography

--- a/yarn.lock
+++ b/yarn.lock
@@ -30764,11 +30764,6 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-randomhex@0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/randomhex/-/randomhex-0.1.5.tgz#baceef982329091400f2a2912c6cd02f1094f585"
-  integrity sha1-us7vmCMpCRQA8qKRLGzQLxCU9YU=
-
 range-parser@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
@@ -37247,19 +37242,6 @@ web3-shh@1.3.0:
     web3-core-subscriptions "1.3.0"
     web3-net "1.3.0"
 
-web3-utils@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.1.tgz#21466e38291551de0ab34558de21512ac4274534"
-  integrity sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==
-  dependencies:
-    bn.js "4.11.8"
-    eth-lib "0.2.7"
-    ethjs-unit "0.1.6"
-    number-to-bn "1.7.0"
-    randomhex "0.1.5"
-    underscore "1.9.1"
-    utf8 "3.0.0"
-
 web3-utils@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.4.tgz#96832a39a66b05bf8862a5b0bdad2799d709d951"
@@ -37274,7 +37256,7 @@ web3-utils@1.2.4:
     underscore "1.9.1"
     utf8 "3.0.0"
 
-web3-utils@1.3.0, web3-utils@^1.2.1:
+web3-utils@1.3.0, web3-utils@^1.2.1, web3-utils@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.3.0.tgz#5bac16e5e0ec9fe7bdcfadb621655e8aa3cf14e1"
   integrity sha512-2mS5axFCbkhicmoDRuJeuo0TVGQDgC2sPi/5dblfVC+PMtX0efrb8Xlttv/eGkq7X4E83Pds34FH98TP2WOUZA==
@@ -37302,7 +37284,7 @@ web3@1.2.4:
     web3-shh "1.2.4"
     web3-utils "1.2.4"
 
-web3@^1.2.6:
+web3@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.3.0.tgz#8fe4cd6e2a21c91904f343ba75717ee4c76bb349"
   integrity sha512-4q9dna0RecnrlgD/bD1C5S+81Untbd6Z/TBD7rb+D5Bvvc0Wxjr4OP70x+LlnwuRDjDtzBwJbNUblh2grlVArw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -296,18 +296,18 @@
     cross-fetch "3.0.5"
     lru-cache "6.0.0"
 
-"@ampproject/toolbox-optimizer@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/toolbox-optimizer/-/toolbox-optimizer-2.6.0.tgz#e1bde0697d0fb25ab888bc0d0422998abaf6bad1"
-  integrity sha512-saToXVopb15a6zKK6kW4B1N/sYZZddkECcqmfTotRxJ2DaLE+wFB6jgWLbaPkgHwvLPQyA2IjV9BHJ/KUFuGzg==
+"@ampproject/toolbox-optimizer@2.7.0-alpha.1":
+  version "2.7.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/toolbox-optimizer/-/toolbox-optimizer-2.7.0-alpha.1.tgz#ab4c386645f991e5da5a9d2967ed2bb734a9f6c4"
+  integrity sha512-2wTvOyM6GP6FrYQzxSQCg43STo1jMRGeDKa6YUkYXYH9fm9Wbt2wTRx+ajjb48JQ6WwUnGwga1MhQhVFzRQ+wQ==
   dependencies:
     "@ampproject/toolbox-core" "^2.6.0"
-    "@ampproject/toolbox-runtime-version" "^2.6.0"
+    "@ampproject/toolbox-runtime-version" "^2.7.0-alpha.1"
     "@ampproject/toolbox-script-csp" "^2.5.4"
     "@ampproject/toolbox-validator-rules" "^2.5.4"
     abort-controller "3.0.0"
     cross-fetch "3.0.5"
-    cssnano-simple "1.0.5"
+    cssnano-simple "1.2.0"
     dom-serializer "1.0.1"
     domhandler "3.0.0"
     domutils "2.1.0"
@@ -318,12 +318,12 @@
     normalize-html-whitespace "1.0.0"
     postcss "7.0.32"
     postcss-safe-parser "4.0.2"
-    terser "4.8.0"
+    terser "5.1.0"
 
-"@ampproject/toolbox-runtime-version@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@ampproject/toolbox-runtime-version/-/toolbox-runtime-version-2.6.0.tgz#c2a310840a6c60a7f5046d2ccaf45646a761bd4f"
-  integrity sha512-wT+Ehsoq2PRXqpgjebygHD01BpSlaAE4HfDEVxgPVT8oAsLzE4ywZgzI2VQZfaCdb8qLyO5+WXrLSoJXxDBo2Q==
+"@ampproject/toolbox-runtime-version@^2.7.0-alpha.1":
+  version "2.7.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@ampproject/toolbox-runtime-version/-/toolbox-runtime-version-2.7.0-alpha.1.tgz#2ecd603e1fc986f21048947639e99b5706e01ec3"
+  integrity sha512-JruvO4RfaC/piKOY/2w6vuasNjdrHnb+xvmQTl4zBBdMsDooohZKsN9jv9YiKIdpny4MzLt1ce497840vJJq+g==
   dependencies:
     "@ampproject/toolbox-core" "^2.6.0"
 
@@ -935,20 +935,20 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.10.4"
 
-"@babel/plugin-proposal-nullish-coalescing-operator@7.10.4", "@babel/plugin-proposal-nullish-coalescing-operator@^7.0.0", "@babel/plugin-proposal-nullish-coalescing-operator@^7.10.4", "@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz#02a7e961fc32e6d5b2db0649e01bf80ddee7e04a"
-  integrity sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
-
 "@babel/plugin-proposal-nullish-coalescing-operator@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz#e4572253fdeed65cddeecfdab3f928afeb2fd5d2"
   integrity sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.0.0", "@babel/plugin-proposal-nullish-coalescing-operator@^7.10.4", "@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz#02a7e961fc32e6d5b2db0649e01bf80ddee7e04a"
+  integrity sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
 "@babel/plugin-proposal-numeric-separator@7.10.4", "@babel/plugin-proposal-numeric-separator@^7.0.0", "@babel/plugin-proposal-numeric-separator@^7.10.4", "@babel/plugin-proposal-numeric-separator@^7.8.3":
@@ -992,21 +992,21 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@7.11.0", "@babel/plugin-proposal-optional-chaining@^7.0.0", "@babel/plugin-proposal-optional-chaining@^7.11.0", "@babel/plugin-proposal-optional-chaining@^7.9.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz#de5866d0646f6afdaab8a566382fe3a221755076"
-  integrity sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.11.0"
-    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
-
 "@babel/plugin-proposal-optional-chaining@7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz#31db16b154c39d6b8a645292472b98394c292a58"
   integrity sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+
+"@babel/plugin-proposal-optional-chaining@^7.0.0", "@babel/plugin-proposal-optional-chaining@^7.11.0", "@babel/plugin-proposal-optional-chaining@^7.9.0":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz#de5866d0646f6afdaab8a566382fe3a221755076"
+  integrity sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.11.0"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
 "@babel/plugin-proposal-pipeline-operator@^7.0.0":
@@ -2873,6 +2873,14 @@
   dependencies:
     assemblyscript "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
 
+"@hapi/accept@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-5.0.1.tgz#068553e867f0f63225a506ed74e899441af53e10"
+  integrity sha512-fMr4d7zLzsAXo28PRRQPXR1o2Wmu+6z+VY1UzDp0iFo13Twj8WePakwXBiqn3E1aAlTpSNzCXdnnQXFhst8h8Q==
+  dependencies:
+    "@hapi/boom" "9.x.x"
+    "@hapi/hoek" "9.x.x"
+
 "@hapi/accept@^3.2.4":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-3.2.4.tgz#687510529493fe1d7d47954c31aff360d9364bd1"
@@ -2913,6 +2921,13 @@
   integrity sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==
   dependencies:
     "@hapi/hoek" "8.x.x"
+
+"@hapi/boom@9.x.x":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/boom/-/boom-9.1.0.tgz#0d9517657a56ff1e0b42d0aca9da1b37706fec56"
+  integrity sha512-4nZmpp4tXbm162LaZT45P7F7sgiem8dwAh2vHWT6XX24dozNjGMg6BvKCRvtCUcmcXqeMIUqWN8Rc5X8yKuROQ==
+  dependencies:
+    "@hapi/hoek" "9.x.x"
 
 "@hapi/bounce@1.x.x":
   version "1.3.2"
@@ -3014,6 +3029,11 @@
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.1.tgz#fde96064ca446dec8c55a8c2f130957b070c6e06"
   integrity sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==
+
+"@hapi/hoek@9.x.x":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.0.tgz#6c9eafc78c1529248f8f4d92b0799a712b6052c6"
+  integrity sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==
 
 "@hapi/inert@^5.2.0", "@hapi/inert@^5.2.2":
   version "5.2.2"
@@ -4647,15 +4667,25 @@
   resolved "https://registry.yarnpkg.com/@multiformats/base-x/-/base-x-4.0.1.tgz#95ff0fa58711789d53aefb2590a8b7a4e715d121"
   integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
 
+"@next/env@10.0.1":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-10.0.1.tgz#5f49329fcc4fe8948737aeb8108c9d7d75155f93"
+  integrity sha512-6dwx5YXKG88IR9Q1aai+pprF7WKcmtl0ShQy/iENj5yMWMzsQCem6hxe198u9j7z1IsWyGDXZPsaLEJEatOpeQ==
+
 "@next/mdx@^9.4.0":
   version "9.5.3"
   resolved "https://registry.yarnpkg.com/@next/mdx/-/mdx-9.5.3.tgz#246fd65b2f0854894d7d80b27a7af1708ccceb49"
   integrity sha512-r4C5bFG6bQ1WfCR8re/GUFgw2CmpMByOILMYAqKhrHE/Ota2mloxdqLQOR/fBMy3f3wvEMFvl7YdEtQPPA9oLg==
 
-"@next/react-dev-overlay@9.5.3":
-  version "9.5.3"
-  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-9.5.3.tgz#3275301f08045ecc709e3273031973a1f5e81427"
-  integrity sha512-R2ZAyFjHHaMTBVi19ZZNRJNXiwn46paRi7EZvKNvMxbrzBcUYtSFj/edU3jQoF1UOcC6vGeMhtPqH55ONrIjCQ==
+"@next/polyfill-module@10.0.1":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/@next/polyfill-module/-/polyfill-module-10.0.1.tgz#483c8f8692d842800f6badb59f8de74b540580a9"
+  integrity sha512-Vf8HYy74jx8aQgv/ftFXQtD/udJY4/OXYiiBepqrxC0T3PPl4cns1cbrr5f15xjPELMfcqulxwMYEurioBmv+w==
+
+"@next/react-dev-overlay@10.0.1":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/@next/react-dev-overlay/-/react-dev-overlay-10.0.1.tgz#38f99f78316e9e7fa61a95e1d883e90d6d1fa4d0"
+  integrity sha512-VYwwGBtV9hqpqYoVABvZEFHBt3oL6PMpiLrDmnHaOwsPDQ+kQsiWd1L8tsYvAC2dgu/x/a/TG0D81FGF77Tohw==
   dependencies:
     "@babel/code-frame" "7.10.4"
     ally.js "1.4.1"
@@ -4668,10 +4698,10 @@
     stacktrace-parser "0.1.10"
     strip-ansi "6.0.0"
 
-"@next/react-refresh-utils@9.5.3":
-  version "9.5.3"
-  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-9.5.3.tgz#a14fb6489d412b201b98aa44716fb8727ca4c6ae"
-  integrity sha512-W3VKOqbg+4Kw+k6M/SODf+WIzwcx60nAemGV1nNPa/yrDtAS2YcJfqiswrJ3+2nJHzqefAFWn4XOfM0fy8ww2Q==
+"@next/react-refresh-utils@10.0.1":
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-10.0.1.tgz#ea6f808a9a6242d2da85138edee5562f17c0243a"
+  integrity sha512-K3thGrgD0uic/x4PZh9oRK/+LWTsn6zmDSHoEXgdft1gtlOjQIVGz7yuPMvuEB9oXDl+giuvRbU+JRlhtSf/eQ==
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -4698,6 +4728,13 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
+
+"@npmcli/move-file@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.0.1.tgz#de103070dac0f48ce49cf6693c23af59c0f70464"
+  integrity sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==
+  dependencies:
+    mkdirp "^1.0.4"
 
 "@octokit/auth-token@^2.4.0":
   version "2.4.2"
@@ -7259,6 +7296,14 @@ adjust-sourcemap-loader@2.0.0:
     object-path "0.11.4"
     regex-parser "2.2.10"
 
+adjust-sourcemap-loader@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/adjust-sourcemap-loader/-/adjust-sourcemap-loader-3.0.0.tgz#5ae12fb5b7b1c585e80bbb5a63ec163a1a45e61e"
+  integrity sha512-YBrGyT2/uVQ/c6Rr+t6ZJXniY03YtHGMJQYal368burRGYKqhx9qGTWqcBU5s1CwYY9E/ri63RYyG1IacMZtqw==
+  dependencies:
+    loader-utils "^2.0.0"
+    regex-parser "^2.2.11"
+
 aes-js@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
@@ -7368,7 +7413,7 @@ ajv@6.5.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.12.3, ajv@^6.12.4:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.5"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
   integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
@@ -10514,28 +10559,27 @@ bytewise@~1.1.0:
     bytewise-core "^1.2.2"
     typewise "^1.0.3"
 
-cacache@13.0.1, cacache@^13.0.1:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-13.0.1.tgz#a8000c21697089082f85287a1aec6e382024a71c"
-  integrity sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==
+cacache@15.0.5:
+  version "15.0.5"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.0.5.tgz#69162833da29170d6732334643c60e005f5f17d0"
+  integrity sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==
   dependencies:
-    chownr "^1.1.2"
-    figgy-pudding "^3.5.1"
+    "@npmcli/move-file" "^1.0.1"
+    chownr "^2.0.0"
     fs-minipass "^2.0.0"
     glob "^7.1.4"
-    graceful-fs "^4.2.2"
     infer-owner "^1.0.4"
-    lru-cache "^5.1.1"
-    minipass "^3.0.0"
+    lru-cache "^6.0.0"
+    minipass "^3.1.1"
     minipass-collect "^1.0.2"
     minipass-flush "^1.0.5"
     minipass-pipeline "^1.2.2"
-    mkdirp "^0.5.1"
-    move-concurrently "^1.0.1"
-    p-map "^3.0.0"
+    mkdirp "^1.0.3"
+    p-map "^4.0.0"
     promise-inflight "^1.0.1"
-    rimraf "^2.7.1"
-    ssri "^7.0.0"
+    rimraf "^3.0.2"
+    ssri "^8.0.0"
+    tar "^6.0.2"
     unique-filename "^1.1.1"
 
 cacache@^11.3.3:
@@ -10578,6 +10622,30 @@ cacache@^12.0.0, cacache@^12.0.2, cacache@^12.0.3:
     ssri "^6.0.1"
     unique-filename "^1.1.1"
     y18n "^4.0.0"
+
+cacache@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-13.0.1.tgz#a8000c21697089082f85287a1aec6e382024a71c"
+  integrity sha512-5ZvAxd05HDDU+y9BVvcqYu2LLXmPnQ0hW62h32g4xBTgL/MppR4/04NHfj/ycM2y6lmTnbw6HVi+1eN0Psba6w==
+  dependencies:
+    chownr "^1.1.2"
+    figgy-pudding "^3.5.1"
+    fs-minipass "^2.0.0"
+    glob "^7.1.4"
+    graceful-fs "^4.2.2"
+    infer-owner "^1.0.4"
+    lru-cache "^5.1.1"
+    minipass "^3.0.0"
+    minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.2"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    p-map "^3.0.0"
+    promise-inflight "^1.0.1"
+    rimraf "^2.7.1"
+    ssri "^7.0.0"
+    unique-filename "^1.1.1"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -10765,6 +10833,11 @@ camelcase@^4.0.0, camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
+camelcase@^6.0.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 camelize@^1.0.0:
   version "1.0.0"
@@ -10959,7 +11032,22 @@ cheerio@^1.0.0-rc.3:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
-chokidar@2.1.8, chokidar@^2.0.0, chokidar@^2.0.4, chokidar@^2.1.5, chokidar@^2.1.8:
+chokidar@3.4.2, chokidar@^3.0.2, chokidar@^3.3.0, chokidar@^3.4.1:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
+  integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
+chokidar@^2.0.0, chokidar@^2.0.4, chokidar@^2.1.5, chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -10978,25 +11066,15 @@ chokidar@2.1.8, chokidar@^2.0.0, chokidar@^2.0.4, chokidar@^2.1.5, chokidar@^2.1
   optionalDependencies:
     fsevents "^1.2.7"
 
-chokidar@3.4.2, chokidar@^3.0.2, chokidar@^3.3.0, chokidar@^3.4.1:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.2.tgz#38dc8e658dec3809741eb3ef7bb0a47fe424232d"
-  integrity sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.4.0"
-  optionalDependencies:
-    fsevents "~2.1.2"
-
 chownr@^1.0.1, chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 chrome-trace-event@^1.0.2:
   version "1.0.2"
@@ -12363,24 +12441,23 @@ css-loader@3.4.2:
     postcss-value-parser "^4.0.2"
     schema-utils "^2.6.0"
 
-css-loader@3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.5.3.tgz#95ac16468e1adcd95c844729e0bb167639eb0bcf"
-  integrity sha512-UEr9NH5Lmi7+dguAm+/JSPovNjYbm2k3TK58EiwQHzOHH5Jfq1Y+XoP2bQO6TMn7PptMd0opxxedAWcaSTRKHw==
+css-loader@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-4.3.0.tgz#c888af64b2a5b2e85462c72c0f4a85c7e2e0821e"
+  integrity sha512-rdezjCjScIrsL8BSYszgT4s476IcNKt6yX69t0pHjJVnPUTDpn4WfIpDQTN3wCJvUvfsz/mFjuGOekf3PY3NUg==
   dependencies:
-    camelcase "^5.3.1"
+    camelcase "^6.0.0"
     cssesc "^3.0.0"
     icss-utils "^4.1.1"
-    loader-utils "^1.2.3"
-    normalize-path "^3.0.0"
-    postcss "^7.0.27"
+    loader-utils "^2.0.0"
+    postcss "^7.0.32"
     postcss-modules-extract-imports "^2.0.0"
-    postcss-modules-local-by-default "^3.0.2"
+    postcss-modules-local-by-default "^3.0.3"
     postcss-modules-scope "^2.2.0"
     postcss-modules-values "^3.0.0"
-    postcss-value-parser "^4.0.3"
-    schema-utils "^2.6.6"
-    semver "^6.3.0"
+    postcss-value-parser "^4.1.0"
+    schema-utils "^2.7.1"
+    semver "^7.3.2"
 
 css-loader@^3.0.0:
   version "3.6.0"
@@ -12571,27 +12648,12 @@ cssnano-preset-default@^4.0.7:
     postcss-svgo "^4.0.2"
     postcss-unique-selectors "^4.0.1"
 
-cssnano-preset-simple@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/cssnano-preset-simple/-/cssnano-preset-simple-1.1.4.tgz#7b287a31df786348565d02342df71af8f758ac82"
-  integrity sha512-EYKDo65W+AxMViUijv/hvhbEnxUjmu3V7omcH1MatPOwjRLrAgVArUOE8wTUyc1ePFEtvV8oCT4/QSRJDorm/A==
-  dependencies:
-    postcss "^7.0.32"
-
 cssnano-preset-simple@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/cssnano-preset-simple/-/cssnano-preset-simple-1.2.0.tgz#afcf13eb076e8ebd91c4f311cd449781c14c7371"
   integrity sha512-zojGlY+KasFeQT/SnD/WqYXHcKddz2XHRDtIwxrWpGqGHp5IyLWsWFS3UW7pOf3AWvfkpYSRdxOSlYuJPz8j8g==
   dependencies:
     caniuse-lite "^1.0.30001093"
-    postcss "^7.0.32"
-
-cssnano-simple@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/cssnano-simple/-/cssnano-simple-1.0.5.tgz#66ee528f3a4e60754e2625ea9f51ac315f5f0a92"
-  integrity sha512-NJjx2Er1C3pa75v1GwMKm0w6xAp1GsW2Ql1As4CWPNFxTgYFN5e8wblYeHfna13sANAhyIdSIPqKJjBO4CU5Eg==
-  dependencies:
-    cssnano-preset-simple "1.1.4"
     postcss "^7.0.32"
 
 cssnano-simple@1.2.0:
@@ -12987,6 +13049,13 @@ decompress-response@^4.2.0:
   integrity sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==
   dependencies:
     mimic-response "^2.0.0"
+
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
 
 decompress-tar@^4.0.0, decompress-tar@^4.1.0, decompress-tar@^4.1.1:
   version "4.1.1"
@@ -22625,6 +22694,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+klona@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.4.tgz#7bb1e3affb0cb8624547ef7e8f6708ea2e39dfc0"
+  integrity sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==
+
 known-css-properties@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.14.0.tgz#d7032b4334a32dc22e6e46b081ec789daf18756c"
@@ -23928,6 +24002,14 @@ liftoff@^3.1.0:
     rechoir "^0.6.2"
     resolve "^1.1.7"
 
+line-column@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/line-column/-/line-column-1.0.2.tgz#d25af2936b6f4849172b312e4792d1d987bc34a2"
+  integrity sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=
+  dependencies:
+    isarray "^1.0.0"
+    isobject "^2.0.0"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -24640,7 +24722,7 @@ lru-cache@5.1.1, lru-cache@^5.0.0, lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lru-cache@6.0.0:
+lru-cache@6.0.0, lru-cache@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
@@ -25446,6 +25528,11 @@ mimic-response@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-2.1.0.tgz#d13763d35f613d09ec37ebb30bac0469c0ee8f43"
   integrity sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
@@ -25573,7 +25660,7 @@ minizlib@^1.2.1:
   dependencies:
     minipass "^2.9.0"
 
-minizlib@^2.1.0:
+minizlib@^2.1.0, minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
@@ -25613,7 +25700,7 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mkdirp-classic@^0.5.2:
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
@@ -25625,7 +25712,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@^1.0.4:
+mkdirp@*, mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -26283,7 +26370,7 @@ neo-async@2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
+neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -26311,22 +26398,21 @@ next-transpile-modules@^4.1.0:
     micromatch "^4.0.2"
     slash "^3.0.0"
 
-next@^9.5.2:
-  version "9.5.3"
-  resolved "https://registry.yarnpkg.com/next/-/next-9.5.3.tgz#7af5270631f98d330a7f75a6e8e1ac202aa155e2"
-  integrity sha512-DGrpTNGV2RNMwLaSzpgbkbaUuVk30X71/roXHS10isSXo2Gm+qWcjonDyOxf1KmOvHZRHA/Fa+LaAR7ysdYS3A==
+next@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/next/-/next-10.0.1.tgz#e1366b41b8547dfc7e9a14d1f7dd8a8584dcf0b2"
+  integrity sha512-EFlcWe82CQc1QkeIhNogcdC25KBz4CBwjyzfRHhig+wp28GW1O2P/mX+2a7EG1wXg69GyW1JYXOkKk2/VjIwVg==
   dependencies:
-    "@ampproject/toolbox-optimizer" "2.6.0"
+    "@ampproject/toolbox-optimizer" "2.7.0-alpha.1"
     "@babel/code-frame" "7.10.4"
     "@babel/core" "7.7.7"
     "@babel/plugin-proposal-class-properties" "7.10.4"
     "@babel/plugin-proposal-export-namespace-from" "7.10.4"
-    "@babel/plugin-proposal-nullish-coalescing-operator" "7.10.4"
     "@babel/plugin-proposal-numeric-separator" "7.10.4"
     "@babel/plugin-proposal-object-rest-spread" "7.11.0"
-    "@babel/plugin-proposal-optional-chaining" "7.11.0"
     "@babel/plugin-syntax-bigint" "7.8.3"
     "@babel/plugin-syntax-dynamic-import" "7.8.3"
+    "@babel/plugin-syntax-jsx" "7.10.4"
     "@babel/plugin-transform-modules-commonjs" "7.10.4"
     "@babel/plugin-transform-runtime" "7.11.5"
     "@babel/preset-env" "7.11.5"
@@ -26335,19 +26421,21 @@ next@^9.5.2:
     "@babel/preset-typescript" "7.10.4"
     "@babel/runtime" "7.11.2"
     "@babel/types" "7.11.5"
-    "@next/react-dev-overlay" "9.5.3"
-    "@next/react-refresh-utils" "9.5.3"
+    "@hapi/accept" "5.0.1"
+    "@next/env" "10.0.1"
+    "@next/polyfill-module" "10.0.1"
+    "@next/react-dev-overlay" "10.0.1"
+    "@next/react-refresh-utils" "10.0.1"
     ast-types "0.13.2"
-    babel-plugin-syntax-jsx "6.18.0"
     babel-plugin-transform-define "2.0.0"
     babel-plugin-transform-react-remove-prop-types "0.4.24"
     browserslist "4.13.0"
     buffer "5.6.0"
-    cacache "13.0.1"
+    cacache "15.0.5"
     caniuse-lite "^1.0.30001113"
-    chokidar "2.1.8"
+    chokidar "3.4.2"
     crypto-browserify "3.12.0"
-    css-loader "3.5.3"
+    css-loader "4.3.0"
     cssnano-simple "1.2.0"
     find-cache-dir "3.3.1"
     jest-worker "24.9.0"
@@ -26358,23 +26446,25 @@ next@^9.5.2:
     node-html-parser "^1.2.19"
     path-browserify "1.0.1"
     pnp-webpack-plugin "1.6.4"
-    postcss "7.0.32"
+    postcss "8.1.1"
     process "0.11.10"
     prop-types "15.7.2"
     react-is "16.13.1"
     react-refresh "0.8.3"
-    resolve-url-loader "3.1.1"
-    sass-loader "8.0.2"
-    schema-utils "2.6.6"
+    resolve-url-loader "3.1.2"
+    sass-loader "10.0.2"
+    schema-utils "2.7.1"
     stream-browserify "3.0.0"
     style-loader "1.2.1"
-    styled-jsx "3.3.0"
-    use-subscription "1.4.1"
+    styled-jsx "3.3.1"
+    use-subscription "1.5.0"
     vm-browserify "1.1.2"
     watchpack "2.0.0-beta.13"
-    web-vitals "0.2.1"
+    web-vitals "0.2.4"
     webpack "4.44.1"
     webpack-sources "1.4.3"
+  optionalDependencies:
+    sharp "0.26.2"
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -26432,6 +26522,11 @@ node-addon-api@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
+
+node-addon-api@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.0.2.tgz#04bc7b83fd845ba785bb6eae25bc857e1ef75681"
+  integrity sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg==
 
 node-dev@^3.1.3:
   version "3.1.3"
@@ -29364,7 +29459,7 @@ postcss-modules-local-by-default@1.2.0:
     css-selector-tokenizer "^0.7.0"
     postcss "^6.0.1"
 
-postcss-modules-local-by-default@^3.0.2:
+postcss-modules-local-by-default@^3.0.2, postcss-modules-local-by-default@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.3.tgz#bb14e0cc78279d504dbdcbfd7e0ca28993ffbbb0"
   integrity sha512-e3xDq+LotiGesympRlKNgaJ0PCzoUIdpH0dj47iWAui/kyTgh3CiAr1qP54uodmJhl6p9rN6BoNcdEDVJx9RDw==
@@ -29705,7 +29800,7 @@ postcss-value-parser@^3.0.0, postcss-value-parser@^3.3.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
 
-postcss-value-parser@^4.0.2, postcss-value-parser@^4.0.3, postcss-value-parser@^4.1.0:
+postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
@@ -29745,6 +29840,16 @@ postcss@7.0.32:
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+postcss@8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.1.tgz#c3a287dd10e4f6c84cb3791052b96a5d859c9389"
+  integrity sha512-9DGLSsjooH3kSNjTZUOt2eIj2ZTW0VI2PZ/3My+8TC7KIbH2OKwUlISfDsf63EP4aiRUt3XkEWMWvyJHvJelEg==
+  dependencies:
+    colorette "^1.2.1"
+    line-column "^1.0.2"
+    nanoid "^3.1.12"
+    source-map "^0.6.1"
 
 postcss@^6.0.1:
   version "6.0.23"
@@ -29852,6 +29957,27 @@ prebuild-install@^5.3.0, prebuild-install@^5.3.3:
     github-from-package "0.0.0"
     minimist "^1.2.3"
     mkdirp "^0.5.1"
+    napi-build-utils "^1.0.1"
+    node-abi "^2.7.0"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^3.0.3"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
+
+prebuild-install@^5.3.5:
+  version "5.3.6"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.6.tgz#7c225568d864c71d89d07f8796042733a3f54291"
+  integrity sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
     napi-build-utils "^1.0.1"
     node-abi "^2.7.0"
     noop-logger "^0.1.1"
@@ -31923,6 +32049,11 @@ regex-parser@2.2.10:
   resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.10.tgz#9e66a8f73d89a107616e63b39d4deddfee912b37"
   integrity sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA==
 
+regex-parser@^2.2.11:
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/regex-parser/-/regex-parser-2.2.11.tgz#3b37ec9049e19479806e878cabe7c1ca83ccfe58"
+  integrity sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==
+
 regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz#7aba89b3c13a64509dabcf3ca8d9fbb9bdf5cb75"
@@ -32410,6 +32541,22 @@ resolve-url-loader@3.1.1:
     rework-visit "1.0.0"
     source-map "0.6.1"
 
+resolve-url-loader@3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/resolve-url-loader/-/resolve-url-loader-3.1.2.tgz#235e2c28e22e3e432ba7a5d4e305c59a58edfc08"
+  integrity sha512-QEb4A76c8Mi7I3xNKXlRKQSlLBwjUV/ULFMP+G7n3/7tJZ8MG5wsZ3ucxP1Jz8Vevn6fnJsxDx9cIls+utGzPQ==
+  dependencies:
+    adjust-sourcemap-loader "3.0.0"
+    camelcase "5.3.1"
+    compose-function "3.0.3"
+    convert-source-map "1.7.0"
+    es6-iterator "2.0.3"
+    loader-utils "1.2.3"
+    postcss "7.0.21"
+    rework "1.0.1"
+    rework-visit "1.0.0"
+    source-map "0.6.1"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -32539,7 +32686,7 @@ rimraf@2.6.3, rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -32739,6 +32886,17 @@ sanitize.css@^10.0.0:
   resolved "https://registry.yarnpkg.com/sanitize.css/-/sanitize.css-10.0.0.tgz#b5cb2547e96d8629a60947544665243b1dc3657a"
   integrity sha512-vTxrZz4dX5W86M6oVWVdOVe72ZiPs41Oi7Z6Km4W5Turyz28mrXSJhhEBZoRtzJWIv3833WKVwLSDWWkEfupMg==
 
+sass-loader@10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.0.2.tgz#c7b73010848b264792dd45372eea0b87cba4401e"
+  integrity sha512-wV6NDUVB8/iEYMalV/+139+vl2LaRFlZGEd5/xmdcdzQcgmis+npyco6NsDTVOlNA3y2NV9Gcz+vHyFMIT+ffg==
+  dependencies:
+    klona "^2.0.3"
+    loader-utils "^2.0.0"
+    neo-async "^2.6.2"
+    schema-utils "^2.7.1"
+    semver "^7.3.2"
+
 sass-loader@8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.2.tgz#debecd8c3ce243c76454f2e8290482150380090d"
@@ -32783,13 +32941,14 @@ scheduler@^0.19.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-schema-utils@2.6.6:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.6.tgz#299fe6bd4a3365dc23d99fd446caff8f1d6c330c"
-  integrity sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==
+schema-utils@2.7.1, schema-utils@^2.0.1, schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0, schema-utils@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.1.tgz#1ca4f32d1b24c590c203b8e7a50bf0ea4cd394d7"
+  integrity sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
   dependencies:
-    ajv "^6.12.0"
-    ajv-keywords "^3.4.1"
+    "@types/json-schema" "^7.0.5"
+    ajv "^6.12.4"
+    ajv-keywords "^3.5.2"
 
 schema-utils@^1.0.0:
   version "1.0.0"
@@ -32799,15 +32958,6 @@ schema-utils@^1.0.0:
     ajv "^6.1.0"
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
-
-schema-utils@^2.0.1, schema-utils@^2.5.0, schema-utils@^2.6.0, schema-utils@^2.6.1, schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.1.tgz#1ca4f32d1b24c590c203b8e7a50bf0ea4cd394d7"
-  integrity sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
-  dependencies:
-    "@types/json-schema" "^7.0.5"
-    ajv "^6.12.4"
-    ajv-keywords "^3.5.2"
 
 screenfull@^5.0.0:
   version "5.0.2"
@@ -33238,6 +33388,21 @@ shallowequal@^1.1.0:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
+sharp@0.26.2:
+  version "0.26.2"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.26.2.tgz#3d5777d246ae32890afe82a783c1cbb98456a88c"
+  integrity sha512-bGBPCxRAvdK9bX5HokqEYma4j/Q5+w8Nrmb2/sfgQCLEUx/HblcpmOfp59obL3+knIKnOhyKmDb4tEOhvFlp6Q==
+  dependencies:
+    color "^3.1.2"
+    detect-libc "^1.0.3"
+    node-addon-api "^3.0.2"
+    npmlog "^4.1.2"
+    prebuild-install "^5.3.5"
+    semver "^7.3.2"
+    simple-get "^4.0.0"
+    tar-fs "^2.1.0"
+    tunnel-agent "^0.6.0"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -33337,6 +33502,15 @@ simple-get@^3.0.3:
   integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
   dependencies:
     decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+simple-get@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.0.tgz#73fa628278d21de83dadd5512d2cc1f4872bd675"
+  integrity sha512-ZalZGexYr3TA0SwySsr5HlgOOinS4Jsa8YB2GJ6lUNAazyAu4KG/VmzMTwAt2YVXzzVj8QmefmAonZIK2BSGcQ==
+  dependencies:
+    decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 
@@ -33889,6 +34063,13 @@ ssri@^7.0.0:
   integrity sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==
   dependencies:
     figgy-pudding "^3.5.1"
+    minipass "^3.1.1"
+
+ssri@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.0.tgz#79ca74e21f8ceaeddfcb4b90143c458b8d988808"
+  integrity sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==
+  dependencies:
     minipass "^3.1.1"
 
 stable@^0.1.8, stable@~0.1.8:
@@ -34506,10 +34687,10 @@ styled-components@^5.0.1, styled-components@^5.1.1:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
-styled-jsx@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.3.0.tgz#32335c1a3ecfc923ba4f9c056eeb3d4699006b09"
-  integrity sha512-sh8BI5eGKyJlwL4kNXHjb27/a/GJV8wP4ElRIkRXrGW3sHKOsY9Pa1VZRNxyvf3+lisdPwizD9JDkzVO9uGwZw==
+styled-jsx@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.3.1.tgz#d79f306c42c99cefbe8e76f35dad8100dc5c9ecc"
+  integrity sha512-RhW71t3k95E3g7Zq3lEBk+kmf+p4ZME7c5tfsYf9M5mq6CgIvFXkbvhawL2gWriXLRlMyKAYACE89Qa2JnTqUw==
   dependencies:
     "@babel/types" "7.8.3"
     babel-plugin-syntax-jsx "6.18.0"
@@ -34817,7 +34998,7 @@ tape@^4.4.0, tape@^4.6.3:
     string.prototype.trim "~1.2.1"
     through "~2.3.8"
 
-tar-fs@^2.0.0:
+tar-fs@^2.0.0, tar-fs@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.0.tgz#d1cdd121ab465ee0eb9ccde2d35049d3f3daf0d5"
   integrity sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==
@@ -34884,6 +35065,18 @@ tar@^5.0.5:
     minipass "^3.0.0"
     minizlib "^2.1.0"
     mkdirp "^0.5.0"
+    yallist "^4.0.0"
+
+tar@^6.0.2:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.5.tgz#bde815086e10b39f1dcd298e89d596e1535e200f"
+  integrity sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
     yallist "^4.0.0"
 
 tdigest@^0.1.1:
@@ -34980,10 +35173,10 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
-terser@4.8.0, terser@^4.1.2, terser@^4.6.12, terser@^4.6.3, terser@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
-  integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
+terser@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.1.0.tgz#1f4ab81c8619654fdded51f3157b001e1747281d"
+  integrity sha512-pwC1Jbzahz1ZPU87NQ8B3g5pKbhyJSiHih4gLH6WZiPU8mmS1IlGbB0A2Nuvkj/LCNsgIKctg6GkYwWCeTvXZQ==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -34997,6 +35190,15 @@ terser@^3.7.3:
     commander "^2.19.0"
     source-map "~0.6.1"
     source-map-support "~0.5.10"
+
+terser@^4.1.2, terser@^4.6.12, terser@^4.6.3, terser@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
+  integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
 
 test-exclude@^5.2.3:
   version "5.2.3"
@@ -36267,10 +36469,10 @@ use-sidecar@^1.0.1:
     detect-node-es "^1.0.0"
     tslib "^1.9.3"
 
-use-subscription@1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.4.1.tgz#edcbcc220f1adb2dd4fa0b2f61b6cc308e620069"
-  integrity sha512-7+IIwDG/4JICrWHL/Q/ZPK5yozEnvRm6vHImu0LKwQlmWGKeiF7mbAenLlK/cTNXrTtXHU/SFASQHzB6+oSJMQ==
+use-subscription@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.0.tgz#0df66fdf97b9a340147ad72f76fac1db6f56d240"
+  integrity sha512-/FVRiB2I7NDjzWoNBYPt6YkkvleMm/lFtxj1hH6nX2TVrJ/5UTbovw9OE1efv2Zl0HoAYuTjM7zHd9OsABn5sg==
   dependencies:
     object-assign "^4.1.1"
 
@@ -36733,10 +36935,10 @@ web-namespaces@^1.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
-web-vitals@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.1.tgz#60782fa690243fe35613759a0c26431f57ba7b2d"
-  integrity sha512-2pdRlp6gJpOCg0oMMqwFF0axjk5D9WInc09RSYtqFgPXQ15+YKNQ7YnBBEqAL5jvmfH9WvoXDMb8DHwux7pIew==
+web-vitals@0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/web-vitals/-/web-vitals-0.2.4.tgz#ec3df43c834a207fd7cdefd732b2987896e08511"
+  integrity sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==
 
 web3-bzz@1.2.4:
   version "1.2.4"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR makes a few minor developer experience improvements. Namely, it transforms anonymous components into named components to make sure they [work with Fast Refresh](https://nextjs.org/docs/advanced-features/codemods#name-default-component).

It also upgrades `next`, `web3` and `web-util` to the latest versions which reduces installation and build times and changes the development port back to 3000 (port 3009 was previously used to avoid port collision with the classic explorer which has been removed from the monorepo).
