### PR TITLE
update documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,6 @@ other resources:
 - 🌐 [The Livepeer Website](https://livepeer.org)
 - 🔭 [The 10-Minute Primer](https://livepeer.org/primer/)
 - ✍ [The Livepeer Blog](https://medium.com/livepeer-blog)
-- 📖 [The Livepeer Docs](https://livepeer.readthedocs.io/)
+- 📖 [The Livepeer Docs](https://livepeer.org/docs)
 - 💬 [The Livepeer Chat](https://discord.gg/uaPhtyrWsF)
 - ❓ [The Livepeer Forum](https://forum.livepeer.org/)

--- a/packages/explorer-2.0/components/Drawer/index.tsx
+++ b/packages/explorer-2.0/components/Drawer/index.tsx
@@ -129,7 +129,7 @@ const Index = ({ items = [], open, onDrawerOpen, onDrawerClose }) => {
               </Box>
               <Box sx={{ mb: 10 }}>
                 <a
-                  href="https://livepeer.readthedocs.io/"
+                  href="https://livepeer.org/docs"
                   target="_blank"
                   rel="noopener noreferrer"
                   sx={{

--- a/packages/explorer-2.0/components/Orchestrators/PerformanceTable.tsx
+++ b/packages/explorer-2.0/components/Orchestrators/PerformanceTable.tsx
@@ -457,7 +457,7 @@ const PerformanceTable = ({
               delayUpdate={500}
             />
             <Help
-              data-tip='<span>The average percentage of video segments sent by a broadcaster that are successfully transcoded. See <a href="http://livepeer.readthedocs.io/en/latest/reference/leaderboard_faq.html" rel="noopener noreferrer" target="_blank">the FAQ</a> for more details on how this metric is calculated.</span>'
+              data-tip='<span>The average percentage of video segments sent by a broadcaster that are successfully transcoded. See <a href="https://livepeer.org/docs/video-miners/reference/leaderboard" rel="noopener noreferrer" target="_blank">the FAQ</a> for more details on how this metric is calculated.</span>'
               data-for="tooltip-success-rate"
               sx={{
                 cursor: "pointer",
@@ -484,7 +484,7 @@ const PerformanceTable = ({
               delayUpdate={500}
             />
             <Help
-              data-tip='<span>The average utility of the overall transcoding latency for an orchestrator. See <a href="http://livepeer.readthedocs.io/en/latest/reference/leaderboard_faq.html" rel="noopener noreferrer" target="_blank">the FAQ</a> for more details on how this metric is calculated.</span>'
+              data-tip='<span>The average utility of the overall transcoding latency for an orchestrator. See <a href="https://livepeer.org/docs/video-miners/reference/leaderboard" rel="noopener noreferrer" target="_blank">the FAQ</a> for more details on how this metric is calculated.</span>'
               data-for="tooltip-latency-score"
               sx={{
                 cursor: "pointer",
@@ -511,7 +511,7 @@ const PerformanceTable = ({
               delayUpdate={500}
             />
             <Help
-              data-tip='<span>The average utility of the overall quality and reliability of an orchestrator based on success rate and latency scores. See <a href="http://livepeer.readthedocs.io/en/latest/reference/leaderboard_faq.html" rel="noopener noreferrer" target="_blank">the FAQ</a> for more details on how this metric is calculated.</span>'
+              data-tip='<span>The average utility of the overall quality and reliability of an orchestrator based on success rate and latency scores. See <a href="https://livepeer.org/docs/video-miners/reference/leaderboard" rel="noopener noreferrer" target="_blank">the FAQ</a> for more details on how this metric is calculated.</span>'
               data-for="tooltip-score"
               sx={{
                 cursor: "pointer",


### PR DESCRIPTION
This PR updates the documentation links to point to the new docs at https://livepeer.org/docs.