### PR TITLE
add default revalidate value

### DIFF
--- a/packages/explorer-2.0/apollo/getStaticApolloProps.tsx
+++ b/packages/explorer-2.0/apollo/getStaticApolloProps.tsx
@@ -97,10 +97,10 @@ export default function getStaticApolloProps<
       props: {
         apolloState: apolloClient.cache.extract(),
         generatedAt: new Date().toISOString(),
-        revalidate: revalidate || null,
+        revalidate: revalidate || 60,
         ...otherProps,
       },
-      revalidate,
+      revalidate: revalidate || 60,
     };
   };
 }

--- a/packages/explorer-2.0/pages/_app.tsx
+++ b/packages/explorer-2.0/pages/_app.tsx
@@ -10,7 +10,7 @@ import Layout from "../layouts/main";
 import { withApollo } from "../apollo";
 import { NextPage } from "next";
 import { IdProvider } from "@radix-ui/react-id";
-import { darkThemeClass, global } from "../stitches.config";
+import { darkThemeClass } from "../stitches.config";
 import { ThemeProvider } from "next-themes";
 
 function getLibrary(provider) {
@@ -42,8 +42,7 @@ function App({ Component, pageProps }) {
           disableTransitionOnChange
           attribute="class"
           defaultTheme="system"
-          value={{ dark: darkThemeClass.className }}
-        >
+          value={{ dark: darkThemeClass.className }}>
           <Web3ReactProvider getLibrary={getLibrary}>
             <Web3ReactManager>
               <CookiesProvider>

--- a/packages/explorer-2.0/pages/index.tsx
+++ b/packages/explorer-2.0/pages/index.tsx
@@ -156,5 +156,5 @@ Home.getLayout = getLayout;
 export default withApollo({ ssr: false })(Home as NextPage);
 
 export const getStaticProps = getStaticApolloProps<Props, Params>(Home, {
-  revalidate: 5,
+  revalidate: 60,
 });

--- a/packages/explorer-2.0/pages/orchestrators.tsx
+++ b/packages/explorer-2.0/pages/orchestrators.tsx
@@ -48,6 +48,6 @@ export default withApollo({ ssr: false })(OrchestratorsPage as NextPage);
 export const getStaticProps = getStaticApolloProps<Props, Params>(
   OrchestratorsPage,
   {
-    revalidate: 10,
+    revalidate: 60,
   }
 );


### PR DESCRIPTION
**What does this pull request do? Explain your changes. (required)**
Occasionally pages aren't statically generated causing the loading spinner to appear when rendering the overview and orchestrator routes. Adding a default revalidation value appears to resolve the issue. We also increase the revalidation value to 60s to save on bandwidth.