### PR TITLE
Expose usage data via api

### DIFF
--- a/packages/explorer-2.0/apollo/resolvers/Query.tsx
+++ b/packages/explorer-2.0/apollo/resolvers/Query.tsx
@@ -122,7 +122,7 @@ export async function block(_obj, _args, _ctx, _info) {
   };
 }
 
-export async function getChartData(_obj, _args, _ctx, _info) {
+export async function getChartData(_obj?, _args?, _ctx?, _info?) {
   const data = {
     dayData: [],
     weeklyData: [],
@@ -370,6 +370,7 @@ export async function getChartData(_obj, _args, _ctx, _info) {
     data.oneDayVolumeUSD = oneDayVolumeUSD;
     data.oneWeekVolumeUSD = oneWeekVolumeUSD;
     data.oneWeekVolumeETH = oneWeekVolumeETH;
+    data.totalUsage = totalFeeDerivedMinutes + totalLivepeerComUsage;
     data.oneWeekUsage = oneWeekUsage;
     data.weeklyUsageChange = weeklyUsageChange;
     data.weeklyVolumeChangeUSD = weeklyVolumeChangeUSD;

--- a/packages/explorer-2.0/pages/api/totalTokenSupply.tsx
+++ b/packages/explorer-2.0/pages/api/totalTokenSupply.tsx
@@ -1,4 +1,6 @@
-const totalTokenSupply = async (_req, res) => {
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const totalTokenSupply = async (_req: NextApiRequest, res: NextApiResponse) => {
   const response = await fetch(
     `https://${
       process.env.NEXT_PUBLIC_NETWORK === "rinkeby" ? "api-rinkeby" : "api"

--- a/packages/explorer-2.0/pages/api/usage.tsx
+++ b/packages/explorer-2.0/pages/api/usage.tsx
@@ -1,0 +1,9 @@
+import { getChartData } from "../../apollo/resolvers/Query";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const usageData = async (_req: NextApiRequest, res: NextApiResponse) => {
+  const usage = await getChartData();
+  res.json(usage);
+};
+
+export default usageData;


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR exposes the usage data that powers the charts at `/api/usage`.