### PR TITLE
change default ordering to total fees earned

### DIFF
--- a/packages/explorer-2.0/components/AccountCell/index.tsx
+++ b/packages/explorer-2.0/components/AccountCell/index.tsx
@@ -47,8 +47,8 @@ const Index = ({ threeBoxSpace, active, address }) => {
           <QRCode
             style={{
               borderRadius: 1000,
-              width: 30,
-              height: 30,
+              width: 24,
+              height: 24,
               padding: "2px",
               border: "1px solid",
               borderColor: "rgba(255,255,255,.6)",

--- a/packages/explorer-2.0/components/Orchestrators/StakingTable.tsx
+++ b/packages/explorer-2.0/components/Orchestrators/StakingTable.tsx
@@ -192,7 +192,7 @@ const StakingTable = ({
     autoResetPage: false,
     initialState: {
       pageSize,
-      sortBy: [{ id: "totalStake", desc: true }],
+      sortBy: [{ id: "totalVolumeETH", desc: true }],
       hiddenColumns: [
         "activationRound",
         "deactivationRound",

--- a/packages/explorer-2.0/components/Orchestrators/StakingTable.tsx
+++ b/packages/explorer-2.0/components/Orchestrators/StakingTable.tsx
@@ -111,13 +111,13 @@ const StakingTable = ({
         accessor: "delegator",
       },
       {
+        Header: "Fees",
+        accessor: "totalVolumeETH",
+      },
+      {
         Header: "Stake",
         accessor: "totalStake",
         mobile: true,
-      },
-      {
-        Header: "Fees",
-        accessor: "totalVolumeETH",
       },
       {
         Header: "Reward Cut",

--- a/packages/explorer-2.0/components/Orchestrators/StakingTable.tsx
+++ b/packages/explorer-2.0/components/Orchestrators/StakingTable.tsx
@@ -370,7 +370,10 @@ const StakingTable = ({
                               textAlign: "right",
                               fontFamily: "$monospace",
                             }}>
-                            {abbreviateNumber(cell.value ? cell.value : 0, 4)}
+                            {abbreviateNumber(cell.value ? cell.value : 0, 4)}{" "}
+                            <Box as="span" css={{ fontSize: 12 }}>
+                              LPT
+                            </Box>
                           </TableCell>
                         );
                       case "Fees":

--- a/packages/explorer-2.0/components/Orchestrators/index.tsx
+++ b/packages/explorer-2.0/components/Orchestrators/index.tsx
@@ -343,7 +343,7 @@ export default Index;
 export function getOrchestratorQuery(currentRound) {
   const query = gql`query transcoders {
     transcoders(
-      orderBy: totalStake,
+      orderBy: totalVolumeETH,
       orderDirection: desc,
       where: {
         activationRound_lte: ${currentRound},


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
As proposed in [this forum post](https://forum.livepeer.org/t/livepeer-explorer-rewarding-top-performers-through-ui-changes/1479), this PR changes the default ordering of the orchestrator leaderboard from total stake to total fees earned.

**Screenshots (optional):**
![image](https://user-images.githubusercontent.com/555740/139745271-626d2b37-0841-4986-a6f3-6376634cc8db.png)

