### PR TITLE
get block data powering charts from blocklytics subgraph

### DIFF
--- a/packages/explorer-2.0/apollo/index.tsx
+++ b/packages/explorer-2.0/apollo/index.tsx
@@ -9,3 +9,10 @@ export const client = new ApolloClient({
   }),
   cache: new InMemoryCache(),
 });
+
+export const blockClient = new ApolloClient({
+  link: new HttpLink({
+    uri: "https://api.thegraph.com/subgraphs/name/blocklytics/ethereum-blocks",
+  }),
+  cache: new InMemoryCache(),
+});


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR changes the way we fetch the ethereum block information that powers the charts. It now uses the blocklytics subgraph as opposed to etherscan, which would occasionally return a null result for some reason causing the charts to display 0's