### PR TITLE
fix safari bug

### DIFF
--- a/packages/explorer-2.0/pages/index.tsx
+++ b/packages/explorer-2.0/pages/index.tsx
@@ -21,12 +21,12 @@ type Props = {}
 const Panel = ({ children }) => (
   <Box
     sx={{
-      minHeight: '350px',
+      minHeight: 350,
+      height: 350,
       position: 'relative',
       backgroundColor: 'rgba(255,255,255,.01)',
       padding: 3,
       width: '100%',
-      height: '100%',
       display: 'flex',
       flexDirection: 'column',
       alignItems: 'center',


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes a bug in safari causing the overview charts to overflow into the orchestrator table.

**Screenshots of bug:**
![image](https://user-images.githubusercontent.com/555740/102922531-2bf3a580-445c-11eb-924e-d3db1b493218.png)
