### PR TITLE
Prevent MetaMask from overestimating gas fee

### DIFF
--- a/packages/explorer-2.0/apollo/resolvers/Mutation.tsx
+++ b/packages/explorer-2.0/apollo/resolvers/Mutation.tsx
@@ -29,6 +29,7 @@ export async function approve(_obj, _args, _ctx) {
         amount,
       ]);
       txHash = await _ctx.livepeer.rpc.approveTokenBondAmount(amount, {
+        gas,
         returnTxHash: true,
       });
       return {
@@ -45,6 +46,7 @@ export async function approve(_obj, _args, _ctx) {
       ]);
 
       txHash = await _ctx.livepeer.rpc.approveTokenPollCreationCost(amount, {
+        gas,
         returnTxHash: true,
       });
       return {
@@ -147,6 +149,7 @@ export async function bond(_obj, _args, _ctx) {
     ..._ctx.livepeer.config.defaultTx,
     to: _ctx.livepeer.config.contracts["BondingManager"].address,
     data,
+    gas,
     returnTxHash: true,
   });
 
@@ -188,6 +191,7 @@ export async function unbond(_obj, _args, _ctx) {
     ..._ctx.livepeer.config.defaultTx,
     to: _ctx.livepeer.config.contracts["BondingManager"].address,
     data,
+    gas,
     returnTxHash: true,
   });
 
@@ -231,6 +235,7 @@ export async function rebond(_obj, _args, _ctx) {
     ..._ctx.livepeer.config.defaultTx,
     to: _ctx.livepeer.config.contracts["BondingManager"].address,
     data,
+    gas,
     returnTxHash: true,
   });
 
@@ -259,6 +264,7 @@ export async function withdrawStake(_obj, _args, _ctx) {
 
   const txHash = await _ctx.livepeer.rpc.withdrawStake(unbondingLockId, {
     ..._ctx.livepeer.config.defaultTx,
+    gas,
     returnTxHash: true,
   });
 
@@ -300,6 +306,7 @@ export async function withdrawFees(_obj, _args, _ctx) {
     ..._ctx.livepeer.config.defaultTx,
     to: _ctx.livepeer.config.contracts["BondingManager"].address,
     data,
+    gas,
     returnTxHash: true,
   });
 
@@ -343,6 +350,7 @@ export async function rebondFromUnbonded(_obj, _args, _ctx) {
     ..._ctx.livepeer.config.defaultTx,
     to: _ctx.livepeer.config.contracts["BondingManager"].address,
     data,
+    gas,
     returnTxHash: true,
   });
 
@@ -367,6 +375,7 @@ export async function initializeRound(_obj, _args, _ctx) {
     []
   );
   const txHash = await _ctx.livepeer.rpc.initializeRound({
+    gas,
     returnTxHash: true,
   });
 
@@ -393,6 +402,7 @@ export async function createPoll(_obj, _args, _ctx) {
 
   const txHash = await _ctx.livepeer.rpc.createPoll(Utils.fromAscii(proposal), {
     ..._ctx.livepeer.config.defaultTx,
+    gas,
     returnTxHash: true,
   });
 
@@ -415,6 +425,7 @@ export async function vote(_obj, _args, _ctx) {
   const gas = await _ctx.livepeer.rpc.estimateGas("Poll", "vote", [choiceId]);
   const txHash = await _ctx.livepeer.rpc.vote(pollAddress, choiceId, {
     ..._ctx.livepeer.config.defaultTx,
+    gas,
     returnTxHash: true,
   });
 


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR prevents MetaMask from overestimating the gas fee for transactions submitted from the Explorer by explicitly setting the estimated gas in the transaction. 

 **How did you test each of these updates (required)**
I created a bond and unbond transaction with and without explicitly setting the estimated gas and it's clear that MetaMask is overestimating the gas fee by a good amount.

**Bond Transaction**
| MetaMask estimation        | Manual estimation           | 
| ------------- |:-------------:| 
| 0.085776 ($143.26)      | 0.068621 ($114.61) |

**Unbond Transaction**
| MetaMask estimation        | Manual estimation           | 
| ------------- |:-------------:| 
| 0.082428 ($137.93)      | 0.065943 ($110.35) |


**Checklist:**

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
