### PR TITLE
add transcoder day data

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -293,6 +293,22 @@ type Day @entity {
   participationRate: BigDecimal!
 }
 
+"""
+Transcoder data accumulated and condensed into day stats
+"""
+type TranscoderDay @entity {
+  "Timestamp rounded to current day by dividing by 86400"
+  id: ID!
+  "The date beginning at 12:00am UTC"
+  date: Int!
+  "Fees generated this day in ETH"
+  volumeETH: BigDecimal!
+  "Fees generated this day in USD"
+  volumeUSD: BigDecimal!
+  "Transcoder associated with the day"
+  transcoder: Transcoder!
+}
+
 ###############################################################################
 #
 # Event types && transactions for historical records

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -297,7 +297,7 @@ type Day @entity {
 Transcoder data accumulated and condensed into day stats
 """
 type TranscoderDay @entity {
-  "Timestamp rounded to current day by dividing by 86400"
+  "Combination of the transcoder address and the timestamp rounded to current day by dividing by 86400"
   id: ID!
   "The date beginning at 12:00am UTC"
   date: Int!

--- a/packages/subgraph/src/mappings/ticketBroker.ts
+++ b/packages/subgraph/src/mappings/ticketBroker.ts
@@ -23,6 +23,7 @@ import {
   convertToDecimal,
   createOrLoadDay,
   createOrLoadRound,
+  createOrLoadTranscoderDay,
   getUniswapV1DaiEthExchangeAddress,
   getUniswapV2DaiEthPairAddress,
   makeEventId,
@@ -112,6 +113,16 @@ export function winningTicketRedeemed(event: WinningTicketRedeemed): void {
   day.volumeETH = day.volumeETH.plus(faceValue)
   day.volumeUSD = day.volumeUSD.plus(faceValue.times(ethPrice))
   day.save()
+
+  let transcoderDay = createOrLoadTranscoderDay(
+    event.block.timestamp.toI32(),
+    event.params.recipient.toHex(),
+  )
+  transcoderDay.volumeETH = transcoderDay.volumeETH.plus(faceValue)
+  transcoderDay.volumeUSD = transcoderDay.volumeUSD.plus(
+    faceValue.times(ethPrice),
+  )
+  transcoderDay.save()
 
   // Update fee volume for this round
   round.volumeETH = round.volumeETH.plus(faceValue)

--- a/packages/subgraph/utils/helpers.ts
+++ b/packages/subgraph/utils/helpers.ts
@@ -3,10 +3,10 @@ import { integer } from '@protofire/subgraph-toolkit'
 import {
   Day,
   Delegator,
-  Pool,
   Protocol,
   Round,
   Transcoder,
+  TranscoderDay,
 } from '../src/types/schema'
 
 let x = BigInt.fromI32(2)
@@ -210,6 +210,28 @@ export function createOrLoadDay(timestamp: i32): Day {
     day.save()
   }
   return day as Day
+}
+
+export function createOrLoadTranscoderDay(
+  timestamp: i32,
+  transcoderAddress: string,
+): TranscoderDay {
+  let dayID = timestamp / 86400
+  let dayStartTimestamp = dayID * 86400
+  let transcoderDayID = transcoderAddress
+    .concat('-')
+    .concat(BigInt.fromI32(dayID).toString())
+  let transcoderDay = TranscoderDay.load(transcoderDayID)
+
+  if (transcoderDay == null) {
+    transcoderDay = new TranscoderDay(transcoderDayID)
+    transcoderDay.date = dayStartTimestamp
+    transcoderDay.transcoder = transcoderAddress
+    transcoderDay.volumeUSD = ZERO_BD
+    transcoderDay.volumeETH = ZERO_BD
+    transcoderDay.save()
+  }
+  return transcoderDay as TranscoderDay
 }
 
 export function createOrLoadRound(blockNumber: BigInt): Round {


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds a `TranscoderDay` entity for tracking daily fees earned by transcoders. This can be used for estimating minutes of video transcoded per orchestrator in combination with off chain pricing data.