### PR TITLE
fix active var

### DIFF
--- a/packages/explorer-2.0/@types/index.d.ts
+++ b/packages/explorer-2.0/@types/index.d.ts
@@ -12,12 +12,9 @@ export interface Transcoder {
   lastRewardRound?: Round;
   rewardCut?: string;
   feeShare?: string;
-  pricePerSegment?: string;
-  pendingRewardCut?: string;
-  pendingFeeShare?: string;
-  pendingPricePerSegment?: string;
+  activationRound?: string;
+  deactivationRound?: string;
   totalStake?: string;
-  accruedFees?: string;
   pools?: [Pool];
   delegators?: [Delegator];
   delegator?: Delegator;

--- a/packages/explorer-2.0/components/CampaignView/index.tsx
+++ b/packages/explorer-2.0/components/CampaignView/index.tsx
@@ -35,8 +35,12 @@ const Index = ({ currentRound, transcoder }) => {
   const [isPriceSettingOpen, setIsPriceSettingOpen] = useState(false);
   const targetRef = useRef();
   const [priceSetting, setPriceSetting] = useState("pixel");
-  const callsMade = transcoder.pools.filter((r) => r.rewardTokens != null)
-    .length;
+  const callsMade = transcoder.pools.filter(
+    (r) => r.rewardTokens != null
+  ).length;
+  const active =
+    transcoder?.activationRound <= currentRound.id &&
+    transcoder?.deactivationRound > currentRound.id;
 
   const PriceSettingToggle = () => (
     <Box
@@ -211,7 +215,7 @@ const Index = ({ currentRound, transcoder }) => {
               <Subtitle>
                 <Flex css={{ alignItems: "center" }}>
                   {transcoder.lastRewardRound.id}{" "}
-                  {transcoder.active && (
+                  {active && (
                     <Flex>
                       {transcoder.lastRewardRound.id === currentRound.id ? (
                         <Box

--- a/packages/explorer-2.0/components/Profile/index.tsx
+++ b/packages/explorer-2.0/components/Profile/index.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import Box from "../Box";
 import Flex from "../Flex";
 import QRCode from "qrcode.react";
-import { Transcoder, Delegator, ThreeBoxSpace } from "../../@types";
+import { Transcoder, Delegator, ThreeBoxSpace, Round } from "../../@types";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import ReactTooltip from "react-tooltip";
 import EditProfile from "../EditProfile";
@@ -23,6 +23,7 @@ interface Props {
   isMyAccount: boolean;
   threeBoxSpace?: ThreeBoxSpace;
   css?: object;
+  currentRound?: Round;
 }
 
 const Index = ({
@@ -33,6 +34,7 @@ const Index = ({
   transcoder,
   isMyAccount = false,
   threeBoxSpace,
+  currentRound,
 }: Props) => {
   const client = useApolloClient();
   const [copied, setCopied] = useState(false);
@@ -44,6 +46,10 @@ const Index = ({
       }, 2000);
     }
   }, [copied]);
+
+  const active =
+    transcoder?.activationRound <= currentRound.id &&
+    transcoder?.deactivationRound > currentRound.id;
 
   return (
     <Box css={{ mb: "$3" }}>
@@ -98,7 +104,7 @@ const Index = ({
               position: "absolute",
               right: 0,
               bottom: "-2px",
-              bg: transcoder.active ? "$primary" : "$muted",
+              bg: active ? "$primary" : "$muted",
               border: "5px solid #131418",
               boxSizing: "border-box",
               width: 24,

--- a/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
+++ b/packages/explorer-2.0/pages/accounts/[account]/[slug].tsx
@@ -189,6 +189,7 @@ const Account = () => {
           role={role}
           transcoder={data.transcoder}
           threeBoxSpace={threeBoxData?.threeBoxSpace}
+          currentRound={data.protocol.currentRound}
         />
         <Tabs tabs={tabs} />
         {slug === "campaign" && (

--- a/packages/explorer-2.0/queries/accountView.gql
+++ b/packages/explorer-2.0/queries/accountView.gql
@@ -38,6 +38,8 @@ query delegator($account: ID!) {
     active
     totalStake
     totalVolumeETH
+    activationRound
+    deactivationRound
     lastRewardRound {
       id
     }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
The subgraph doesn’t always index the active boolean for some orchestrators. For example, query the active field for orchestrator `0xda43d85b8d419a9c51bbf0089c9bd5169c23f2f9` and you'll see it return false when it should return true. This causes the green status dot in the explorer to appear gray for some orchestrators.

Until this is resolved in the subgraph, this PR uses the `activationRound` and `deactivationRound` fields in the explorer instead to accurately query whether an orchestrator is active or not.
