### PR TITLE
add participation rate

### DIFF
--- a/packages/subgraph/abis/PollCreator.json
+++ b/packages/subgraph/abis/PollCreator.json
@@ -3,28 +3,27 @@
     "constant": true,
     "inputs": [],
     "name": "QUORUM",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "payable": false,
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "bytes", "name": "_proposal", "type": "bytes" }
+    ],
+    "name": "createPoll",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "constant": true,
     "inputs": [],
     "name": "POLL_CREATION_COST",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "payable": false,
     "stateMutability": "view",
     "type": "function"
@@ -33,13 +32,7 @@
     "constant": true,
     "inputs": [],
     "name": "QUOTA",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "payable": false,
     "stateMutability": "view",
     "type": "function"
@@ -48,13 +41,7 @@
     "constant": true,
     "inputs": [],
     "name": "POLL_PERIOD",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "payable": false,
     "stateMutability": "view",
     "type": "function"
@@ -76,11 +63,7 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "_tokenAddr",
-        "type": "address"
-      }
+      { "internalType": "address", "name": "_tokenAddr", "type": "address" }
     ],
     "payable": false,
     "stateMutability": "nonpayable",
@@ -122,20 +105,5 @@
     ],
     "name": "PollCreated",
     "type": "event"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
-        "internalType": "bytes",
-        "name": "_proposal",
-        "type": "bytes"
-      }
-    ],
-    "name": "createPoll",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
   }
 ]

--- a/packages/subgraph/networks.yaml
+++ b/packages/subgraph/networks.yaml
@@ -36,9 +36,6 @@ mainnet:
     serviceRegistry:
       address: '406a112f3218b988c66778fd72fc8467f2601366'
       startBlock: 6194966
-    uniswapEthDaiPair:
-      address: 'a478c2975ab1ea89e8196811f51a7b7ade33eb11'
-      startBlock: 10000835
   networkName: mainnet
 rinkeby:
   contracts:
@@ -116,8 +113,5 @@ development:
       startBlock: 0
     serviceRegistry:
       address: 'aD888d0Ade988EbEe74B8D4F39BF29a8d0fe8A8D'
-      startBlock: 0
-    uniswapEthDaiPair:
-      address: 'FE82b1C8A177EF370867803fdA5fA515a1642561'
       startBlock: 0
   networkName: development

--- a/packages/subgraph/networks.yaml
+++ b/packages/subgraph/networks.yaml
@@ -112,7 +112,7 @@ development:
       address: 'A57B8a5584442B467b4689F1144D269d096A3daF'
       startBlock: 0
     pollCreator:
