### PR TITLE
set lastClaimRound optional

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -169,7 +169,7 @@ type Delegator @entity {
   "Round the delegator becomes bonded and delegated to its delegate"
   startRound: BigInt!
   "Last round that the delegator claimed reward and fee pool shares"
-  lastClaimRound: Round!
+  lastClaimRound: Round
   "Amount of Livepeer Token a delegator currently has bonded"
   bondedAmount: BigDecimal!
   "Amount of Livepeer Token a delegator has bonded over its lifetime separate from rewards"

--- a/packages/subgraph/utils/helpers.ts
+++ b/packages/subgraph/utils/helpers.ts
@@ -181,7 +181,6 @@ export function createOrLoadDelegator(id: string): Delegator {
   if (delegator == null) {
     delegator = new Delegator(id);
     delegator.startRound = ZERO_BI;
-    delegator.lastClaimRound = ZERO_BI.toString();
     delegator.bondedAmount = ZERO_BD;
     delegator.principal = ZERO_BD;
     delegator.unbonded = ZERO_BD;


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Quering a `delegator` with no `lastClaimRound` currently throws an error since it was recently made a required field. This PR resolves this issue by setting the `lastClaimRound` field on the `delegator` entity as optional.