### PR TITLE
set lastRewardRound optional

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -66,7 +66,7 @@ type Transcoder @entity {
   "Status of the transcoder"
   status: TranscoderStatus!
   "Last round that the transcoder called reward"
-  lastRewardRound: Round!
+  lastRewardRound: Round
   "% of block reward cut paid to transcoder by a delegator"
   rewardCut: BigInt!
   "% of fees paid to delegators by transcoder"

--- a/packages/subgraph/utils/helpers.ts
+++ b/packages/subgraph/utils/helpers.ts
@@ -162,7 +162,6 @@ export function createOrLoadTranscoder(id: string): Transcoder {
     transcoder.lastActiveStakeUpdateRound = ZERO_BI;
     transcoder.active = false;
     transcoder.status = "NotRegistered";
-    transcoder.lastRewardRound = ZERO_BI.toString();
     transcoder.rewardCut = ZERO_BI;
     transcoder.feeShare = ZERO_BI;
     transcoder.pricePerSegment = ZERO_BI;


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Quering a transcoder with no `lastRewardRound` currently throws an error since it was recently made a required field. This causes some account pages on the explorer delegated to a transcoder with no `lastRewardRound` to not load. This PR resolves this issue by setting the `lastRewardRound` field on the `transcoder` entity as optional.