### PR TITLE
Support price updates when calculating usage

### DIFF
--- a/packages/explorer-2.0/apollo/resolvers/Query.tsx
+++ b/packages/explorer-2.0/apollo/resolvers/Query.tsx
@@ -246,7 +246,7 @@ export async function getChartData(_obj, _args, _ctx, _info) {
       // if Livepeer.com's broadcaster changed max price, use updated price
       if (
         pricePerPixelIndex &&
-        item.date <= pricePerPixel[pricePerPixelIndex].startDate
+        item.date < pricePerPixel[pricePerPixelIndex].startDate
       ) {
         pricePerPixelIndex--;
       }

--- a/packages/explorer-2.0/apollo/resolvers/Query.tsx
+++ b/packages/explorer-2.0/apollo/resolvers/Query.tsx
@@ -235,7 +235,7 @@ export async function getChartData(_obj, _args, _ctx, _info) {
     let totalFeeDerivedMinutes = 0;
     let totalFeeDerivedMinutesOneWeekAgo = 0;
     let totalFeeDerivedMinutesTwoWeeksAgo = 0;
-    let pricePerPixelIndex = 0;
+    let pricePerPixelIndex = pricePerPixel.length - 1;
 
     // merge in Livepeer.com usage data
     dayData = dayData.map((item) => {
@@ -244,8 +244,11 @@ export async function getChartData(_obj, _args, _ctx, _info) {
       );
 
       // if Livepeer.com's broadcaster changed max price, use updated price
-      if (item.date >= pricePerPixel[pricePerPixelIndex].endDate) {
-        pricePerPixelIndex++;
+      if (
+        pricePerPixelIndex &&
+        item.date <= pricePerPixel[pricePerPixelIndex].startDate
+      ) {
+        pricePerPixelIndex--;
       }
 
       const feeDerivedMinutes = getTotalFeeDerivedMinutes({


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR adds support for Livepeer.com price updates for more precise usage data displayed in the chart.

Closes #950 