### PR TITLE
fix order

### DIFF
--- a/packages/explorer-2.0/components/AccountCell/index.tsx
+++ b/packages/explorer-2.0/components/AccountCell/index.tsx
@@ -78,8 +78,8 @@ const Index = ({ threeBoxSpace, active, address }) => {
           }}>
           <Box css={{ fontWeight: 600 }}>
             {process.env.NEXT_PUBLIC_THREEBOX_ENABLED && threeBoxSpace?.name
-              ? textTruncate(threeBoxSpace.name, 15, "…")
-              : address.replace(address.slice(5, 39), "…")}
+              ? textTruncate(threeBoxSpace.name, 12, "…")
+              : address.replace(address.slice(5, 36), "…")}
           </Box>
         </Flex>
       </Flex>

--- a/packages/explorer-2.0/components/Orchestrators/StakingTable.tsx
+++ b/packages/explorer-2.0/components/Orchestrators/StakingTable.tsx
@@ -113,6 +113,7 @@ const StakingTable = ({
       {
         Header: "Fees",
         accessor: "totalVolumeETH",
+        sortType: "number",
       },
       {
         Header: "Stake",
@@ -284,6 +285,7 @@ const StakingTable = ({
                           alignItems: "center",
                           fontSize: 10,
                           position: "relative",
+                          letterSpacing: "-.3px",
                         }}
                         {...column.getHeaderProps(
                           column.getSortByToggleProps({ title: "" })

--- a/packages/explorer-2.0/package.json
+++ b/packages/explorer-2.0/package.json
@@ -102,7 +102,7 @@
     "react-markdown": "^4.3.1",
     "react-number-format": "^4.3.1",
     "react-show-more-text": "1.2.3",
-    "react-table": "7.0.0-rc.15",
+    "react-table": "^7.7.0",
     "react-tooltip": "^4.2.11",
     "react-use": "^12.2.0",
     "reactour": "1.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -30331,10 +30331,10 @@ react-style-singleton@^2.1.0:
     invariant "^2.2.4"
     tslib "^1.0.0"
 
-react-table@7.0.0-rc.15:
-  version "7.0.0-rc.15"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.0.0-rc.15.tgz#bb855e4e2abbb4aaf0ed2334404a41f3ada8e13a"
-  integrity sha512-ofMOlgrioHhhvHjvjsQkxvfQzU98cqwy6BjPGNwhLN1vhgXeWi0mUGreaCPvRenEbTiXsQbMl4k3Xmx3Mut8Rw==
+react-table@^7.7.0:
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.7.0.tgz#e2ce14d7fe3a559f7444e9ecfe8231ea8373f912"
+  integrity sha512-jBlj70iBwOTvvImsU9t01LjFjy4sXEtclBovl3mTiqjz23Reu0DKnRza4zlLtOPACx6j2/7MrQIthIK1Wi+LIA==
 
 react-test-renderer@^16.0.0-0, react-test-renderer@^16.1.0:
   version "16.14.0"


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
As reported by Papa_Bear on discord orchestrators #1-44 are ordered by ETH earned but starting with #45 Orchestrators are out of order. This PR fixes the ordering.