### PR TITLE
fix performance table region views

### DIFF
--- a/packages/explorer-2.0/apollo/createSchema.ts
+++ b/packages/explorer-2.0/apollo/createSchema.ts
@@ -355,21 +355,21 @@ const createSchema = async () => {
                 id: key,
                 scores: {
                   global: avg(metrics[key], "score") * 10000,
-                  fra: metrics[key].FRA?.score || 0 * 10000,
-                  mdw: metrics[key].MDW?.score || 0 * 10000,
-                  sin: metrics[key].SIN?.score || 0 * 10000,
+                  fra: (metrics[key].FRA?.score || 0) * 10000,
+                  mdw: (metrics[key].MDW?.score || 0) * 10000,
+                  sin: (metrics[key].SIN?.score || 0) * 10000,
                 },
                 successRates: {
                   global: avg(metrics[key], "success_rate") * 100,
-                  fra: metrics[key].FRA?.success_rate || 0 * 100,
-                  mdw: metrics[key].MDW?.success_rate || 0 * 100,
-                  sin: metrics[key].SIN?.success_rate || 0 * 100,
+                  fra: (metrics[key].FRA?.success_rate || 0) * 100,
+                  mdw: (metrics[key].MDW?.success_rate || 0) * 100,
+                  sin: (metrics[key].SIN?.success_rate || 0) * 100,
                 },
                 roundTripScores: {
                   global: avg(metrics[key], "round_trip_score") * 10000,
-                  fra: metrics[key].FRA?.round_trip_score || 0 * 10000,
-                  mdw: metrics[key].MDW?.round_trip_score || 0 * 10000,
-                  sin: metrics[key].SIN?.round_trip_score || 0 * 10000,
+                  fra: (metrics[key].FRA?.round_trip_score || 0) * 10000,
+                  mdw: (metrics[key].MDW?.round_trip_score || 0) * 10000,
+                  sin: (metrics[key].SIN?.round_trip_score || 0) * 10000,
                 },
               });
             }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The performance table region views currently display a value of 0 for all orchestrators (bug introduced in this [commit](https://github.com/livepeer/livepeerjs/commit/ba054a43db07660de436dc11d1b89d69bdb5860e)). This PR fixes the issue by wrapping the `NaN` check in parentheses.