### PR TITLE
fix max unstake bug and projected rewards calculation

### DIFF
--- a/packages/explorer-2.0/@types/index.d.ts
+++ b/packages/explorer-2.0/@types/index.d.ts
@@ -81,7 +81,7 @@ export interface UnbondingLock {
 }
 
 export interface Protocol {
-  totalTokenSupply?: string
+  totalSupply?: string
   totalBondedToken?: string
   paused?: boolean
   targetBondingRate?: string

--- a/packages/explorer-2.0/apollo/createSchema.ts
+++ b/packages/explorer-2.0/apollo/createSchema.ts
@@ -63,7 +63,6 @@ const createSchema = async () => {
     }
     extend type Protocol {
       totalStake(block: String): String
-      totalTokenSupply: String
     }
     extend type Delegator {
       pendingStake: String
@@ -172,12 +171,7 @@ const createSchema = async () => {
           async resolve(_protocol, _args, _ctx, _info) {
             return await getTotalStake(_ctx, _args.blockNumber)
           },
-        },
-        totalTokenSupply: {
-          async resolve(_protocol, _args, _ctx, _info) {
-            return await _ctx.livepeer.rpc.getTokenTotalSupply()
-          },
-        },
+        }
       },
       Poll: {
         totalVoteStake: {

--- a/packages/explorer-2.0/components/AccountMenu/index.tsx
+++ b/packages/explorer-2.0/components/AccountMenu/index.tsx
@@ -220,7 +220,7 @@ const AccountMenu = ({ isInHeader = false }) => {
             fontWeight: 500,
             cursor: 'pointer',
             alignItems: 'center',
-            py: 2,
+            py: 1,
             backgroundColor: 'transparent',
             borderRadius: 5,
             transition: 'color .3s',

--- a/packages/explorer-2.0/components/StakingWidget/InputBox.tsx
+++ b/packages/explorer-2.0/components/StakingWidget/InputBox.tsx
@@ -14,16 +14,9 @@ const InputBox = ({
   protocol,
 }) => {
   const tokenBalance = account && Utils.fromWei(account.tokenBalance.toString())
-
-  let stake = '0'
-  if (
-    (delegator?.bondedAmount || '0') >
-    Utils.fromWei(delegator?.pendingStake || '0')
-  ) {
-    stake = delegator?.bondedAmount || '0'
-  } else {
-    stake = Utils.fromWei(delegator?.pendingStake || '0')
-  }
+  const stake = delegator?.pendingStake
+    ? Utils.fromWei(delegator.pendingStake)
+    : '0'
 
   return (
     <div
@@ -61,7 +54,7 @@ const InputBox = ({
                 </div>
               ) : (
                 <>
-                  {stake && (
+                  {+stake > 0 && (
                     <div
                       data-tip="Enter max"
                       data-for="stake"
@@ -76,9 +69,7 @@ const InputBox = ({
                         effect="solid"
                       />
                       Stake:{' '}
-                      <span sx={{ fontFamily: 'monospace' }}>
-                        {parseFloat(stake).toPrecision(4)}
-                      </span>
+                      <span sx={{ fontFamily: 'monospace' }}>{+stake}</span>
                     </div>
                   )}
                 </>

--- a/packages/explorer-2.0/components/TokenholdersView/index.tsx
+++ b/packages/explorer-2.0/components/TokenholdersView/index.tsx
@@ -28,7 +28,7 @@ const GET_DATA = gql`
       }
     }
     protocol {
-      totalTokenSupply
+      totalSupply
       totalActiveStake
     }
     currentRound: rounds(first: 1, orderBy: timestamp, orderDirection: desc) {

--- a/packages/explorer-2.0/queries/accountView.gql
+++ b/packages/explorer-2.0/queries/accountView.gql
@@ -63,21 +63,11 @@ query($account: ID!) {
     ethBalance
     allowance
   }
-  threeBoxSpace(id: $account) {
-    __typename
-    id
-    did
-    name
-    website
-    description
-    image
-    addressLinks
-    defaultProfile
-  }
   protocol(id: "0") {
     id
-    totalTokenSupply
+    totalSupply
     totalActiveStake
+    participationRate
     inflation
     inflationChange
     currentRound {

--- a/packages/explorer-2.0/queries/orchestratorsView.gql
+++ b/packages/explorer-2.0/queries/orchestratorsView.gql
@@ -61,7 +61,7 @@ query(
   }
   protocol(id: "0") {
     id
-    totalTokenSupply
+    totalSupply
     totalActiveStake
     inflation
     inflationChange


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes a bug reported by a user on discord when clicking "Max" while unstaking causing the page to refresh. It also addresses an issue I noticed causing an incorrect projected rewards calculation (now using newly indexed subgraph values `totalSupply` and `participationRate` as part of calculation).
