### PR TITLE
use int for subgraph count fields

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -9,10 +9,10 @@ type Protocol @entity {
   "Change in inflation rate per round until the target bonding rate is achieved"
   inflationChange: BigInt!
   "Max number of rounds that a caller can claim earnings for at once"
-  maxEarningsClaimsRounds: BigInt!
+  maxEarningsClaimsRounds: Int!
     @deprecated(reason: "This constraint of was removed as of LIP-52")
   "Total active transcoders"
-  numActiveTranscoders: BigInt!
+  numActiveTranscoders: Int!
   "True if the protocol is paused"
   paused: Boolean!
   "Target bonding rate (participation) that determines whether inflation should increase or decrease"
@@ -41,12 +41,12 @@ type Protocol @entity {
   roundLength: BigInt!
   "Block when round length was last updated"
   lastRoundLengthUpdateStartBlock: BigInt!
-  "Total rounds"
-  roundCount: BigInt!
-  "Total winning tickets"
-  totalWinningTickets: BigInt!
   "Livepeer Token supply"
   totalSupply: BigDecimal!
+  "Total winning tickets"
+  winningTicketCount: Int!
+  "Total rounds"
+  roundCount: Int!
 }
 
 """

--- a/packages/subgraph/src/mappings/bondingManager_deprecated.ts
+++ b/packages/subgraph/src/mappings/bondingManager_deprecated.ts
@@ -42,10 +42,7 @@ import { integer } from "@protofire/subgraph-toolkit";
 export function transcoderUpdate(event: TranscoderUpdate): void {
   let bondingManager = BondingManager.bind(event.address);
   let round = createOrLoadRound(event.block.number);
-  let transcoder =
-    Transcoder.load(event.params.transcoder.toHex()) ||
-    new Transcoder(event.params.transcoder.toHex());
-
+  let transcoder = createOrLoadTranscoder(event.params.transcoder.toHex());
   let active = bondingManager.isActiveTranscoder(
     event.params.transcoder,
     integer.fromString(round.id)
@@ -158,12 +155,11 @@ export function bond(call: BondCall): void {
     let amount = convertToDecimal(call.inputs._amount);
     let delegatorData = bondingManager.getDelegator(delegatorAddress);
     let delegateData = bondingManager.getDelegator(newDelegateAddress);
-    let protocol = Protocol.load("0");
-
     let round = createOrLoadRound(call.block.number);
     let transcoder = createOrLoadTranscoder(newDelegateAddress.toHex());
     let delegate = createOrLoadDelegator(newDelegateAddress.toHex());
     let delegator = createOrLoadDelegator(delegatorAddress.toHex());
+    let protocol = Protocol.load("0");
 
     if (delegator.delegate) {
       oldDelegateAddress = Address.fromString(delegator.delegate);
@@ -260,13 +256,13 @@ export function unbond(event: Unbond): void {
   let bondingManager = BondingManager.bind(event.address);
   let delegator = Delegator.load(event.params.delegator.toHex());
   let transcoderAddress = delegator.delegate;
-  let protocol = Protocol.load("0");
   let round = createOrLoadRound(event.block.number);
   let transcoder = Transcoder.load(transcoderAddress);
   let delegate = Delegator.load(transcoderAddress);
   let delegateData = bondingManager.getDelegator(
     Address.fromString(transcoderAddress)
   );
+  let protocol = Protocol.load("0");
   let delegatorData = bondingManager.getDelegator(event.params.delegator);
 
   transcoder.totalStake = convertToDecimal(delegateData.value3);
@@ -320,7 +316,6 @@ export function claimEarnings(call: ClaimEarningsCall): void {
   if (call.block.number.le(BigInt.fromI32(9274414))) {
     let delegatorAddress = call.from;
     let endRound = call.inputs._endRound;
-    let protocol = Protocol.load("0");
     let round = createOrLoadRound(call.block.number);
     let delegator = createOrLoadDelegator(delegatorAddress.toHex());
     let bondingManager = BondingManager.bind(call.to);

--- a/packages/subgraph/src/mappings/livepeerToken.ts
+++ b/packages/subgraph/src/mappings/livepeerToken.ts
@@ -9,13 +9,13 @@ import { Mint, Burn } from "../types/LivepeerToken/LivepeerToken";
 import { Transaction, MintEvent, BurnEvent, Protocol } from "../types/schema";
 
 export function mint(event: Mint): void {
+  let day = createOrLoadDay(event.block.timestamp.toI32());
   let protocol = Protocol.load("0");
   let amount = convertToDecimal(event.params.amount);
   let totalSupply = protocol.totalSupply.plus(amount);
 
   protocol.totalSupply = totalSupply;
 
-  let day = createOrLoadDay(event.block.timestamp.toI32());
   day.totalSupply = totalSupply;
   day.totalActiveStake = protocol.totalActiveStake;
 
@@ -54,13 +54,13 @@ export function mint(event: Mint): void {
 }
 
 export function burn(event: Burn): void {
+  let round = createOrLoadRound(event.block.number);
+  let day = createOrLoadDay(event.block.timestamp.toI32());
   let protocol = Protocol.load("0");
   let value = convertToDecimal(event.params.value);
   let totalSupply = protocol.totalSupply.minus(value);
 
   protocol.totalSupply = totalSupply;
-
-  let day = createOrLoadDay(event.block.timestamp.toI32());
 
   day.totalSupply = totalSupply;
   day.totalActiveStake = protocol.totalActiveStake;
@@ -70,7 +70,6 @@ export function burn(event: Burn): void {
     day.participationRate = protocol.participationRate;
   }
 
-  let round = createOrLoadRound(event.block.number);
   round.totalSupply = totalSupply;
   round.participationRate = protocol.participationRate;
   round.save();

--- a/packages/subgraph/src/mappings/minter.ts
+++ b/packages/subgraph/src/mappings/minter.ts
@@ -17,8 +17,9 @@ import {
 
 export function setCurrentRewardTokens(event: SetCurrentRewardTokens): void {
   let minter = Minter.bind(event.address);
-  let protocol = Protocol.load("0");
   let round = createOrLoadRound(event.block.number);
+  let protocol = Protocol.load("0");
+
   round.mintableTokens = convertToDecimal(event.params.currentMintableTokens);
   round.save();
 
@@ -56,8 +57,8 @@ export function setCurrentRewardTokens(event: SetCurrentRewardTokens): void {
 
 export function parameterUpdate(event: ParameterUpdate): void {
   let minter = Minter.bind(event.address);
-  let protocol = Protocol.load("0");
   let round = createOrLoadRound(event.block.number);
+  let protocol = Protocol.load("0");
 
   if (event.params.param == "targetBondingRate") {
     protocol.targetBondingRate = minter.targetBondingRate();

--- a/packages/subgraph/src/mappings/roundsManager.ts
+++ b/packages/subgraph/src/mappings/roundsManager.ts
@@ -38,11 +38,12 @@ export function newRound(event: NewRound): void {
   let bondingManager = BondingManager.bind(
     Address.fromString(bondingManagerAddress)
   );
+  let round = createOrLoadRound(event.block.number);
+  let day = createOrLoadDay(event.block.timestamp.toI32());
   let currentTranscoder = bondingManager.getFirstTranscoderInPool();
   let transcoder = Transcoder.load(currentTranscoder.toHex());
   let totalActiveStake = convertToDecimal(bondingManager.getTotalBonded());
 
-  let round = createOrLoadRound(event.block.number);
   round.initialized = true;
   round.totalActiveStake = totalActiveStake;
   round.save();
@@ -81,7 +82,6 @@ export function newRound(event: NewRound): void {
   protocol.lastInitializedRound = event.params.round.toString();
   protocol.totalActiveStake = totalActiveStake;
 
-  let day = createOrLoadDay(event.block.timestamp.toI32());
   day.totalActiveStake = totalActiveStake;
   day.totalSupply = protocol.totalSupply;
 

--- a/packages/subgraph/src/mappings/roundsManager_deprecated.ts
+++ b/packages/subgraph/src/mappings/roundsManager_deprecated.ts
@@ -31,12 +31,12 @@ export function newRound(event: NewRound): void {
   let bondingManager = BondingManager.bind(
     Address.fromString(bondingManagerAddress)
   );
+  let day = createOrLoadDay(event.block.timestamp.toI32());
+  let round = createOrLoadRound(event.block.number);
   let currentTranscoder = bondingManager.getFirstTranscoderInPool();
   let transcoder = Transcoder.load(currentTranscoder.toHex());
-
   let totalActiveStake = convertToDecimal(bondingManager.getTotalBonded());
 
-  let round = createOrLoadRound(event.block.number);
   round.initialized = true;
   round.totalActiveStake = totalActiveStake;
   round.save();
@@ -90,7 +90,6 @@ export function newRound(event: NewRound): void {
   protocol.lastInitializedRound = event.params.round.toString();
   protocol.totalActiveStake = totalActiveStake;
 
-  let day = createOrLoadDay(event.block.timestamp.toI32());
   day.totalActiveStake = totalActiveStake;
   day.totalSupply = protocol.totalSupply;
 

--- a/packages/subgraph/utils/helpers.ts
+++ b/packages/subgraph/utils/helpers.ts
@@ -127,6 +127,7 @@ export function createOrLoadProtocol(): Protocol {
   let protocol = Protocol.load("0");
   if (protocol == null) {
     protocol = new Protocol("0");
+    protocol.paused = false;
     protocol.currentRound = ZERO_BI.toString();
     protocol.lastInitializedRound = ZERO_BI.toString();
     protocol.lastRoundLengthUpdateRound = ZERO_BI.toString();
@@ -134,10 +135,6 @@ export function createOrLoadProtocol(): Protocol {
     protocol.inflationChange = ZERO_BI;
     protocol.lastRoundLengthUpdateStartBlock = ZERO_BI;
     protocol.lockPeriod = ZERO_BI;
-    protocol.maxEarningsClaimsRounds = ZERO_BI;
-    protocol.numActiveTranscoders = ZERO_BI;
-    protocol.paused = false;
-    protocol.roundCount = ZERO_BI;
     protocol.roundLength = ZERO_BI;
     protocol.roundLockAmount = ZERO_BI;
     protocol.targetBondingRate = ZERO_BI;
@@ -146,8 +143,11 @@ export function createOrLoadProtocol(): Protocol {
     protocol.participationRate = ZERO_BD;
     protocol.totalVolumeETH = ZERO_BD;
     protocol.totalVolumeUSD = ZERO_BD;
-    protocol.totalWinningTickets = ZERO_BI;
     protocol.unbondingPeriod = ZERO_BI;
+    protocol.maxEarningsClaimsRounds = 0;
+    protocol.numActiveTranscoders = 0;
+    protocol.winningTicketCount = 0;
+    protocol.roundCount = 0;
     protocol.save();
   }
   return protocol as Protocol;
@@ -258,7 +258,7 @@ export function createOrLoadRound(blockNumber: BigInt): Round {
       roundsSinceLastUpdate.times(protocol.roundLength)
     );
     round = createRound(startBlock, protocol.roundLength, newRound);
-    protocol.roundCount = protocol.roundCount.plus(BigInt.fromI32(1));
+    protocol.roundCount = protocol.roundCount + 1;
     protocol.currentRound = newRound.toString();
     protocol.save();
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR makes some small subgraph improvements:
- uses Int instead of BigInt for count fields
- loads protocol entity *after* entity creations inside mappings (unable to update protocol entity inside helper methods if we load it before hand)
- uses uniform count naming convention for aggregate data (ie `winningTicketCount` instead of `totalWinningTickets`).