-      address: '7414e38377D6DAf6045626EC8a8ABB8a1BC4B97a'
+      address: '4bf3A7dFB3b76b5B3E169ACE65f888A4b4FCa5Ee'
       startBlock: 0
     serviceRegistry:
       address: 'aD888d0Ade988EbEe74B8D4F39BF29a8d0fe8A8D'

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -91,6 +91,12 @@ type Round @entity {
   volumeETH: BigDecimal
   "Fees generated this round in USD"
   volumeUSD: BigDecimal
+  "Total active stake during the round"
+  totalActiveStake: BigDecimal
+  "Total Livepeer token supply during the round"
+  totalSupply: BigDecimal
+  "Participation rate during the round (totalActiveStake/totalSupply)"
+  participationRate: BigDecimal
   "Total stake moved from one delegate to another during the round"
   movedStake: BigDecimal
   "Total amount of new stake introduced during the round"
@@ -173,6 +179,8 @@ type Protocol @entity {
   roundLockAmount: BigInt
   targetBondingRate: BigInt
   totalActiveStake: BigDecimal
+  totalSupply: BigDecimal
+  participationRate: BigDecimal
   totalVolumeETH: BigDecimal
   totalVolumeUSD: BigDecimal
   totalWinningTickets: BigInt
@@ -233,6 +241,12 @@ type DayData @entity {
   date: Int!
   volumeETH: BigDecimal!
   volumeUSD: BigDecimal!
+  "Total active stake during the day"
+  totalActiveStake: BigDecimal!
+  "Total Livepeer token supply during the day"
+  totalSupply: BigDecimal!
+  "Participation rate during the day (totalActiveStake/totalSupply)"
+  participationRate: BigDecimal!
 }
 
 ###############################################################################

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -185,8 +185,6 @@ type Protocol @entity {
   totalVolumeUSD: BigDecimal
   totalWinningTickets: BigInt
   unbondingPeriod: BigInt
-  # price of ETH usd
-  ethPrice: BigDecimal
 }
 
 """

--- a/packages/subgraph/src/mappings/livepeerToken.ts
+++ b/packages/subgraph/src/mappings/livepeerToken.ts
@@ -1,0 +1,44 @@
+import { BigDecimal } from '@graphprotocol/graph-ts'
+import { convertToDecimal, ZERO_BD } from '../../utils/helpers'
+import { Mint as MintEvent } from '../types/LivepeerToken/LivepeerToken'
+import { DayData, Protocol, Round } from '../types/schema'
+
+export function mint(event: MintEvent): void {
+  let protocol = Protocol.load('0') || new Protocol('0')
+  let totalSupply = protocol.totalSupply.plus(convertToDecimal(event.params.amount) as BigDecimal)
+  
+  protocol.totalSupply = totalSupply
+  
+  let timestamp = event.block.timestamp.toI32()
+  let dayID = timestamp / 86400
+  let dayStartTimestamp = dayID * 86400
+  let dayData = DayData.load(dayID.toString())
+  
+  if (dayData === null) {
+    dayData = new DayData(dayID.toString())
+    dayData.date = dayStartTimestamp
+    dayData.volumeUSD = ZERO_BD
+    dayData.volumeETH = ZERO_BD
+    dayData.totalSupply = ZERO_BD
+    dayData.totalActiveStake = ZERO_BD
+    dayData.participationRate = ZERO_BD
+  }
+
+  dayData.totalSupply = totalSupply
+  dayData.totalActiveStake = protocol.totalActiveStake as BigDecimal
+  
+  if(protocol.totalActiveStake.gt(ZERO_BD)) {
+    protocol.participationRate = protocol.totalActiveStake.div(totalSupply)
+    dayData.participationRate = protocol.participationRate as BigDecimal
+  }
+  
+  let round = Round.load(protocol.currentRound)
+  if(round != null && protocol.totalActiveStake.gt(ZERO_BD)) {
+    round.totalSupply = totalSupply
+    round.participationRate = protocol.participationRate as BigDecimal
+    round.save()
+  }
+  
+  protocol.save()
+  dayData.save()
+}

--- a/packages/subgraph/src/mappings/livepeerToken.ts
+++ b/packages/subgraph/src/mappings/livepeerToken.ts
@@ -1,11 +1,51 @@
 import { BigDecimal } from '@graphprotocol/graph-ts'
 import { convertToDecimal, ZERO_BD } from '../../utils/helpers'
-import { Mint as MintEvent } from '../types/LivepeerToken/LivepeerToken'
+import { Mint as MintEvent, Burn as BurnEvent } from '../types/LivepeerToken/LivepeerToken'
 import { DayData, Protocol, Round } from '../types/schema'
 
 export function mint(event: MintEvent): void {
   let protocol = Protocol.load('0') || new Protocol('0')
   let totalSupply = protocol.totalSupply.plus(convertToDecimal(event.params.amount) as BigDecimal)
+  
+  protocol.totalSupply = totalSupply
+  
+  let timestamp = event.block.timestamp.toI32()
+  let dayID = timestamp / 86400
+  let dayStartTimestamp = dayID * 86400
+  let dayData = DayData.load(dayID.toString())
+  
+  if (dayData === null) {
+    dayData = new DayData(dayID.toString())
+    dayData.date = dayStartTimestamp
+    dayData.volumeUSD = ZERO_BD
+    dayData.volumeETH = ZERO_BD
+    dayData.totalSupply = ZERO_BD
+    dayData.totalActiveStake = ZERO_BD
+    dayData.participationRate = ZERO_BD
+  }
+
+  dayData.totalSupply = totalSupply
+  dayData.totalActiveStake = protocol.totalActiveStake as BigDecimal
+  
+  if(protocol.totalActiveStake.gt(ZERO_BD)) {
+    protocol.participationRate = protocol.totalActiveStake.div(totalSupply)
+    dayData.participationRate = protocol.participationRate as BigDecimal
+  }
+  
+  let round = Round.load(protocol.currentRound)
+  if(round != null && protocol.totalActiveStake.gt(ZERO_BD)) {
+    round.totalSupply = totalSupply
+    round.participationRate = protocol.participationRate as BigDecimal
+    round.save()
+  }
+  
+  protocol.save()
+  dayData.save()
+}
+
+export function burn(event: BurnEvent): void {
+  let protocol = Protocol.load('0') || new Protocol('0')
+  let totalSupply = protocol.totalSupply.minus(convertToDecimal(event.params.value) as BigDecimal)
   
   protocol.totalSupply = totalSupply
   

--- a/packages/subgraph/src/mappings/pollTallyHandlers.ts
+++ b/packages/subgraph/src/mappings/pollTallyHandlers.ts
@@ -200,13 +200,6 @@ export function updatePollTallyOnRebond(event: RebondEvent): void {
 export function updatePollTallyOnEarningsClaimed(
   event: EarningsClaimedEvent,
 ): void {
-  // After LIP-36 the pending stake of other delegators does not change 
-  // after earnings are claimed so after the LIP-36 mainnet upgrade block 
-  // we stop updating all voters vote weight on each EarningsClaim event
-  if(dataSource.network() != 'mainnet' || event.block.number.gt(BigInt.fromI32(10972430))) {
-    return
-  }
-  
   let voterAddress = dataSource.context().getString('voter')
   let delegator = Delegator.load(voterAddress) as Delegator
 

--- a/packages/subgraph/src/mappings/pollTallyHandlers.ts
+++ b/packages/subgraph/src/mappings/pollTallyHandlers.ts
@@ -200,6 +200,13 @@ export function updatePollTallyOnRebond(event: RebondEvent): void {
 export function updatePollTallyOnEarningsClaimed(
   event: EarningsClaimedEvent,
 ): void {
+  // After LIP-36 the pending stake of other delegators does not change 
+  // after earnings are claimed so after the LIP-36 mainnet upgrade block 
+  // we stop updating all voters vote weight on each EarningsClaim event
+  if(dataSource.network() != 'mainnet' || event.block.number.gt(BigInt.fromI32(10972430))) {
+    return
+  }
+  
   let voterAddress = dataSource.context().getString('voter')
   let delegator = Delegator.load(voterAddress) as Delegator
 

--- a/packages/subgraph/src/mappings/roundsManager.ts
+++ b/packages/subgraph/src/mappings/roundsManager.ts
@@ -1,5 +1,5 @@
 // Import types and APIs from graph-ts
-import { Address, dataSource, BigInt } from '@graphprotocol/graph-ts'
+import { Address, dataSource, BigInt, BigDecimal } from '@graphprotocol/graph-ts'
 
 // Import event types from the registrar contract ABIs
 import {
@@ -17,6 +17,7 @@ import {
   InitializeRound,
   Protocol,
   ParameterUpdate,
+  DayData,
 } from '../types/schema'
 
 import {
@@ -26,6 +27,8 @@ import {
   makeEventId,
   EMPTY_ADDRESS,
   convertToDecimal,
+  getLivepeerTokenAddress,
+  ZERO_BD,
 } from '../../utils/helpers'
 
 // Handler for NewRound events
@@ -78,20 +81,45 @@ export function newRound(event: NewRoundEvent): void {
     transcoder = Transcoder.load(currentTranscoder.toHex())
   }
 
+  let protocol = Protocol.load('0') || new Protocol('0')
+  let totalActiveStake = convertToDecimal(bondingManager.getTotalBonded()) as BigDecimal
+  
   // Create new round
   round = new Round(roundNumber.toString())
   round.initialized = true
   round.timestamp = event.block.timestamp
   round.length = roundsManager.roundLength()
   round.startBlock = roundsManager.currentRoundStartBlock()
-  round.save()
+  round.totalActiveStake = totalActiveStake
 
   // Update protocol
-  let protocol = Protocol.load('0') || new Protocol('0')
   protocol.lastInitializedRound = roundsManager.lastInitializedRound()
   protocol.currentRound = roundNumber.toString()
-  protocol.totalActiveStake = convertToDecimal(bondingManager.getTotalBonded())
-  protocol.save()
+  protocol.totalActiveStake = totalActiveStake
+
+  let timestamp = event.block.timestamp.toI32()
+  let dayID = timestamp / 86400
+  let dayStartTimestamp = dayID * 86400
+  let dayData = DayData.load(dayID.toString())
+  
+  if (dayData === null) {
+    dayData = new DayData(dayID.toString())
+    dayData.date = dayStartTimestamp
+    dayData.volumeUSD = ZERO_BD
+    dayData.volumeETH = ZERO_BD
+    dayData.totalSupply = ZERO_BD
+    dayData.totalActiveStake = ZERO_BD
+    dayData.participationRate = ZERO_BD
+  }
+
+  dayData.totalActiveStake = totalActiveStake
+  dayData.totalSupply = protocol.totalSupply as BigDecimal
+
+  if(protocol.totalActiveStake.gt(ZERO_BD)) {
+    protocol.participationRate = protocol.totalActiveStake.div(protocol.totalSupply as BigDecimal)
+    round.participationRate = protocol.participationRate as BigDecimal
+    dayData.participationRate = protocol.participationRate as BigDecimal
+  }
 
   // Store transaction info
   let initializeRound = new InitializeRound(
@@ -105,6 +133,10 @@ export function newRound(event: NewRoundEvent): void {
   initializeRound.from = event.transaction.from.toHex()
   initializeRound.to = event.transaction.to.toHex()
   initializeRound.round = roundNumber.toString()
+
+  dayData.save()
+  protocol.save()
+  round.save()
   initializeRound.save()
 }
 

--- a/packages/subgraph/src/mappings/roundsManager_streamflow.ts
+++ b/packages/subgraph/src/mappings/roundsManager_streamflow.ts
@@ -1,5 +1,5 @@
 // Import types and APIs from graph-ts
-import { Address, dataSource } from '@graphprotocol/graph-ts'
+import { Address, BigDecimal, dataSource } from '@graphprotocol/graph-ts'
 
 // Import event types from the registrar contract ABIs
 import {
@@ -14,6 +14,7 @@ import {
   Round,
   InitializeRound,
   Protocol,
+  DayData,
 } from '../types/schema'
 
 import {
@@ -22,6 +23,7 @@ import {
   makeEventId,
   EMPTY_ADDRESS,
   convertToDecimal,
+  ZERO_BD,
 } from '../../utils/helpers'
 import { BondingManager } from '../types/BondingManager_streamflow/BondingManager'
 
@@ -63,19 +65,44 @@ export function newRound(event: NewRoundEvent): void {
     transcoder = Transcoder.load(currentTranscoder.toHex())
   }
 
+  let protocol = Protocol.load('0') || new Protocol('0')
+  let totalActiveStake = convertToDecimal(bondingManager.getTotalBonded()) as BigDecimal
+
   // Create new round
   round = new Round(roundNumber.toString())
   round.initialized = true
   round.timestamp = event.block.timestamp
   round.length = roundsManager.roundLength()
   round.startBlock = roundsManager.currentRoundStartBlock()
-  round.save()
-
-  let protocol = Protocol.load('0') || new Protocol('0')
+  round.totalActiveStake = totalActiveStake
+  
   protocol.lastInitializedRound = roundsManager.lastInitializedRound()
   protocol.currentRound = roundNumber.toString()
-  protocol.totalActiveStake = convertToDecimal(bondingManager.getTotalBonded())
-  protocol.save()
+  protocol.totalActiveStake = totalActiveStake
+  
+  let timestamp = event.block.timestamp.toI32()
+  let dayID = timestamp / 86400
+  let dayStartTimestamp = dayID * 86400
+  let dayData = DayData.load(dayID.toString())
+  
+  if (dayData === null) {
+    dayData = new DayData(dayID.toString())
+    dayData.date = dayStartTimestamp
+    dayData.volumeUSD = ZERO_BD
+    dayData.volumeETH = ZERO_BD
+    dayData.totalSupply = ZERO_BD
+    dayData.totalActiveStake = ZERO_BD
+    dayData.participationRate = ZERO_BD
+  }
+
+  dayData.totalActiveStake = totalActiveStake
+  dayData.totalSupply = protocol.totalSupply as BigDecimal
+  
+  if(protocol.totalActiveStake.gt(ZERO_BD)) {
+    protocol.participationRate = protocol.totalActiveStake.div(protocol.totalSupply as BigDecimal)
+    round.participationRate = protocol.participationRate as BigDecimal
+    dayData.participationRate = protocol.participationRate as BigDecimal
+  }
 
   // Store transaction info
   let initializeRound = new InitializeRound(
@@ -89,5 +116,9 @@ export function newRound(event: NewRoundEvent): void {
   initializeRound.from = event.transaction.from.toHex()
   initializeRound.to = event.transaction.to.toHex()
   initializeRound.round = roundNumber.toString()
+
+  dayData.save()
+  protocol.save()
+  round.save()
   initializeRound.save()
 }

--- a/packages/subgraph/src/mappings/ticketBroker.ts
+++ b/packages/subgraph/src/mappings/ticketBroker.ts
@@ -5,6 +5,7 @@ import {
   ReserveClaimed as ReserveClaimedEvent,
   Withdrawal as WithdrawalEvent,
 } from '../types/TicketBroker/TicketBroker'
+import { UniswapV2Pair } from '../types/TicketBroker/UniswapV2Pair'
 import {
   DayData,
   WinningTicketRedeemed,
@@ -17,21 +18,31 @@ import {
   DepositFunded,
   Withdrawal,
 } from '../types/schema'
-import { BigDecimal } from '@graphprotocol/graph-ts'
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts'
 import {
   convertToDecimal,
+  getDaiEthPairAddress,
   makeEventId,
   ZERO_BD,
   ZERO_BI,
 } from '../../utils/helpers'
 
 export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
+  let uniswapV2PairAddress = getDaiEthPairAddress()
+  let daiEthPair = UniswapV2Pair.bind(Address.fromString(uniswapV2PairAddress))
   let protocol = Protocol.load('0') || new Protocol('0')
   let round = Round.load(protocol.currentRound)
   let winningTicketRedeemed = new WinningTicketRedeemed(
     makeEventId(event.transaction.hash, event.logIndex),
   )
   let faceValue = convertToDecimal(event.params.faceValue)
+  let ethPrice = ZERO_BD
+
+  // DAI-ETH pair was created during this block
+  if(event.block.number.gt(BigInt.fromI32(10095742))) {
+    let daiEthPairReserves = daiEthPair.getReserves()
+    ethPrice = convertToDecimal(daiEthPairReserves.value0).div(convertToDecimal(daiEthPairReserves.value1))
+  }
 
   winningTicketRedeemed.hash = event.transaction.hash.toHex()
   winningTicketRedeemed.blockNumber = event.block.number
@@ -63,12 +74,12 @@ export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
     Transcoder.load(event.params.recipient.toHex()) ||
     new Transcoder(event.params.recipient.toHex())
   transcoder.totalVolumeETH = transcoder.totalVolumeETH.plus(faceValue)
-  transcoder.totalVolumeUSD = transcoder.totalVolumeUSD.plus(faceValue.times(protocol.ethPrice as BigDecimal))
+  transcoder.totalVolumeUSD = transcoder.totalVolumeUSD.plus(faceValue.times(ethPrice))
   transcoder.save()
 
   // Update total protocol fee volume
   protocol.totalVolumeETH = protocol.totalVolumeETH.plus(faceValue)
-  protocol.totalVolumeUSD = protocol.totalVolumeUSD.plus(faceValue.times(protocol.ethPrice as BigDecimal))
+  protocol.totalVolumeUSD = protocol.totalVolumeUSD.plus(faceValue.times(ethPrice))
   
   protocol.totalWinningTickets = protocol.totalWinningTickets.plus(ZERO_BI)
   protocol.save()
@@ -90,12 +101,12 @@ export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
 
   // Update fee volume for this day
   dayData.volumeETH = dayData.volumeETH.plus(faceValue)
-  dayData.volumeUSD = dayData.volumeUSD.plus(faceValue.times(protocol.ethPrice as BigDecimal))
+  dayData.volumeUSD = dayData.volumeUSD.plus(faceValue.times(ethPrice))
   dayData.save()
 
   // Update fee volume for this round
   round.volumeETH = round.volumeETH.plus(faceValue)
-  round.volumeUSD = round.volumeUSD.plus(faceValue.times(protocol.ethPrice as BigDecimal))
+  round.volumeUSD = round.volumeUSD.plus(faceValue.times(ethPrice))
   round.save()
 }
 

--- a/packages/subgraph/src/mappings/ticketBroker.ts
+++ b/packages/subgraph/src/mappings/ticketBroker.ts
@@ -83,9 +83,9 @@ export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
     dayData.date = dayStartTimestamp
     dayData.volumeUSD = ZERO_BD
     dayData.volumeETH = ZERO_BD
-    dayData.totalSupply = ZERO_BD
-    dayData.totalActiveStake = ZERO_BD
-    dayData.participationRate = ZERO_BD
+    dayData.totalSupply = protocol.totalSupply as BigDecimal
+    dayData.totalActiveStake = protocol.totalActiveStake as BigDecimal
+    dayData.participationRate = protocol.participationRate as BigDecimal
   }
 
   // Update fee volume for this day

--- a/packages/subgraph/src/mappings/ticketBroker.ts
+++ b/packages/subgraph/src/mappings/ticketBroker.ts
@@ -83,6 +83,9 @@ export function winningTicketRedeemed(event: WinningTicketRedeemedEvent): void {
     dayData.date = dayStartTimestamp
     dayData.volumeUSD = ZERO_BD
     dayData.volumeETH = ZERO_BD
+    dayData.totalSupply = ZERO_BD
+    dayData.totalActiveStake = ZERO_BD
+    dayData.participationRate = ZERO_BD
   }
 
   // Update fee volume for this day

--- a/packages/subgraph/src/mappings/uniswapEthDaiPair.ts
+++ b/packages/subgraph/src/mappings/uniswapEthDaiPair.ts
@@ -1,9 +1,0 @@
-import { Sync as SyncEvent } from '../types/UniswapV2Pair/UniswapV2Pair'
-import { Protocol } from '../types/schema'
-import { convertToDecimal } from '../../utils/helpers'
-
-export function handleEthDaiSync(event: SyncEvent): void {
-  let protocol = Protocol.load('0') || new Protocol('0')
-  protocol.ethPrice = convertToDecimal(event.params.reserve0).div(convertToDecimal(event.params.reserve1))
-  protocol.save()
-}

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -259,6 +259,8 @@ dataSources:
       abis:
         - name: TicketBroker
           file: ./abis/TicketBroker.json
+        - name: UniswapV2Pair
+          file: ./abis/UniswapV2Pair.json
       eventHandlers:
         - event: WinningTicketRedeemed(indexed address,indexed address,uint256,uint256,uint256,uint256,bytes)
           handler: winningTicketRedeemed
@@ -335,26 +337,6 @@ dataSources:
       eventHandlers:
         - event: ServiceURIUpdate(indexed address,string)
           handler: serviceURIUpdate
-  - kind: ethereum/contract
-    name: UniswapV2Pair
-    network: {{networkName}}
-    source:
-      startBlock: {{contracts.uniswapEthDaiPair.startBlock}}
-      address: {{contracts.uniswapEthDaiPair.address}}
-      abi: UniswapV2Pair
-    mapping:
-      kind: ethereum/events
-      apiVersion: 0.0.4
-      language: wasm/assemblyscript
-      file: ./src/mappings/uniswapEthDaiPair.ts   
-      entities:
-        - Protocol
-      abis:
-        - name: UniswapV2Pair
-          file: ./abis/UniswapV2Pair.json
-      eventHandlers:
-        - event: Sync(uint112,uint112)
-          handler: handleEthDaiSync
   - kind: ethereum/contract
     name: LivepeerToken
     network: {{networkName}}

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -375,6 +375,8 @@ dataSources:
       eventHandlers:
         - event: Mint(indexed address,uint256)
           handler: mint
+        - event: Burn(indexed address,uint256)
+          handler: burn
 ###############################################################################
 #
 # Data source templates

--- a/packages/subgraph/subgraph.template.yaml
+++ b/packages/subgraph/subgraph.template.yaml
@@ -151,6 +151,8 @@ dataSources:
           file: ./abis/RoundsManager.json
         - name: BondingManager
           file: ./abis/BondingManager_LIP11.json
+        - name: LivepeerToken
+          file: ./abis/LivepeerToken.json
       eventHandlers:
         - event: NewRound(uint256)
           handler: newRound
@@ -178,6 +180,8 @@ dataSources:
           file: ./abis/RoundsManager_streamflow.json
         - name: BondingManager
           file: ./abis/BondingManager_streamflow.json
+        - name: LivepeerToken
+          file: ./abis/LivepeerToken.json
       eventHandlers:
         - event: NewRound(indexed uint256,bytes32)
           handler: newRound
@@ -351,6 +355,26 @@ dataSources:
       eventHandlers:
         - event: Sync(uint112,uint112)
           handler: handleEthDaiSync
+  - kind: ethereum/contract
+    name: LivepeerToken
+    network: {{networkName}}
+    source:
+      startBlock: {{contracts.livepeerToken.startBlock}}
+      address: {{contracts.livepeerToken.address}}
+      abi: LivepeerToken
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/livepeerToken.ts 
+      entities:
+        - Protocol
+      abis:
+        - name: LivepeerToken
+          file: ./abis/LivepeerToken.json
+      eventHandlers:
+        - event: Mint(indexed address,uint256)
+          handler: mint
 ###############################################################################
 #
 # Data source templates

--- a/packages/subgraph/test/integration/test.js
+++ b/packages/subgraph/test/integration/test.js
@@ -13,7 +13,7 @@ const PollABI = require('../../abis/Poll.json')
 const roundsManagerAddress = '0x5f8e26fAcC23FA4cbd87b8d9Dbbd33D5047abDE1'
 const bondingManagerAddress = '0xA94B7f0465E98609391C623d0560C5720a3f2D33'
 const livepeerTokenAddress = '0xD833215cBcc3f914bD1C9ece3EE7BF8B14f841bb'
-const pollCreatorAddress = '0x7414e38377D6DAf6045626EC8a8ABB8a1BC4B97a'
+const pollCreatorAddress = '0x4bf3A7dFB3b76b5B3E169ACE65f888A4b4FCa5Ee'
 
 const defaults = { gas: 1000000 }
 

--- a/packages/subgraph/utils/helpers.ts
+++ b/packages/subgraph/utils/helpers.ts
@@ -94,6 +94,10 @@ export function getLivepeerTokenAddress(network: string): string {
   }
 }
 
+export function getDaiEthPairAddress(): string {
+  return 'a478c2975ab1ea89e8196811f51a7b7ade33eb11'
+}
+
 export function exponentToBigDecimal(decimals: BigInt): BigDecimal {
   let bd = BigDecimal.fromString('1')
   for (let i = ZERO_BI; i.lt(decimals as BigInt); i = i.plus(ONE_BI)) {

--- a/packages/subgraph/utils/helpers.ts
+++ b/packages/subgraph/utils/helpers.ts
@@ -84,6 +84,16 @@ export function getBondingManagerAddress(network: string): string {
   }
 }
 
+export function getLivepeerTokenAddress(network: string): string {
+  if (network == 'mainnet') {
+    return '58b6a8a3302369daec383334672404ee733ab239'
+  } else if (network == 'rinkeby') {
+    return '23b814a57D53b1a7A860194F53401D0D639abED7'
+  } else {
+    return 'D833215cBcc3f914bD1C9ece3EE7BF8B14f841bb'
+  }
+}
+
 export function exponentToBigDecimal(decimals: BigInt): BigDecimal {
   let bd = BigDecimal.fromString('1')
   for (let i = ZERO_BI; i.lt(decimals as BigInt); i = i.plus(ONE_BI)) {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds `totalSupply`, `totalActiveStake` and `participationRate` fields to the `Round`, `Protocol`, and `DayData` entities. The `participationRate` field in the `DayData` entity will power the participation chart in the explorer overview page.