### PR TITLE
remove ethgasstation api call

### DIFF
--- a/packages/explorer-2.0/apollo/resolvers/Query.tsx
+++ b/packages/explorer-2.0/apollo/resolvers/Query.tsx
@@ -112,13 +112,8 @@ export async function threeBoxSpace(_obj, _args, _ctx, _info) {
 
 export async function block(_obj, _args, _ctx, _info) {
   const { number: blockNumber } = await _ctx.livepeer.rpc.getBlock("latest");
-  const response = await fetch(
-    "https://ethgasstation.info/json/ethgasAPI.json"
-  );
-  const ethGasStationResult = await response.json();
   return {
     number: blockNumber,
-    time: ethGasStationResult.block_time,
   };
 }
 

--- a/packages/explorer-2.0/components/RoundStatus/index.tsx
+++ b/packages/explorer-2.0/components/RoundStatus/index.tsx
@@ -17,6 +17,8 @@ const GET_ROUND_MODAL_STATUS = gql`
   }
 `;
 
+const BLOCK_TIME = 13; // ethereum blocks are confirmed on average 13 seconds
+
 const Index = () => {
   const isVisible = usePageVisibility();
   const { data: modalData } = useQuery(GET_ROUND_MODAL_STATUS);
@@ -106,7 +108,7 @@ const Index = () => {
     ? +protocolData.protocol.roundLength -
       (blockData.block.number - +protocolData.protocol.currentRound.startBlock)
     : 0;
-  const timeRemaining = blockData.block.time * blocksRemaining;
+  const timeRemaining = BLOCK_TIME * blocksRemaining;
   const blocksSinceCurrentRoundStart = initialized
     ? blockData.block.number - +protocolData.protocol.currentRound.startBlock
     : 0;
@@ -137,16 +139,14 @@ const Index = () => {
             roundStatusModalOpen: true,
           },
         })
-      }
-    >
+      }>
       <Box>
         <Flex
           css={{
             alignItems: "center",
             justifyContent: "space-between",
             fontFamily: "$monospace",
-          }}
-        >
+          }}>
           <Box
             css={{
               width: 16,
@@ -154,8 +154,7 @@ const Index = () => {
               height: 16,
               minHeight: 16,
               mr: 12,
-            }}
-          >
+            }}>
             <CircularProgressbar
               strokeWidth={10}
               styles={buildStyles({
@@ -180,12 +179,10 @@ const Index = () => {
               alignItems: "center",
               justifyContent: "space-between",
               width: "100%",
-            }}
-          >
+            }}>
             <Box>Round #{currentRoundNumber}</Box>
             <Flex
-              css={{ alignItems: "center", fontSize: "$2", fontWeight: 600 }}
-            >
+              css={{ alignItems: "center", fontSize: "$2", fontWeight: 600 }}>
               Initialized{" "}
               {initialized ? (
                 <Box
@@ -200,15 +197,13 @@ const Index = () => {
               )}
             </Flex>
           </Flex>
-        }
-      >
+        }>
         <Flex
           css={{
             pb: "$4",
             justifyContent: "space-between",
             alignItems: "center",
-          }}
-        >
+          }}>
           <Box
             css={{
               width: 160,
@@ -220,8 +215,7 @@ const Index = () => {
               "@bp3": {
                 display: "block",
               },
-            }}
-          >
+            }}>
             <Box
               as={CircularProgressbar}
               strokeWidth={10}
@@ -231,8 +225,7 @@ const Index = () => {
                 textColor: theme.colors.text,
                 trailColor: theme.colors.lightBlack,
               })}
-              value={Math.round(percentage)}
-            >
+              value={Math.round(percentage)}>
               <Box css={{ textAlign: "center" }}>
                 <Box css={{ fontWeight: "bold", fontSize: "$5" }}>
                   {blocksSinceCurrentRoundStart}
@@ -251,8 +244,7 @@ const Index = () => {
                 fontWeight: "bold",
                 borderBottom: "1px dashed",
                 borderColor: "$text",
-              }}
-            >
+              }}>
               {blocksRemaining} blocks
             </Box>{" "}
             and approximately{" "}
@@ -262,8 +254,7 @@ const Index = () => {
                 fontWeight: "bold",
                 borderBottom: "1px dashed",
                 borderColor: "$text",
-              }}
-            >
+              }}>
               {moment().add(timeRemaining, "seconds").fromNow(true)}
             </Box>{" "}
             remaining until the current round ends and round{" "}
@@ -273,8 +264,7 @@ const Index = () => {
                 fontWeight: "bold",
                 borderBottom: "1px dashed",
                 borderColor: "$text",
-              }}
-            >
+              }}>
               #{currentRoundNumber + 1}
             </Box>{" "}
             begins.


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR fixes an issue that causes the Explorer to refresh and display a blank page due the ethgasstation API throwing an error. It seems a breaking change was introduced to the ethgasstation API where it now requires an API key. The only dependency on that endpoint is the rounds widget where we provide an estimate of time remaining in a round.  This PR removes the ethgasstation endpoint and instead hardcodes the average block time of 13 seconds to estimate time left in a round. 