### PR TITLE
fix sort bug

### DIFF
--- a/packages/explorer-2.0/components/Orchestrators/PerformanceTable.tsx
+++ b/packages/explorer-2.0/components/Orchestrators/PerformanceTable.tsx
@@ -518,7 +518,7 @@ const PerformanceTable = ({ data: { currentRound, transcoders }, region }) => {
           return null
         return (
           <span sx={{ fontFamily: 'monospace' }}>
-            {(cell.value / 10).toFixed(2)}
+            {(cell.value / 1000).toFixed(2)}
           </span>
         )
       case 'Total Score (0-10)':
@@ -526,7 +526,7 @@ const PerformanceTable = ({ data: { currentRound, transcoders }, region }) => {
           return null
         return (
           <span sx={{ fontFamily: 'monospace' }}>
-            {(cell.value / 10).toFixed(2)}
+            {(cell.value / 1000).toFixed(2)}
           </span>
         )
       default:

--- a/packages/explorer-2.0/lib/createSchema.tsx
+++ b/packages/explorer-2.0/lib/createSchema.tsx
@@ -189,9 +189,7 @@ const Index = async () => {
               _poll?.tally?.no ? _poll?.tally?.no : '0',
             ).add(Utils.toBN(_poll?.tally?.yes ? _poll?.tally?.yes : '0'))
 
-            return Utils.toBN(totalStake)
-              .sub(totalVoteStake)
-              .toString()
+            return Utils.toBN(totalStake).sub(totalVoteStake).toString()
           },
         },
         status: {
@@ -284,7 +282,7 @@ const Index = async () => {
         )
         let transcodersWithPrice = await response.json()
         let transcoderWithPrice = transcodersWithPrice.filter(
-          t => t.Address.toLowerCase() === args.id.toLowerCase(),
+          (t) => t.Address.toLowerCase() === args.id.toLowerCase(),
         )[0]
         transcoder['price'] = transcoderWithPrice?.PricePerPixel
           ? transcoderWithPrice?.PricePerPixel
@@ -305,8 +303,8 @@ const Index = async () => {
           )
           let transcodersWithPrice = await response.json()
 
-          transcodersWithPrice.map(t => {
-            if (transcoders.filter(a => a.id === t.Address).length > 0) {
+          transcodersWithPrice.map((t) => {
+            if (transcoders.filter((a) => a.id === t.Address).length > 0) {
               arr.push({
                 id: t.Address,
                 price: t.PricePerPixel,
@@ -328,14 +326,14 @@ const Index = async () => {
           let metrics = await metricsResponse.json()
 
           for (const key in metrics) {
-            if (transcoders.filter(a => a.id === key).length > 0) {
+            if (transcoders.filter((a) => a.id === key).length > 0) {
               performanceMetrics.push({
                 id: key,
                 scores: {
-                  global: avg(metrics[key], 'score') * 100,
-                  fra: metrics[key].FRA?.score * 100,
-                  mdw: metrics[key].MDW?.score * 100,
-                  sin: metrics[key].SIN?.score * 100,
+                  global: avg(metrics[key], 'score') * 10000,
+                  fra: metrics[key].FRA?.score * 10000,
+                  mdw: metrics[key].MDW?.score * 10000,
+                  sin: metrics[key].SIN?.score * 10000,
                 },
                 successRates: {
                   global: avg(metrics[key], 'success_rate') * 100,
@@ -344,10 +342,10 @@ const Index = async () => {
                   sin: metrics[key].SIN?.success_rate * 100,
                 },
                 roundTripScores: {
-                  global: avg(metrics[key], 'round_trip_score') * 100,
-                  fra: metrics[key].FRA?.round_trip_score * 100,
-                  mdw: metrics[key].MDW?.round_trip_score * 100,
-                  sin: metrics[key].SIN?.round_trip_score * 100,
+                  global: avg(metrics[key], 'round_trip_score') * 10000,
+                  fra: metrics[key].FRA?.round_trip_score * 10000,
+                  mdw: metrics[key].MDW?.round_trip_score * 10000,
+                  sin: metrics[key].SIN?.round_trip_score * 10000,
                 },
               })
             }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes an issue reported by a discord user where sorting numbers alphanumerically in the range of 0.01 and .09 are sorted in ascending order. It's a bit hacky but, multiplying scores by a factor of 10000 before sorting fixes the issue for now.