### PR TITLE
remove manual gas estimation in explorer

### DIFF
--- a/packages/explorer-2.0/apollo/resolvers/Mutation.tsx
+++ b/packages/explorer-2.0/apollo/resolvers/Mutation.tsx
@@ -24,33 +24,20 @@ export async function approve(_obj, _args, _ctx) {
 
   switch (type) {
     case "bond":
-      gas = await _ctx.livepeer.rpc.estimateGas("LivepeerToken", "approve", [
-        _ctx.livepeer.config.contracts.BondingManager.address,
-        amount,
-      ]);
       txHash = await _ctx.livepeer.rpc.approveTokenBondAmount(amount, {
-        gas,
         returnTxHash: true,
       });
       return {
-        gas,
         txHash,
         inputData: {
           ..._args,
         },
       };
     case "createPoll":
-      gas = await _ctx.livepeer.rpc.estimateGas("LivepeerToken", "approve", [
-        _ctx.livepeer.config.contracts.PollCreator.address,
-        amount,
-      ]);
-
       txHash = await _ctx.livepeer.rpc.approveTokenPollCreationCost(amount, {
-        gas,
         returnTxHash: true,
       });
       return {
-        gas,
         txHash,
         inputData: {
           ..._args,
@@ -139,22 +126,14 @@ export async function bond(_obj, _args, _ctx) {
   );
   data = claimData ? claimData : data;
 
-  const gas = await _ctx.livepeer.rpc.estimateGasRaw({
-    ..._ctx.livepeer.config.defaultTx,
-    to: _ctx.livepeer.config.contracts["BondingManager"].address,
-    data,
-  });
-
   const txHash = await _ctx.livepeer.rpc.sendTransaction({
     ..._ctx.livepeer.config.defaultTx,
     to: _ctx.livepeer.config.contracts["BondingManager"].address,
     data,
-    gas,
     returnTxHash: true,
   });
 
   return {
-    gas,
     txHash,
     inputData: {
       ..._args,
@@ -181,22 +160,14 @@ export async function unbond(_obj, _args, _ctx) {
   );
   data = claimData ? claimData : data;
 
-  const gas = await _ctx.livepeer.rpc.estimateGasRaw({
-    ..._ctx.livepeer.config.defaultTx,
-    to: _ctx.livepeer.config.contracts["BondingManager"].address,
-    data,
-  });
-
   const txHash = await _ctx.livepeer.rpc.sendTransaction({
     ..._ctx.livepeer.config.defaultTx,
     to: _ctx.livepeer.config.contracts["BondingManager"].address,
     data,
-    gas,
     returnTxHash: true,
   });
 
   return {
-    gas,
     txHash,
     inputData: {
       ..._args,
@@ -225,22 +196,14 @@ export async function rebond(_obj, _args, _ctx) {
   );
   data = claimData ? claimData : data;
 
-  const gas = await _ctx.livepeer.rpc.estimateGasRaw({
-    ..._ctx.livepeer.config.defaultTx,
-    to: _ctx.livepeer.config.contracts["BondingManager"].address,
-    data,
-  });
-
   const txHash = await _ctx.livepeer.rpc.sendTransaction({
     ..._ctx.livepeer.config.defaultTx,
     to: _ctx.livepeer.config.contracts["BondingManager"].address,
     data,
-    gas,
     returnTxHash: true,
   });
 
   return {
-    gas,
     txHash,
     inputData: {
       ..._args,
@@ -256,20 +219,12 @@ export async function rebond(_obj, _args, _ctx) {
 export async function withdrawStake(_obj, _args, _ctx) {
   const { unbondingLockId } = _args;
 
-  const gas = await _ctx.livepeer.rpc.estimateGas(
-    "BondingManager",
-    "withdrawStake",
-    [unbondingLockId]
-  );
-
   const txHash = await _ctx.livepeer.rpc.withdrawStake(unbondingLockId, {
     ..._ctx.livepeer.config.defaultTx,
-    gas,
     returnTxHash: true,
   });
 
   return {
-    gas,
     txHash,
     inputData: {
       ..._args,
@@ -296,22 +251,14 @@ export async function withdrawFees(_obj, _args, _ctx) {
   );
   data = claimData ? claimData : data;
 
-  const gas = await _ctx.livepeer.rpc.estimateGasRaw({
-    ..._ctx.livepeer.config.defaultTx,
-    to: _ctx.livepeer.config.contracts["BondingManager"].address,
-    data,
-  });
-
   const txHash = await _ctx.livepeer.rpc.sendTransaction({
     ..._ctx.livepeer.config.defaultTx,
     to: _ctx.livepeer.config.contracts["BondingManager"].address,
     data,
-    gas,
     returnTxHash: true,
   });
 
   return {
-    gas,
     txHash,
     inputData: {
       ..._args,
@@ -340,22 +287,14 @@ export async function rebondFromUnbonded(_obj, _args, _ctx) {
   );
   data = claimData ? claimData : data;
 
-  const gas = await _ctx.livepeer.rpc.estimateGasRaw({
-    ..._ctx.livepeer.config.defaultTx,
-    to: _ctx.livepeer.config.contracts["BondingManager"].address,
-    data,
-  });
-
   const txHash = await _ctx.livepeer.rpc.sendTransaction({
     ..._ctx.livepeer.config.defaultTx,
     to: _ctx.livepeer.config.contracts["BondingManager"].address,
     data,
-    gas,
     returnTxHash: true,
   });
 
   return {
-    gas,
     txHash,
     inputData: {
       ..._args,
@@ -369,18 +308,11 @@ export async function rebondFromUnbonded(_obj, _args, _ctx) {
  * @return {Promise}
  */
 export async function initializeRound(_obj, _args, _ctx) {
-  const gas = await _ctx.livepeer.rpc.estimateGas(
-    "RoundsManager",
-    "initializeRound",
-    []
-  );
   const txHash = await _ctx.livepeer.rpc.initializeRound({
-    gas,
     returnTxHash: true,
   });
 
   return {
-    gas,
     txHash,
     inputData: {
       ..._args,
@@ -396,18 +328,13 @@ export async function initializeRound(_obj, _args, _ctx) {
 export async function createPoll(_obj, _args, _ctx) {
   const Utils = require("web3-utils");
   const { proposal } = _args;
-  const gas = await _ctx.livepeer.rpc.estimateGas("PollCreator", "createPoll", [
-    Utils.fromAscii(proposal),
-  ]);
 
   const txHash = await _ctx.livepeer.rpc.createPoll(Utils.fromAscii(proposal), {
     ..._ctx.livepeer.config.defaultTx,
-    gas,
     returnTxHash: true,
   });
 
   return {
-    gas,
     txHash,
     inputData: {
       ..._args,
@@ -422,15 +349,12 @@ export async function createPoll(_obj, _args, _ctx) {
  */
 export async function vote(_obj, _args, _ctx) {
   const { pollAddress, choiceId } = _args;
-  const gas = await _ctx.livepeer.rpc.estimateGas("Poll", "vote", [choiceId]);
   const txHash = await _ctx.livepeer.rpc.vote(pollAddress, choiceId, {
     ..._ctx.livepeer.config.defaultTx,
-    gas,
     returnTxHash: true,
   });
 
   return {
-    gas,
     txHash,
     inputData: {
       ..._args,

--- a/packages/explorer-2.0/components/TxStartedDialog/index.tsx
+++ b/packages/explorer-2.0/components/TxStartedDialog/index.tsx
@@ -21,8 +21,7 @@ const Index = ({ tx, isOpen, onDismiss }) => {
       clickAnywhereToClose={false}
       onDismiss={onDismiss}
       title="Sending"
-      Icon={<Spinner />}
-    >
+      Icon={<Spinner />}>
       <Box
         css={{
           position: "absolute",
@@ -43,15 +42,12 @@ const Index = ({ tx, isOpen, onDismiss }) => {
           border: "1px solid",
           borderColor: "$border",
           mb: "$4",
-        }}
-      >
+        }}>
         <Header tx={tx} timeLeft={timeLeft} />
         <Box
           css={{
-            px: "$3",
-            py: "$4",
-          }}
-        >
+            p: "$3",
+          }}>
           {Table({ tx, timeLeft })}
         </Box>
       </Box>
@@ -72,12 +68,6 @@ function Table({ tx, timeLeft }) {
         <Box>Your account</Box> {tx.from.replace(tx.from.slice(7, 37), "…")}
       </Row>
       <Inputs tx={tx} />
-      <Row>
-        <Box>Max Transaction fee</Box>{" "}
-        {tx.gasPrice && tx.gas
-          ? `${parseFloat(Utils.fromWei(tx.gasPrice)) * tx.gas} ETH`
-          : "Estimating..."}
-      </Row>
       <Row css={{ mb: 0 }}>
         <Box>Estimated wait</Box>
         <Box>
@@ -166,10 +156,12 @@ function Row({ css = {}, children, ...props }) {
         alignItems: "center",
         justifyContent: "space-between",
         fontSize: "$2",
+        "&:last-of-type": {
+          mb: 0,
+        },
         ...css,
       }}
-      {...props}
-    >
+      {...props}>
       {children}
     </Flex>
   );
@@ -185,16 +177,14 @@ function Header({ css = {}, tx, timeLeft }) {
         alignItems: "center",
         justifyContent: "space-between",
         ...css,
-      }}
-    >
+      }}>
       <Flex
         css={{
           mr: "$3",
           color: "white",
           fontSize: "$1",
           fontWeight: "bold",
-        }}
-      >
+        }}>
         {timeLeft
           ? `${
               Math.floor(((tx?.estimate - timeLeft) / tx?.estimate) * 100) < 100
@@ -211,8 +201,7 @@ function Header({ css = {}, tx, timeLeft }) {
         rel="noopener noreferrer"
         href={`https://${
           process.env.NEXT_PUBLIC_NETWORK === "rinkeby" ? "rinkeby." : ""
-        }etherscan.io/tx/${tx?.txHash}`}
-      >
+        }etherscan.io/tx/${tx?.txHash}`}>
         Details{" "}
         <Box as={ExternalLinkIcon} css={{ ml: "6px", color: "$primary" }} />
       </Box>

--- a/packages/explorer-2.0/hooks/index.tsx
+++ b/packages/explorer-2.0/hooks/index.tsx
@@ -19,18 +19,16 @@ export function useWeb3Mutation(mutation, options) {
     }
   `;
 
-  const {
-    data: transactionStatusData,
-    loading: transactionStatusLoading,
-  } = useQuery(GET_TRANSACTION_STATUS, {
-    ...options,
-    variables: {
-      txHash: data?.tx?.txHash,
-    },
-    fetchPolicy: "no-cache",
-    notifyOnNetworkStatusChange: true,
-    context: options?.context,
-  });
+  const { data: transactionStatusData, loading: transactionStatusLoading } =
+    useQuery(GET_TRANSACTION_STATUS, {
+      ...options,
+      variables: {
+        txHash: data?.tx?.txHash,
+      },
+      fetchPolicy: "no-cache",
+      notifyOnNetworkStatusChange: true,
+      context: options?.context,
+    });
 
   const GET_TRANSACTION = gql`
     query transaction($txHash: String) {
@@ -93,7 +91,6 @@ export function useWeb3Mutation(mutation, options) {
               estimate: txPredictionData?.txPrediction?.result
                 ? txPredictionData?.txPrediction?.result
                 : null,
-              gas: data.tx.gas,
               gasPrice: transactionData?.transaction?.gasPrice?.toString()
                 ? transactionData?.transaction?.gasPrice?.toString()
                 : null,

--- a/packages/explorer-2.0/queries/transactions.gql
+++ b/packages/explorer-2.0/queries/transactions.gql
@@ -7,7 +7,6 @@
     startTime
     inputData
     estimate
-    gas
     gasPrice
     inputData
   }


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
This PR removes the explorer's manual gas estimation in favor of the gas estimation provided by a user's ethereum wallet. The reason for this change is two fold:

1. The `eth_estimateGas` RPC call is changing in the upcoming London hardfork tomorrow and will no longer work if the new 1559 gas pricing isn't filled in.
2. Ethereum wallets are typically more capable when it comes to gas estimation


**How did you test each of these updates**
Tested affected transactions on Rinkeby