### PR TITLE
add protocol status banner

### DIFF
--- a/packages/explorer-2.0/layouts/main.tsx
+++ b/packages/explorer-2.0/layouts/main.tsx
@@ -51,12 +51,15 @@ const Layout = ({
   const client: any = useApolloClient()
   const context = useWeb3React()
 
-  const { data: pollData } = useQuery(
+  const { data } = useQuery(
     gql`
       {
         polls {
           isActive
           endBlock
+        }
+        protocol(id: "0") {
+          paused
         }
       }
     `,
@@ -68,7 +71,7 @@ const Layout = ({
   const [txDialogState, setTxDialogState]: any = useState([])
   const { width } = useWindowSize()
   const ref = useRef()
-  const totalActivePolls = pollData?.polls.filter((p) => p.isActive).length
+  const totalActivePolls = data?.polls.filter((p) => p.isActive).length
   const GET_TX_SUMMARY_MODAL = gql`
     {
       txSummaryModal @client {
@@ -213,6 +216,23 @@ const Layout = ({
       </Modal>
       <MutationsContext.Provider value={mutations}>
         <Styled.root sx={{ height: 'calc(100vh - 82px)' }}>
+          {data?.protocol.paused && (
+            <Flex
+              sx={{
+                py: 10,
+                px: 2,
+                width: '100%',
+                alignItems: 'center',
+                color: 'black',
+                justifyContent: 'center',
+                background: 'orange',
+                fontWeight: 500,
+                fontSize: 2,
+              }}
+            >
+              The protocol is paused.
+            </Flex>
+          )}
           {bannerActive && (
             <Flex
               sx={{


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds support for a protocol status banner in case the protocol is paused.

**Screenshots (optional):**
![localhost_3000_](https://user-images.githubusercontent.com/555740/104400304-492e0800-5520-11eb-8e25-3f5cfc2dd7f6.png)

Note: need a follow up PR that disables staking actions so users know they can't bond/unbond during pauses.